### PR TITLE
ENG-1895 feat(1ui): add color outline button variants

### DIFF
--- a/packages/1ui/src/components/Button/Button.spec.tsx
+++ b/packages/1ui/src/components/Button/Button.spec.tsx
@@ -113,6 +113,58 @@ describe('Button', () => {
       </DocumentFragment>
     `)
   })
+  it('should render appropriate element and classes when given accentOutline variant value', () => {
+    const { asFragment } = render(<Button variant="accentOutline">Text</Button>)
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <button
+          class="flex items-center gap-2 text-sm font-medium border disabled:bg-muted disabled:text-muted-foreground disabled:border-muted bg-transparent text-accent border-accent rounded-full hover:bg-accent/30 hover:border-accent/30 shadow-md-subtle px-3 py-1"
+        >
+          Text
+        </button>
+      </DocumentFragment>
+    `)
+  })
+  it('should render appropriate element and classes when given warningOutline variant value', () => {
+    const { asFragment } = render(
+      <Button variant="warningOutline">Text</Button>,
+    )
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <button
+          class="flex items-center gap-2 text-sm font-medium border disabled:bg-muted disabled:text-muted-foreground disabled:border-muted bg-transparent text-warning border-warning rounded-full hover:bg-warning/30 hover:border-warning/30 shadow-md-subtle px-3 py-1"
+        >
+          Text
+        </button>
+      </DocumentFragment>
+    `)
+  })
+  it('should render appropriate element and classes when given successOutline variant value', () => {
+    const { asFragment } = render(
+      <Button variant="successOutline">Text</Button>,
+    )
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <button
+          class="flex items-center gap-2 text-sm font-medium border disabled:bg-muted disabled:text-muted-foreground disabled:border-muted bg-transparent text-success border-success rounded-full hover:bg-success/30 hover:border-success/30 shadow-md-subtle px-3 py-1"
+        >
+          Text
+        </button>
+      </DocumentFragment>
+    `)
+  })
+  it('should render appropriate element and classes when given destructive variant value', () => {
+    const { asFragment } = render(<Button variant="destructive">Text</Button>)
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <button
+          class="flex items-center gap-2 text-sm font-medium border disabled:bg-muted disabled:text-muted-foreground disabled:border-muted bg-destructive text-destructive-foreground border-destructive rounded-full hover:bg-destructive/70 hover:border-destructive/30 shadow-md-subtle px-3 py-1"
+        >
+          Text
+        </button>
+      </DocumentFragment>
+    `)
+  })
   it('should render appropriate element and classes when given medium size value', () => {
     const { asFragment } = render(<Button size="md">Text</Button>)
     expect(asFragment()).toMatchInlineSnapshot(`

--- a/packages/1ui/src/components/Button/Button.stories.tsx
+++ b/packages/1ui/src/components/Button/Button.stories.tsx
@@ -35,9 +35,13 @@ const meta: Meta<typeof Button> = {
         'ghost',
         'text',
         'accent',
+        'accentOutline',
         'warning',
+        'warningOutline',
         'success',
+        'successOutline',
         'destructive',
+        'destructiveOutline',
         'navigation',
       ],
       table: {
@@ -344,6 +348,138 @@ export const Destructive: Story = {
         Loading...
       </Button>
       <Button variant="destructive" disabled {...props}>
+        Disabled
+      </Button>
+    </div>
+  ),
+}
+
+export const AccentOutline: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: (props) => (
+    <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+      <Button variant="accentOutline" {...props}>
+        Default
+      </Button>
+      <Button variant="accentOutline" size="md" {...props}>
+        Medium
+      </Button>
+      <Button variant="accentOutline" size="lg" {...props}>
+        Large
+      </Button>
+      <Button variant="accentOutline" size="xl" {...props}>
+        Extra Large
+      </Button>
+      <Button variant="accentOutline" {...props}>
+        <Icon name="crystal-ball" />
+      </Button>
+      <Button variant="accentOutline" isLoading {...props}>
+        Loading...
+      </Button>
+      <Button variant="accentOutline" disabled {...props}>
+        Disabled
+      </Button>
+    </div>
+  ),
+}
+
+export const WarningOutline: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: (props) => (
+    <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+      <Button variant="warningOutline" {...props}>
+        Default
+      </Button>
+      <Button variant="warningOutline" size="md" {...props}>
+        Medium
+      </Button>
+      <Button variant="warningOutline" size="lg" {...props}>
+        Large
+      </Button>
+      <Button variant="warningOutline" size="xl" {...props}>
+        Extra Large
+      </Button>
+      <Button variant="warningOutline" {...props}>
+        <Icon name="crystal-ball" />
+      </Button>
+      <Button variant="warningOutline" isLoading {...props}>
+        Loading...
+      </Button>
+      <Button variant="warningOutline" disabled {...props}>
+        Disabled
+      </Button>
+    </div>
+  ),
+}
+
+export const SuccessOutline: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: (props) => (
+    <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+      <Button variant="successOutline" {...props}>
+        Default
+      </Button>
+      <Button variant="successOutline" size="md" {...props}>
+        Medium
+      </Button>
+      <Button variant="successOutline" size="lg" {...props}>
+        Large
+      </Button>
+      <Button variant="successOutline" size="xl" {...props}>
+        Extra Large
+      </Button>
+      <Button variant="successOutline" {...props}>
+        <Icon name="crystal-ball" />
+      </Button>
+      <Button variant="successOutline" isLoading {...props}>
+        Loading...
+      </Button>
+      <Button variant="successOutline" disabled {...props}>
+        Disabled
+      </Button>
+    </div>
+  ),
+}
+
+export const DestructiveOutline: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: (props) => (
+    <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+      <Button variant="destructiveOutline" {...props}>
+        Default
+      </Button>
+      <Button variant="destructiveOutline" size="md" {...props}>
+        Medium
+      </Button>
+      <Button variant="destructiveOutline" size="lg" {...props}>
+        Large
+      </Button>
+      <Button variant="destructiveOutline" size="xl" {...props}>
+        Extra Large
+      </Button>
+      <Button variant="destructiveOutline" {...props}>
+        <Icon name="crystal-ball" />
+      </Button>
+      <Button variant="destructiveOutline" isLoading {...props}>
+        Loading...
+      </Button>
+      <Button variant="destructiveOutline" disabled {...props}>
         Disabled
       </Button>
     </div>

--- a/packages/1ui/src/components/Button/Button.tsx
+++ b/packages/1ui/src/components/Button/Button.tsx
@@ -28,6 +28,14 @@ const buttonVariants = cva(
           'bg-destructive text-destructive-foreground border-destructive rounded-full hover:bg-destructive/70 hover:border-destructive/30 shadow-md-subtle',
         navigation:
           'bg-transparent text-secondary-foreground/70 border-transparent rounded-lg  hover:text-secondary-foreground hover:border-border/20 aria-selected:bg-primary/10 aria-selected:text-secondary-foreground/80 disabled:text-muted-foreground',
+        accentOutline:
+          'bg-transparent text-accent border-accent rounded-full hover:bg-accent/30 hover:border-accent/30 shadow-md-subtle',
+        warningOutline:
+          'bg-transparent text-warning border-warning rounded-full hover:bg-warning/30 hover:border-warning/30 shadow-md-subtle',
+        successOutline:
+          'bg-transparent text-success border-success rounded-full hover:bg-success/30 hover:border-success/30 shadow-md-subtle',
+        destructiveOutline:
+          'bg-transparent text-destructive border-destructive rounded-full hover:bg-destructive/30 hover:border-destructive/30 shadow-md-subtle',
       },
       size: {
         default: 'px-3 py-1',


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] portal

Packages

- [x] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Add accent outline, success outline, destructive outline and warning outline button variants

## Screen Captures

![Screenshot 2024-06-13 at 15 09 52](https://github.com/0xIntuition/intuition-ts/assets/25107433/d2414425-add4-4ba2-ac40-07bdcfe7f744)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
