### PR TITLE
ENG-2524 feat(portal): adds onclose to the success navigate function for view x

### DIFF
--- a/apps/portal/app/components/create-claim-form.tsx
+++ b/apps/portal/app/components/create-claim-form.tsx
@@ -116,6 +116,7 @@ function CreateClaimForm({
   dispatch,
   setTransactionResponseData,
   transactionResponseData,
+  onClose,
 }: CreateClaimFormProps) {
   const feeFetcher = useLoaderFetcher<CreateLoaderData>(CREATE_RESOURCE_ROUTE)
   const { atomCost: atomCostAmount, tripleCost: tripleCostAmount } =
@@ -744,6 +745,7 @@ function CreateClaimForm({
                       onClick={() => {
                         navigate(
                           `/app/claim/${transactionResponseData.claim_id}`,
+                          onClose(),
                         )
                       }}
                     >

--- a/apps/portal/app/components/create-identity-form.tsx
+++ b/apps/portal/app/components/create-identity-form.tsx
@@ -127,6 +127,7 @@ function CreateIdentityForm({
   dispatch,
   setTransactionResponseData,
   transactionResponseData,
+  onClose,
 }: CreateIdentityFormProps) {
   const { offChainFetcher, lastOffChainSubmission } = useOffChainFetcher()
   const imageUploadFetcher = useImageUploadFetcher()
@@ -643,6 +644,7 @@ function CreateIdentityForm({
           transactionType="identity"
           state={state}
           dispatch={dispatch}
+          onClose={onClose}
           transactionDetail={transactionResponseData?.id}
           statusMessages={statusMessages}
           isTransactionAwaiting={isTransactionAwaiting}

--- a/apps/portal/app/components/transaction-status.tsx
+++ b/apps/portal/app/components/transaction-status.tsx
@@ -17,6 +17,7 @@ type TransactionStatusProps<
   isTransactionProgress: (status: TStatus) => boolean
   transactionDetail?: string | null
   transactionType: 'identity' | 'claim' | 'deposit' | 'redeem'
+  onClose: () => void
 }
 
 const TransactionStatus = <
@@ -30,6 +31,7 @@ const TransactionStatus = <
   isTransactionProgress,
   transactionDetail,
   transactionType,
+  onClose,
 }: TransactionStatusProps<S, A, TStatus>) => {
   const getStatusMessage = () => {
     if (isTransactionAwaiting(state.status)) return 'Awaiting'
@@ -68,6 +70,7 @@ const TransactionStatus = <
               variant="primary"
               onClick={() => {
                 navigate(`/app/${transactionType}/${transactionDetail}`)
+                onClose()
               }}
             >
               View {transactionType}


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds in the `onClose()` handlers similar to how we've done this previously
- On a successful transaction when navigating to the View x, the modal will now close

## Screen Captures

![create-on-close](https://github.com/0xIntuition/intuition-ts/assets/9438776/4a89f3e1-1ce9-4527-8d22-cfbd894bd024)
- Took this on a smaller screen and noticing we may need to adjust some of our collisions for smaller screens. Will make a specific ticket with examples

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
