### PR TITLE
ENG-2791 fix(portal): swap buttons for remix links on segmented nav

### DIFF
--- a/apps/portal/app/components/segmented-nav.tsx
+++ b/apps/portal/app/components/segmented-nav.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { SegmentedControl, SegmentedControlItem } from '@0xintuition/1ui'
 
-import { useNavigate, useParams } from '@remix-run/react'
+import { useLocation, useParams } from '@remix-run/react'
 
 export interface OptionType {
   value: string
@@ -16,38 +16,36 @@ interface SegmentedNavProps {
 }
 
 export const SegmentedNav = ({ options }: SegmentedNavProps) => {
-  const navigate = useNavigate()
   const params = useParams()
-  const currentPath = window.location.pathname
-  const initialTab =
-    options.find((option) => currentPath.includes(option.value))?.value ||
-    options[0].value
-  const [selectedTab, setSelectedTab] = useState(initialTab)
+  const location = useLocation()
+  const [selectedTab, setSelectedTab] = useState('')
 
-  const handleTabClick = (option: OptionType) => {
-    setSelectedTab(option.value)
-    const wallet = params.wallet || null
-    const id = params.id || null
-    let fullPath
+  useEffect(() => {
+    const currentTab =
+      options.find((option) => location.pathname.includes(option.value))
+        ?.value || options[0].value
+    setSelectedTab(currentTab)
+  }, [location.pathname, options])
+
+  const getFullPath = (option: OptionType) => {
+    const wallet = params.wallet || ''
+    const id = params.id || ''
 
     if (option.path) {
-      fullPath = option.path
-    } else if (option.basePath) {
-      if (option.basePath.includes('/identity')) {
-        fullPath = `${option.basePath}${id ? `/${id}` : ''}${option.value !== 'overview' ? `/${option.value}` : ''}`
-      } else {
-        fullPath = `${option.basePath}${wallet ? `/${wallet}` : ''}${option.value !== 'overview' ? `/${option.value}` : ''}`
-      }
-    } else {
-      const basePath = '/app/profile'
-      console.log('wallet', wallet)
-      fullPath =
-        wallet !== null
-          ? `${basePath}/${wallet}${option.value !== 'overview' ? `/${option.value}` : ''}`
-          : `${basePath}${option.value !== 'overview' ? `/${option.value}` : ''}`
+      return option.path
     }
 
-    navigate(fullPath)
+    if (option.basePath) {
+      const suffix = option.value !== 'overview' ? `/${option.value}` : ''
+      if (option.basePath.includes('/identity')) {
+        return `${option.basePath}${id ? `/${id}` : ''}${suffix}`
+      }
+      return `${option.basePath}${wallet ? `/${wallet}` : ''}${suffix}`
+    }
+
+    const basePath = '/app/profile'
+    const suffix = option.value !== 'overview' ? `/${option.value}` : ''
+    return wallet ? `${basePath}/${wallet}${suffix}` : `${basePath}${suffix}`
   }
 
   return (
@@ -56,7 +54,8 @@ export const SegmentedNav = ({ options }: SegmentedNavProps) => {
         <SegmentedControlItem
           key={index}
           isActive={selectedTab === option.value}
-          onClick={() => handleTabClick(option)}
+          to={getFullPath(option)}
+          onClick={() => setSelectedTab(option.value)}
         >
           {option.label}
         </SegmentedControlItem>

--- a/packages/1ui/src/components/SegmentedControl/SegmentedControl.spec.tsx
+++ b/packages/1ui/src/components/SegmentedControl/SegmentedControl.spec.tsx
@@ -15,25 +15,25 @@ describe('SegmentedControl', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
       <DocumentFragment>
         <ul
-          class="rounded-full flex border p-px border-border/30 primary-gradient-subtle"
+          class="rounded-full flex border border-border/30 primary-gradient-subtle items-center"
           role="tablist"
         >
           <li>
-            <button
+            <a
               aria-selected="true"
               class="rounded-full border border-transparent transition duration-300 ease-in-out hover:border-border/30 aria-selected:border-border/30 py-2 px-3 aria-selected:bg-background"
               role="tab"
             >
               One
-            </button>
+            </a>
           </li>
           <li>
-            <button
+            <a
               class="rounded-full border border-transparent transition duration-300 ease-in-out hover:border-border/30 aria-selected:border-border/30 py-2 px-3 aria-selected:bg-background"
               role="tab"
             >
               Two
-            </button>
+            </a>
           </li>
         </ul>
       </DocumentFragment>

--- a/packages/1ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/1ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import { Link } from '@remix-run/react'
+
 import { cn } from '../../styles'
 
 export interface SegmentedControlProps
@@ -10,7 +12,7 @@ const SegmentedControl = ({ className, ...props }: SegmentedControlProps) => {
     <ul
       role="tablist"
       className={cn(
-        'rounded-full flex border p-px border-border/30 primary-gradient-subtle',
+        'rounded-full flex border border-border/30 primary-gradient-subtle items-center',
         className,
       )}
       {...props}
@@ -19,26 +21,41 @@ const SegmentedControl = ({ className, ...props }: SegmentedControlProps) => {
 }
 
 export interface SegmentedControlItemProps
-  extends React.HTMLAttributes<HTMLButtonElement> {
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   isActive?: boolean
+  to?: string
+  href?: string
 }
 
 const SegmentedControlItem = ({
   className,
   isActive,
+  to,
+  href,
+  children,
   ...props
 }: SegmentedControlItemProps) => {
+  const commonProps = {
+    role: 'tab',
+    'aria-selected': isActive,
+    className: cn(
+      'rounded-full border border-transparent transition duration-300 ease-in-out hover:border-border/30 aria-selected:border-border/30 py-2 px-3 aria-selected:bg-background',
+      className,
+    ),
+    ...props,
+  }
+
   return (
     <li>
-      <button
-        role="tab"
-        aria-selected={isActive}
-        className={cn(
-          'rounded-full border border-transparent transition duration-300 ease-in-out hover:border-border/30 aria-selected:border-border/30 py-2 px-3 aria-selected:bg-background',
-          className,
-        )}
-        {...props}
-      />
+      {to ? (
+        <Link to={to} prefetch="intent" {...commonProps}>
+          {children}
+        </Link>
+      ) : (
+        <a href={href} {...commonProps}>
+          {children}
+        </a>
+      )}
     </li>
   )
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

This changes the buttons in SegmentedControlItem to Remix Link components so that we can leverage prefetching.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
