### PR TITLE
ENG-2776 fix(portal): fix privy logout use effect

### DIFF
--- a/apps/portal/app/.client/privy-logout.tsx
+++ b/apps/portal/app/.client/privy-logout.tsx
@@ -9,9 +9,11 @@ export default function PrivyLogout({ wallet }: { wallet: string }) {
   const submit = useSubmit()
   const { logout } = usePrivy()
   const { disconnect } = useDisconnect()
+
   useEffect(() => {
+    let mounted = true
     const handleLogout = async () => {
-      if (address !== wallet) {
+      if (mounted && address && address !== wallet) {
         await logout()
         disconnect()
         submit(null, {
@@ -21,7 +23,10 @@ export default function PrivyLogout({ wallet }: { wallet: string }) {
       }
     }
     handleLogout()
+    return () => {
+      mounted = false
+    }
   }, [address, wallet, submit, logout, disconnect])
 
-  return <div></div>
+  return null
 }

--- a/apps/portal/app/routes/app.tsx
+++ b/apps/portal/app/routes/app.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 import { UserPresenter, UsersService } from '@0xintuition/api'
 
+import PrivyLogout from '@client/privy-logout'
 import SidebarNav from '@components/sidebar-nav'
 import { fetchWrapper, invariant } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs, redirect } from '@remix-run/node'
@@ -33,7 +34,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function Index() {
-  const { userObject } = useLoaderData<{
+  const { wallet, userObject } = useLoaderData<{
     wallet: string
     userObject: UserPresenter
   }>()
@@ -48,10 +49,7 @@ export default function Index() {
       <SidebarNav userObject={userObject}>
         <Outlet />
       </SidebarNav>
-      {/* 
-      TODO: Fix constant logout issue [ENG-2776]
-      <PrivyLogout wallet={wallet} /> 
-      */}
+      <PrivyLogout wallet={wallet} />
     </div>
   )
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

This should fix the constant logouts on hard refreshes and navigation through the address bar. It now only runs the check when `address` changes or the component mounts, added a check to ensure that `address` is not null or undefined before comparing and added a `mounted` flag to prevent any operations if it unmounts.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
