### PR TITLE
ENG-2093 feat(portal): explore search claims query changes

### DIFF
--- a/apps/portal/app/components/explore/ExploreSearchClaimInput.tsx
+++ b/apps/portal/app/components/explore/ExploreSearchClaimInput.tsx
@@ -97,17 +97,17 @@ const ExploreSearchClaimInput = ({
   }) => {
     const params = new URLSearchParams(window.location.search)
     if (identities.subject) {
-      params.set(Identity.Subject, identities.subject.vault_id)
+      params.set(Identity.Subject, identities.subject.id)
     } else {
       params.delete(Identity.Subject)
     }
     if (identities.predicate) {
-      params.set(Identity.Predicate, identities.predicate.vault_id)
+      params.set(Identity.Predicate, identities.predicate.id)
     } else {
       params.delete(Identity.Predicate)
     }
     if (identities.object) {
-      params.set(Identity.Object, identities.object.vault_id)
+      params.set(Identity.Object, identities.object.id)
     } else {
       params.delete(Identity.Object)
     }

--- a/apps/portal/app/components/identity-input.tsx
+++ b/apps/portal/app/components/identity-input.tsx
@@ -63,17 +63,15 @@ const IdentityInputButton = ({
   return (
     <div className="flex flex-col gap-2 items-start">
       <Popover open={isPopoverOpen} onOpenChange={onClick}>
-        <PopoverTrigger asChild>
+        <PopoverTrigger>
           {selectedValue.name ? (
-            <button onClick={onClick} className="cursor-pointer">
-              <IdentityTag
-                size={IdentityTagSize.lg}
-                variant={selectedValue.variant}
-                {...props}
-              >
-                {selectedValue.name.toLowerCase()}
-              </IdentityTag>
-            </button>
+            <IdentityTag
+              size={IdentityTagSize.lg}
+              variant={selectedValue.variant}
+              {...props}
+            >
+              {selectedValue.name.toLowerCase()}
+            </IdentityTag>
           ) : (
             <Button
               variant={ButtonVariant.secondary}
@@ -85,7 +83,7 @@ const IdentityInputButton = ({
             </Button>
           )}
         </PopoverTrigger>
-        <PopoverContent className="bg-transparent">
+        <PopoverContent className="bg-transparent border-0 w-max p-0">
           <IdentitySearchCombobox
             identities={identitiesToList}
             onIdentitySelect={onIdentitySelect}

--- a/apps/portal/app/routes/app+/explore+/_index+/claims.tsx
+++ b/apps/portal/app/routes/app+/explore+/_index+/claims.tsx
@@ -23,9 +23,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const { page, limit, sortBy, direction } = getStandardPageParams({
     searchParams,
   })
-  const subjectVaultId = searchParams.get('subject') || null
-  const predicateVaultId = searchParams.get('predicate') || null
-  const objectVaultId = searchParams.get('object') || null
+  const subjectId = searchParams.get('subject') || null
+  const predicateId = searchParams.get('predicate') || null
+  const objectId = searchParams.get('object') || null
 
   const claims = await fetchWrapper({
     method: ClaimsService.searchClaims,
@@ -34,9 +34,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
       limit,
       sortBy: sortBy as ClaimSortColumn,
       direction,
-      subject: subjectVaultId,
-      predicate: predicateVaultId,
-      object: objectVaultId,
+      subject: subjectId,
+      predicate: predicateId,
+      object: objectId,
     },
   })
 


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Modifies the claims search query to use the subject/predicate/object `vault_id` 
- Modifies the input to set the `vault_id` for each of these (the `getIdentityById` call still works with `vault_id`, so the UX is intact for setting the selection based on query param)
- Wraps the `IdentityTag` in a button to be able to surface the onClick so that users can reselect identities (and re-trigger the Popover)
- Note: We'll have a UX enhancement for allowing users to reset/clear a selection so that it'll revert that part of the claim to a wildcard

## Screen Captures

![explore-claims-query-2](https://github.com/user-attachments/assets/2db2ec87-896d-4fe5-920a-644510bd9304)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
