### PR TITLE
ENG-0000 fix(1ui): makes the stats prop optional

### DIFF
--- a/packages/1ui/src/components/ProfileCard/ProfileCard.tsx
+++ b/packages/1ui/src/components/ProfileCard/ProfileCard.tsx
@@ -13,7 +13,7 @@ export interface ProfileCardProps {
   name: string
   walletAddress: string
   stats?: {
-    numberOfFollowers: number
+    numberOfFollowers?: number
     numberOfFollowing?: number
     points?: number
   }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] portal

Packages

- [x] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Makes the `stats` prop optional on `ProfileCard`

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
