### PR TITLE
ENG-1303 feat(portal): resolve user's ens if they have one

### DIFF
--- a/apps/portal/app/.client/privy-verified-links.tsx
+++ b/apps/portal/app/.client/privy-verified-links.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@0xintuition/1ui'
 
 import { useSocialLinking } from '@lib/hooks/usePrivySocialLinking'
-import logger from '@lib/utils/logger'
 import { ExtendedPrivyUser, PrivyPlatform } from 'types/privy'
 
 // colocated this for now but we can move into a constants if that is cleaner
@@ -38,7 +37,6 @@ export function PrivyVerifiedLinks() {
     <div className="flex w-full flex-col items-center gap-8">
       {linkedPlatforms.map((platform) => {
         if (privyUser === null) {
-          logger('Privy user is null')
           return null
         }
 

--- a/apps/portal/app/routes/_index.tsx
+++ b/apps/portal/app/routes/_index.tsx
@@ -23,6 +23,9 @@ export default function Index() {
           <Link to="/app">App</Link>
         </li>
         <li>
+          <Link to="/app/profile">Profile</Link>
+        </li>
+        <li>
           <Link to="/app/test">Test</Link>
         </li>
       </ul>

--- a/apps/portal/app/routes/app+/profile+/index.tsx
+++ b/apps/portal/app/routes/app+/profile+/index.tsx
@@ -6,12 +6,37 @@ import {
 } from '@0xintuition/1ui'
 
 import { PrivyVerifiedLinks } from '@client/privy-verified-links'
+import logger from '@lib/utils/logger'
+import { SessionContext } from '@middleware/session'
+import { LoaderFunctionArgs } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+
+export async function loader({ context }: LoaderFunctionArgs) {
+  const session = context.get(SessionContext)
+  logger('[Profile-Loader] user:', session.get('user'))
+  return { user: session.get('user') }
+}
 
 export default function Profile() {
+  const { user } = useLoaderData<typeof loader>()
+  const hasEnsName = user?.details?.ensName !== undefined
+
+  logger('[Profile-clientside] user from loader:', user)
+
   return (
     <div className="m-8 flex flex-col items-center">
       <div className="flex flex-col gap-8">
-        Profile Route
+        <pre>Profile Route</pre>
+        <div className="flex items-center">
+          <div className="flex items-center gap-1.5">
+            <span>
+              {hasEnsName
+                ? user?.details?.ensName
+                : user?.details?.wallet?.address}
+            </span>
+            <span>{hasEnsName ? user?.details?.wallet?.address : null}</span>
+          </div>
+        </div>
         <div className="flex flex-col gap-4">
           <Accordion
             type="multiple"

--- a/apps/portal/app/routes/app.tsx
+++ b/apps/portal/app/routes/app.tsx
@@ -1,5 +1,6 @@
 import PrivyLogoutButton from '@client/privy-logout-button'
 import PrivySwitchWallet from '@client/privy-switch-wallet'
+import logger from '@lib/utils/logger'
 import { requireAuth } from '@middleware/requireAuth'
 import { SessionContext } from '@middleware/session'
 import { LoaderFunctionArgs } from '@remix-run/node'
@@ -16,7 +17,7 @@ export const middleware = serverOnly$([requireAuth])
 
 export async function loader({ context }: LoaderFunctionArgs) {
   const session = context.get(SessionContext)
-  console.log('[LOADER] user', session.get('user'))
+  console.log('[Index-Loader] user', session.get('user'))
   return { user: session.get('user') }
 }
 
@@ -26,12 +27,12 @@ export default function Index() {
   const navigate = useNavigate()
 
   async function handleLogout() {
-    console.log('[Index] handleLogout')
+    logger('[Index] handleLogout')
     navigate('/login')
   }
 
   function handleLinkWalletSuccess() {
-    console.log('[Index] handleLinkWalletSuccess')
+    logger('[Index] handleLinkWalletSuccess')
     revalidate()
   }
 
@@ -47,7 +48,7 @@ export default function Index() {
           />
         </div>
       </div>
-      <pre>{JSON.stringify(user, null, 2)}</pre>
+      {/* <pre>{JSON.stringify(user, null, 2)}</pre> */}
       <Outlet />
     </div>
   )


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Accesses the `user` object from session context in the Profile route loader
- Checks if the user has an `ensName` in the `user.details` and renders it if so (with the address as well). If not, falls back to their address. 
- Cleans up our console.logs a bit and removes unused import of `logger`

## Screen Captures

Bare bones:

ENS: 
![profile-ens](https://github.com/0xIntuition/intuition-ts/assets/9438776/3104bb16-227e-4610-9c5f-9de1b49452d7)

No ENS:
![profile-no-ens](https://github.com/0xIntuition/intuition-ts/assets/9438776/f825d7b3-13c0-484d-8b0c-79991904df0e)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
