### PR TITLE
ENG-2690 fix(portal): fix follow modal button state issue

### DIFF
--- a/apps/portal/app/components/follow/follow-modal.tsx
+++ b/apps/portal/app/components/follow/follow-modal.tsx
@@ -308,6 +308,7 @@ export default function FollowModal({
 
   const handleClose = () => {
     onClose()
+    setMode('follow')
     setTimeout(() => {
       dispatch({ type: 'START_TRANSACTION' })
       reset()

--- a/apps/portal/app/components/follow/follow-toast.tsx
+++ b/apps/portal/app/components/follow/follow-toast.tsx
@@ -31,9 +31,9 @@ export default function FollowToast({ action, assets, txHash }: ToastProps) {
               className="text-secondary-foreground inline-flex gap-1"
             >
               {action}{' '}
-              <Text variant="footnote" weight="bold">
+              <span className="text-sm font-bold">
                 {formatBalance(BigInt(assets), 18, 6)}
-              </Text>{' '}
+              </span>{' '}
               ETH
             </Text>
             <Link

--- a/apps/portal/app/components/stake/stake-toast.tsx
+++ b/apps/portal/app/components/stake/stake-toast.tsx
@@ -31,9 +31,9 @@ export default function StakeToast({ action, assets, txHash }: ToastProps) {
               className="text-secondary-foreground inline-flex gap-1"
             >
               {action}{' '}
-              <Text variant="footnote" weight="bold">
+              <span className="text-sm font-bold">
                 {formatBalance(BigInt(assets), 18, 6)}
-              </Text>{' '}
+              </span>{' '}
               ETH
             </Text>
             <div>

--- a/apps/portal/app/routes/app+/profile+/$wallet.tsx
+++ b/apps/portal/app/routes/app+/profile+/$wallet.tsx
@@ -177,8 +177,6 @@ export default function Profile() {
                 onClick={() =>
                   setFollowModalActive((prevState) => ({
                     ...prevState,
-                    mode: 'redeem',
-                    modalType: 'identity',
                     isOpen: true,
                   }))
                 }
@@ -249,7 +247,6 @@ export default function Profile() {
               }
             />
           </div>
-
           <StakeModal
             userWallet={userWallet}
             contract={userIdentity.contract}
@@ -274,7 +271,6 @@ export default function Profile() {
               setFollowModalActive((prevState) => ({
                 ...prevState,
                 isOpen: false,
-                mode: undefined,
               }))
             }}
           />


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- After unfollowing, we setMode back to follow so that a user can follow again, if they wanted
- Fixed a an issue in FollowToast
- Removed some unnecessary params from setFollowModalActive

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
