### PR TITLE
ENG-2515 feat(portal): add tags modal and basic form layout

### DIFF
--- a/apps/portal/app/components/tags/tags-form.tsx
+++ b/apps/portal/app/components/tags/tags-form.tsx
@@ -1,11 +1,87 @@
+import {
+  DialogHeader,
+  DialogTitle,
+  IdentityTag,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  // Text,
+  Trunctacular,
+} from '@0xintuition/1ui'
+import { IdentityPresenter } from '@0xintuition/api'
+
+import {
+  initialTransactionState,
+  transactionReducer,
+  useTransactionState,
+} from '@lib/hooks/useTransactionReducer'
 import logger from '@lib/utils/logger'
+import { TransactionActionType, TransactionStateType } from 'types/transaction'
+
+// import { useFetcher } from '@remix-run/react'
 
 interface TagsFormProps {
+  identity: IdentityPresenter
+  mode: 'view' | 'add'
   onSuccess?: () => void
   onClose: () => void
 }
 
-export function TagsForm({ onClose }: TagsFormProps) {
+export function TagsForm({ identity, mode, onClose }: TagsFormProps) {
+  logger('identity', identity)
   logger('onClose', onClose)
-  return <div>tags form</div>
+  // const tagsForm = useFetcher()
+
+  const { state } = useTransactionState<
+    TransactionStateType,
+    TransactionActionType
+  >(transactionReducer, initialTransactionState)
+
+  const isTransactionStarted = [
+    'approve',
+    'awaiting',
+    'confirm',
+    'review-transaction',
+    'transaction-pending',
+    'transaction-confirmed',
+    'complete',
+    'error',
+  ].includes(state.status)
+
+  return (
+    <>
+      <>
+        {!isTransactionStarted && (
+          <>
+            <DialogHeader className="py-4">
+              <DialogTitle>
+                <IdentityTag
+                  imgSrc={identity?.user?.image ?? identity?.image}
+                  variant={identity?.user ? 'user' : 'non-user'}
+                >
+                  <Trunctacular
+                    value={
+                      identity?.user?.display_name ??
+                      identity?.display_name ??
+                      'Identity'
+                    }
+                  />
+                </IdentityTag>
+              </DialogTitle>
+            </DialogHeader>
+            <Tabs defaultValue={mode}>
+              <TabsList>
+                <TabsTrigger
+                  variant="alternate"
+                  value="view"
+                  label="View tags"
+                />
+                <TabsTrigger variant="alternate" value="add" label="Add tags" />
+              </TabsList>
+            </Tabs>
+          </>
+        )}
+      </>
+    </>
+  )
 }

--- a/apps/portal/app/components/tags/tags-modal.tsx
+++ b/apps/portal/app/components/tags/tags-modal.tsx
@@ -1,14 +1,19 @@
 import { Dialog, DialogContent } from '@0xintuition/1ui'
+import { IdentityPresenter } from '@0xintuition/api'
 
 import { TagsForm } from './tags-form'
 
 export interface TagsModalProps {
+  identity: IdentityPresenter
   open?: boolean
+  mode: 'view' | 'add'
   onClose: () => void
   onSuccess?: () => void
 }
 
 export default function TagsModal({
+  identity,
+  mode,
   open,
   onClose,
   onSuccess,
@@ -21,7 +26,12 @@ export default function TagsModal({
       }}
     >
       <DialogContent className="bg-neutral-950 rounded-xl shadow border border-solid border-black/10">
-        <TagsForm onClose={onClose} onSuccess={onSuccess} />
+        <TagsForm
+          identity={identity}
+          mode={mode}
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/apps/portal/app/lib/state/store.ts
+++ b/apps/portal/app/lib/state/store.ts
@@ -22,7 +22,14 @@ export const createIdentityModalAtom = atomWithToggle(false)
 export const createClaimModalAtom = atomWithToggle(false)
 export const editProfileModalAtom = atomWithToggle(false)
 export const editSocialLinksModalAtom = atomWithToggle(false)
-export const tagsModalAtom = atomWithToggle(false)
+
+export const tagsModalAtom = atom<{
+  isOpen: boolean
+  mode: 'view' | 'add'
+}>({
+  isOpen: false,
+  mode: 'add',
+})
 
 export const stakeModalAtom = atom<{
   isOpen: boolean

--- a/apps/portal/app/routes/app+/identity+/$id.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id.tsx
@@ -119,7 +119,11 @@ export default function IdentityDetails() {
                 ))}
               </TagsContent>
             )}
-            <TagsButton onClick={() => setTagsModalActive(true)} />
+            <TagsButton
+              onClick={() => {
+                setTagsModalActive({ isOpen: true, mode: 'add' })
+              }}
+            />
           </Tags>
           {vaultDetails !== null && user_assets !== '0' ? (
             <PositionCard onButtonClick={() => logger('sell position clicked')}>
@@ -179,8 +183,15 @@ export default function IdentityDetails() {
           }}
         />
         <TagsModal
-          open={tagsModalActive}
-          onClose={() => setTagsModalActive(false)}
+          identity={identity}
+          open={tagsModalActive.isOpen}
+          mode={tagsModalActive.mode}
+          onClose={() =>
+            setTagsModalActive({
+              ...tagsModalActive,
+              isOpen: false,
+            })
+          }
         />
       </div>
     </NestedLayout>


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds the state store, tags modal, and tags form with the basic layout
- Cleans up the identity details section with tags and the 'Add tags' button pops the modal with the 'add' tab selected (this is set by the state, so we can set 'view' when viewing tags)
- Next PRs will be adding more functionality + UI and then the actual flow

## Screen Captures

![tag-modal-scaffolding](https://github.com/user-attachments/assets/49e60fea-164a-4e60-8cbd-05160f24b053)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
