### PR TITLE
ENG-0000 fix(1ui): add null to imgSrc type options

### DIFF
--- a/packages/1ui/src/components/Claim/Claim.tsx
+++ b/packages/1ui/src/components/Claim/Claim.tsx
@@ -8,17 +8,17 @@ export interface ClaimProps {
   subject: {
     variant?: IdentityType
     label: string
-    imgSrc?: string
+    imgSrc?: string | null
   }
   predicate: {
     variant?: IdentityType
     label: string
-    imgSrc?: string
+    imgSrc?: string | null
   }
   object: {
     variant?: IdentityType
     label: string
-    imgSrc?: string
+    imgSrc?: string | null
   }
 }
 

--- a/packages/1ui/src/components/IdentityInput/IdentityInput.tsx
+++ b/packages/1ui/src/components/IdentityInput/IdentityInput.tsx
@@ -20,7 +20,7 @@ import {
 
 type IdentityInputSelectedValueType = {
   variant?: IdentityType
-  imgSrc?: string
+  imgSrc?: string | null
   name?: string
 }
 

--- a/packages/1ui/src/components/IdentityTag/IdentityTag.tsx
+++ b/packages/1ui/src/components/IdentityTag/IdentityTag.tsx
@@ -46,7 +46,7 @@ export interface IdentityTagProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof identityTagVariants> {
   disabled?: boolean
-  imgSrc?: string
+  imgSrc?: string | null
 }
 
 const IdentityTag = ({


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] portal

Packages

- [x] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- add null as a type option for imgSrc prop in Claim, IdentityTag and IdentityInput

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
