### PR TITLE
ENG-2692 fix(portal): temporarily change block explorer link

### DIFF
--- a/apps/portal/app/lib/utils/constants.ts
+++ b/apps/portal/app/lib/utils/constants.ts
@@ -32,7 +32,7 @@ export const ACCEPTED_IMAGE_TYPES = ['jpeg', 'jpg', 'png']
 
 export const BLOCK_EXPLORER_URL =
   CURRENT_ENV === 'production'
-    ? 'https://basescan.org'
+    ? 'https://sepolia.basescan.org'
     : 'https://sepolia.basescan.org'
 
 export const CREATE_RESOURCE_ROUTE = '/resources/create'


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

This temporarily changes BLOCK_EXPLORER_URL so that they both point to base sepolia explorer. This along with any other CURRENT_ENV checks will be updated once environment handling is in place and we are going to prod.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
