### PR TITLE
ENG-2085 feat(portal): add left-side layout to claim details page

### DIFF
--- a/apps/portal/app/routes/app+/claim+/$id.tsx
+++ b/apps/portal/app/routes/app+/claim+/$id.tsx
@@ -122,7 +122,7 @@ export default function ClaimDetails() {
 
             <ClaimStakeCard
               currency="ETH"
-              totalTVL={4.928}
+              totalTVL={+claim.assets_sum}
               tvlAgainst={+claim.user_assets_against}
               tvlFor={+claim.user_assets_for}
               amountAgainst={+claim.against_assets_sum}


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds in the left-side layout for the claim details page -- uses placeholder `claim` data (with `ClaimPresenter`) in the `loader` 
- Connects the mock claim loader data to the components -- we can update the source data to use the actual claim data and likely make some tweaks to this (@Vitalsine85 we can look at the design again once the Positions are wired up!)

## Screen Captures

![claim-details-mock-data](https://github.com/0xIntuition/intuition-ts/assets/9438776/5c268c8e-67b6-4ea4-aba2-bac462e59120)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
