### PR TITLE
ENG-1938 feat(portal): update user profile components to use the new icons and badges

### DIFF
--- a/apps/portal/app/.client/privy-verified-links.tsx
+++ b/apps/portal/app/.client/privy-verified-links.tsx
@@ -1,4 +1,11 @@
-import { Button, Icon } from '@0xintuition/1ui'
+import {
+  Button,
+  Icon,
+  IconName,
+  SocialLinks,
+  SocialLinksBadge,
+  SocialLinksButton,
+} from '@0xintuition/1ui'
 
 import { useSocialLinking } from '@lib/hooks/usePrivySocialLinking'
 import { verifiedPlatforms } from '@lib/utils/constants'
@@ -42,6 +49,7 @@ export function PrivyVerifiedLinks({ privyUser }: { privyUser: SessionUser }) {
       <VerifiedLinkItem
         key={platform.platformPrivyName}
         platformDisplayName={platform.platformDisplayName}
+        platformIcon={platform.platformIcon}
         isConnected={isConnected}
         privyUser={privyUser}
         platform={platform}
@@ -58,8 +66,15 @@ export function PrivyVerifiedLinks({ privyUser }: { privyUser: SessionUser }) {
 }
 
 interface VerifiedLinkItemProps {
-  platformDisplayName: string
-  platformIcon?: string
+  platformDisplayName:
+    | 'twitter'
+    | 'discord'
+    | 'lens'
+    | 'farcaster'
+    | 'calendly'
+    | 'medium'
+    | 'github'
+  platformIcon: IconName
   linkMethod: () => Promise<void>
   unlinkMethod: () => Promise<void>
   isConnected: boolean
@@ -77,24 +92,32 @@ export function VerifiedLinkItem({
   platform,
 }: VerifiedLinkItemProps) {
   return (
-    <div className="flex w-full justify-between gap-4 px-8">
-      {platformIcon && <img src="" alt="" />}
+    <div className="flex w-full justify-between gap-4 px-8 ">
+      <div className="flex flex-row items-center gap-3">
+        <div className="flex flex-col items-center border border-solid  border-white/10 rounded-full p-2.5">
+          <Icon name={platformIcon} className="w-4 h-4" />
+        </div>
+        {isConnected ? (
+          <span className="font-medium text-sm">
+            {(privyUser &&
+              (privyUser as SessionUser).details?.[platform.platformPrivyName]
+                ?.username) ??
+              platformDisplayName}
+          </span>
+        ) : (
+          <span>{platformDisplayName}</span>
+        )}
+      </div>
       {isConnected ? (
-        <span>
-          {(privyUser &&
-            (privyUser as SessionUser).details?.[platform.platformPrivyName]
-              ?.username) ??
-            platformDisplayName}
-        </span>
-      ) : (
-        <span>{platformDisplayName}</span>
-      )}
-      {isConnected ? (
-        <Button variant="destructive" onClick={unlinkMethod}>
+        <Button
+          variant="destructive"
+          className="py-1 px-3"
+          onClick={unlinkMethod}
+        >
           Unlink
         </Button>
       ) : (
-        <Button variant="accent" onClick={linkMethod}>
+        <Button variant="accent" className="py-1 px-3" onClick={linkMethod}>
           Link Account
         </Button>
       )}
@@ -102,40 +125,15 @@ export function VerifiedLinkItem({
   )
 }
 
-interface VerifiedLinkBadgeProps {
-  platformDisplayName: string
-  platformIcon?: string
-  isConnected: boolean
-  privyUser: SessionUser | null
-  platform: PrivyPlatform
-}
-
-export function VerifiedLinkBadge({
-  platformDisplayName,
-  platformIcon,
+export function VerifiedLinkBadges({
   privyUser,
-  platform,
-}: VerifiedLinkBadgeProps) {
+  handleOpenEditSocialLinksModal,
+}: {
+  privyUser: SessionUser
+  handleOpenEditSocialLinksModal: () => void
+}) {
   return (
-    <div
-      className="flex w-full justify-between
-    border border-solid border-white/10 rounded-xl px-2 py-1 items-center"
-    >
-      {platformIcon && <img src="" alt="" />}
-      <span className="font-normal text-sm text-foreground">
-        {(privyUser &&
-          (privyUser as SessionUser).details?.[platform.platformPrivyName]
-            ?.username) ??
-          platformDisplayName}
-      </span>
-      <Icon name="circle-check" className="text-blue-500 h-4 w-4  " />
-    </div>
-  )
-}
-
-export function VerifiedLinkBadges({ privyUser }: { privyUser: SessionUser }) {
-  return (
-    <div className="flex flex-row gap-2">
+    <SocialLinks>
       {verifiedPlatforms.map((platform) => {
         if (!privyUser) {
           return null
@@ -146,15 +144,20 @@ export function VerifiedLinkBadges({ privyUser }: { privyUser: SessionUser }) {
         )
 
         return isConnected ? (
-          <VerifiedLinkBadge
+          <SocialLinksBadge
             key={platform.platformPrivyName}
-            platformDisplayName={platform.platformDisplayName}
-            isConnected={isConnected}
-            privyUser={privyUser as SessionUser}
-            platform={platform}
+            platform={platform.platformUiName}
+            isVerified={isConnected}
+            username={
+              (privyUser &&
+                (privyUser as SessionUser).details?.[platform.platformPrivyName]
+                  ?.username) ??
+              platform.platformDisplayName
+            }
           />
         ) : null
       })}
-    </div>
+      <SocialLinksButton onClick={handleOpenEditSocialLinksModal} />
+    </SocialLinks>
   )
 }

--- a/apps/portal/app/components/profile-social-accounts.tsx
+++ b/apps/portal/app/components/profile-social-accounts.tsx
@@ -60,16 +60,15 @@ function EditSocialAccounts({
   privyUser: SessionUser
   handleOpenEditSocialLinksModal: () => void
 }) {
+  if (!privyUser) {
+    return null
+  }
   return (
     <div className="flex flex-col w-full gap-5 mt-5">
-      <VerifiedLinkBadges privyUser={privyUser} />
-      <Button
-        variant="secondary"
-        className="text-center justify-center w-full"
-        onClick={handleOpenEditSocialLinksModal}
-      >
-        Edit Social Links
-      </Button>
+      <VerifiedLinkBadges
+        privyUser={privyUser}
+        handleOpenEditSocialLinksModal={handleOpenEditSocialLinksModal}
+      />
     </div>
   )
 }

--- a/apps/portal/app/lib/utils/constants.ts
+++ b/apps/portal/app/lib/utils/constants.ts
@@ -38,19 +38,25 @@ export const BLOCK_EXPLORER_URL =
 export const verifiedPlatforms: PrivyPlatform[] = [
   {
     platformPrivyName: 'twitter',
+    platformUiName: 'x',
     platformDisplayName: 'X',
+    platformIcon: 'x',
     linkMethod: 'linkTwitter',
     unlinkMethod: 'unlinkTwitter',
   },
   {
     platformPrivyName: 'github',
+    platformUiName: 'github',
     platformDisplayName: 'GitHub',
+    platformIcon: 'github',
     linkMethod: 'linkGithub',
     unlinkMethod: 'unlinkGithub',
   },
   {
     platformPrivyName: 'farcaster',
+    platformUiName: 'farcaster',
     platformDisplayName: 'Farcaster',
+    platformIcon: 'farcaster',
     linkMethod: 'linkFarcaster',
     unlinkMethod: 'unlinkFarcaster',
   },

--- a/apps/portal/types/privy.d.ts
+++ b/apps/portal/types/privy.d.ts
@@ -45,8 +45,24 @@ type UnlinkMethodNamesBySubject = 'unlinkTwitter' | 'unlinkGithub'
 type UnlinkMethodNamesByFid = 'unlinkFarcaster'
 
 export interface PrivyPlatform {
-  platformPrivyName: string
+  platformPrivyName:
+    | 'twitter'
+    | 'discord'
+    | 'lens'
+    | 'farcaster'
+    | 'calendly'
+    | 'medium'
+    | 'github'
   platformDisplayName: string
+  platformUiName:
+    | 'x'
+    | 'discord'
+    | 'lens'
+    | 'farcaster'
+    | 'calendly'
+    | 'medium'
+    | 'github'
+  platformIcon: IconName
   linkMethod: LinkMethodNames
   unlinkMethod: UnlinkMethodNamesBySubject | UnlinkMethodNamesByFid
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adjusts the props structure in the existing social components to match the new ones
- Adds in the social icons to the Edit Social Links modal
- Adds the social links to a user's profile -- I updated the prop structure for our `verifiedPlatforms` to more seamlessly work with what we need for checking Privy connection as well as for mapping in the UI

## Screen Captures

![intuition-social-links-new](https://github.com/0xIntuition/intuition-ts/assets/9438776/7791d880-0350-4a8f-bce5-a51210c3a51d)

![intuition-social-links-modal-new](https://github.com/0xIntuition/intuition-ts/assets/9438776/374010cf-df25-4877-83c5-243f118f2d0d)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
