### PR TITLE
ENG-2408 fix(portal): add link to profile card on non-user identities

### DIFF
--- a/apps/portal/app/routes/app+/identity+/$id.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id.tsx
@@ -107,6 +107,7 @@ export default function IdentityDetails() {
             name={identity?.display_name ?? ''}
             walletAddress={sliceString(identity?.identity_id, 6, 4)}
             bio={identity?.description ?? ''}
+            link={identity?.external_reference ?? ''}
           />
           <Tags>
             {identity?.tags && identity?.tags.length > 0 && (


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Added the link prop to the ProfileCard on non-user identities

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
