### PR TITLE
ENG-0000 fix(portal): Throw error on failed user identity fetch

### DIFF
--- a/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
@@ -70,7 +70,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     })
   } catch (error) {
     logger('Error fetching userIdentity', error)
-    return redirect('/create')
+    throw error
   }
 
   if (!userIdentity) {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Right now it redirects the user to /create which should probably only happen on no user identity found, as opposed to the API cal failing

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
