### PR TITLE
ENG-2658 fix(portal): navigate to /login on log out

### DIFF
--- a/apps/portal/app/.client/privy-button.tsx
+++ b/apps/portal/app/.client/privy-button.tsx
@@ -29,7 +29,7 @@ export function PrivyButton({
   async function handleSignout() {
     logout()
     disconnect()
-    navigate('/login')
+    navigate('/')
   }
 
   if (!ready) {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- When logging out through the account menu, navigate to /login route.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
