### PR TITLE
ENG-2707 fix(portal): add error field below image chooser

### DIFF
--- a/apps/portal/app/components/create-identity-form.tsx
+++ b/apps/portal/app/components/create-identity-form.tsx
@@ -532,6 +532,10 @@ function CreateIdentityForm({
                 </button>
               </div>
             </div>
+            <ErrorList
+              id={fields.image_url.errorId}
+              errors={fields.image_url.errors}
+            />
           </div>
           <div className="flex flex-col w-full gap-1.5">
             <Text variant="caption" className="text-secondary-foreground/90">


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds error field beneath the image chooser in create identity form

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
