### PR TITLE
ENG-2117 feat(portal): update the segmented nav in routes to use current route

### DIFF
--- a/apps/portal/app/components/segmented-nav.tsx
+++ b/apps/portal/app/components/segmented-nav.tsx
@@ -16,9 +16,13 @@ interface SegmentedNavProps {
 }
 
 export const SegmentedNav = ({ options }: SegmentedNavProps) => {
-  const [selectedTab, setSelectedTab] = useState(options[0].value)
   const navigate = useNavigate()
   const params = useParams()
+  const currentPath = window.location.pathname
+  const initialTab =
+    options.find((option) => currentPath.includes(option.value))?.value ||
+    options[0].value
+  const [selectedTab, setSelectedTab] = useState(initialTab)
 
   const handleTabClick = (option: OptionType) => {
     setSelectedTab(option.value)


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Changes the initial `selectedTab` value to be the current route instead of hardcoding as the first route option
- This is a QoL fix that'll allow for the proper tab to be selected when users land on nested routes
- This will also be used in the `Explore` routes

## Screen Captures

![segmented-nav-selected-tab](https://github.com/0xIntuition/intuition-ts/assets/9438776/f976c108-2e41-43cf-8a5b-143f3a139554)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
