### PR TITLE
ENG-2730 fix(portal): update connections routes to use follower values from user identity

### DIFF
--- a/apps/portal/app/routes/app+/profile+/$wallet+/connections.tsx
+++ b/apps/portal/app/routes/app+/profile+/$wallet+/connections.tsx
@@ -186,6 +186,16 @@ export default function ProfileConnections() {
     following,
     followingPagination,
   } = useLiveLoader<LoaderData>(['attest'])
+
+  if (!followClaim) {
+    return (
+      <Text>
+        This user has no follow claim yet. A follow claim will be created when
+        the first person follows them.
+      </Text>
+    )
+  }
+
   return (
     <div className="flex-col justify-start items-start flex w-full">
       <div className="self-stretch justify-between items-center inline-flex mb-6">

--- a/apps/portal/app/routes/app+/profile+/_index+/connections.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/connections.tsx
@@ -177,6 +177,16 @@ export default function ProfileConnections() {
     following,
     followingPagination,
   } = useLiveLoader<typeof loader>(['attest'])
+
+  if (!followClaim) {
+    return (
+      <Text>
+        This user has no follow claim yet. A follow claim will be created when
+        the first person follows them.
+      </Text>
+    )
+  }
+
   return (
     <div className="flex-col justify-start items-start flex w-full">
       <div className="self-stretch justify-between items-center inline-flex mb-6">


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- We were temporarily relying on the num_positions on the claim to get these numbers but we should be getting them from the user identity object. 
- This also introduces a check for followClaim on both Connections routes, previously it was only on $wallet route. 
- Added totalFollowers prop to TabContent
- Removed any hardcoded values
- Added a cpl TODO once we're able to get the total stake on claims "I am following x"

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
