### PR TITLE
ENG-2811 fix(portal): fix spacing on paginated lists after introduction of empty/error state card

### DIFF
--- a/apps/portal/app/components/list/active-positions-on-claims.tsx
+++ b/apps/portal/app/components/list/active-positions-on-claims.tsx
@@ -1,9 +1,4 @@
-import {
-  Claim,
-  ClaimPositionRow,
-  EmptyStateCard,
-  Identity,
-} from '@0xintuition/1ui'
+import { Claim, ClaimPositionRow, Identity } from '@0xintuition/1ui'
 import { ClaimPresenter, SortColumn } from '@0xintuition/api'
 
 import { formatBalance } from '@lib/utils/misc'
@@ -27,10 +22,6 @@ export function ActivePositionsOnClaims({
     { value: 'Updated At', sortBy: 'UpdatedAt' },
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
-
-  if (!claims.length) {
-    return <EmptyStateCard message="No positions found." />
-  }
 
   return (
     <List<SortColumn>

--- a/apps/portal/app/components/list/active-positions-on-identities.tsx
+++ b/apps/portal/app/components/list/active-positions-on-identities.tsx
@@ -1,4 +1,4 @@
-import { EmptyStateCard, Identity, IdentityPosition } from '@0xintuition/1ui'
+import { Identity, IdentityPosition } from '@0xintuition/1ui'
 import { IdentityPresenter, SortColumn } from '@0xintuition/api'
 
 import { formatBalance } from '@lib/utils/misc'
@@ -22,10 +22,6 @@ export function ActivePositionsOnIdentities({
     { value: 'Updated At', sortBy: 'UpdatedAt' },
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
-
-  if (!identities.length) {
-    return <EmptyStateCard message="No positions found." />
-  }
 
   return (
     <List<SortColumn>

--- a/apps/portal/app/components/list/activity.tsx
+++ b/apps/portal/app/components/list/activity.tsx
@@ -4,7 +4,6 @@ import {
   ButtonVariant,
   Claim,
   ClaimRow,
-  EmptyStateCard,
   Icon,
   IconName,
   Identity,
@@ -45,16 +44,13 @@ export function ActivityList({
       `redeemed ${formatBalance(value, 18, 4)} ETH from a claim`,
   }
 
-  if (!activities.length) {
-    return <EmptyStateCard message="No activities found." />
-  }
-
   return (
     <List<SortColumn>
       pagination={pagination}
-      paginationLabel="identities"
+      paginationLabel="activities"
       paramPrefix={paramPrefix}
       enableSearch={false}
+      enableSort={false}
     >
       {activities.map((activity) => (
         <ActivityItem
@@ -96,7 +92,7 @@ function ActivityItem({
   return (
     <div
       key={activity.id}
-      className={`grow shrink basis-0 self-stretch p-6 bg-black rounded-xl my-4 border border-neutral-300/20 flex-col justify-start items-start gap-5 inline-flex w-full`}
+      className={`grow shrink basis-0 self-stretch p-6 bg-black rounded-xl border border-neutral-300/20 flex-col justify-start items-start gap-5 inline-flex w-full my-6 first:mt-0 last:mb-0`}
     >
       <div className="flex flex-row items-center justify-between min-w-full">
         <div className="flex flex-row items-center gap-2">

--- a/apps/portal/app/components/list/claims.tsx
+++ b/apps/portal/app/components/list/claims.tsx
@@ -1,4 +1,4 @@
-import { Claim, ClaimRow, EmptyStateCard, Identity } from '@0xintuition/1ui'
+import { Claim, ClaimRow, Identity } from '@0xintuition/1ui'
 import { ClaimPresenter, ClaimSortColumn } from '@0xintuition/api'
 
 import { formatBalance } from '@lib/utils/misc'
@@ -32,10 +32,6 @@ export function ClaimsList({
     { value: 'Updated At', sortBy: 'UpdatedAt' },
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
-
-  if (!claims.length) {
-    return <EmptyStateCard message="No claims found." />
-  }
 
   return (
     <List<ClaimSortColumn>

--- a/apps/portal/app/components/list/follow.tsx
+++ b/apps/portal/app/components/list/follow.tsx
@@ -1,4 +1,4 @@
-import { ClaimPositionRow, EmptyStateCard, Identity } from '@0xintuition/1ui'
+import { ClaimPositionRow, Identity } from '@0xintuition/1ui'
 import { IdentityPresenter, SortColumn } from '@0xintuition/api'
 
 import { SortOption } from '@components/sort-select'
@@ -25,14 +25,10 @@ export function FollowList({
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
 
-  if (!identities.length) {
-    return <EmptyStateCard message="No users found." />
-  }
-
   return (
     <List<SortColumn>
       pagination={pagination}
-      paginationLabel={paramPrefix ?? ''}
+      paginationLabel="users"
       options={options}
       paramPrefix={paramPrefix}
     >

--- a/apps/portal/app/components/list/identities.tsx
+++ b/apps/portal/app/components/list/identities.tsx
@@ -1,4 +1,4 @@
-import { EmptyStateCard, Identity, IdentityContentRow } from '@0xintuition/1ui'
+import { Identity, IdentityContentRow } from '@0xintuition/1ui'
 import { IdentityPresenter, SortColumn } from '@0xintuition/api'
 
 import { formatBalance } from '@lib/utils/misc'
@@ -28,10 +28,6 @@ export function IdentitiesList({
     { value: 'Updated At', sortBy: 'UpdatedAt' },
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
-
-  if (!identities.length) {
-    return <EmptyStateCard message="No identities found." />
-  }
 
   return (
     <List<SortColumn>

--- a/apps/portal/app/components/list/list-claims.tsx
+++ b/apps/portal/app/components/list/list-claims.tsx
@@ -56,7 +56,7 @@ export function ListClaimsList({
     <div className="flex flex-col w-full">
       <div className="flex flex-col w-full gap-6" ref={listContainerRef}>
         <div
-          className={`flex flex-row w-full mt-6 ${enableSearch ? 'justify-between' : 'justify-end'}`}
+          className={`flex flex-row w-full ${enableSearch ? 'justify-between' : 'justify-end'}`}
         >
           {enableSearch && <Search handleSearchChange={handleSearchChange} />}
           {enableSort && options && (

--- a/apps/portal/app/components/list/list.tsx
+++ b/apps/portal/app/components/list/list.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useRef } from 'react'
 
+import { EmptyStateCard } from '@0xintuition/1ui'
 import {
   ClaimSortColumn,
   PositionSortColumn,
@@ -39,28 +40,36 @@ export function List<T extends SortColumnType>({
   const listContainerRef = useRef<HTMLDivElement>(null)
 
   return (
-    <>
-      <div className="flex flex-col w-full gap-6" ref={listContainerRef}>
-        <div
-          className={`flex flex-row w-full mt-6 ${enableSearch ? 'justify-between' : 'justify-end'}`}
-        >
-          {enableSearch && <Search handleSearchChange={handleSearchChange} />}
-          {enableSort && options && (
-            <Sort options={options} handleSortChange={handleSortChange} />
+    <div className="flex flex-col w-full gap-6 mb-6" ref={listContainerRef}>
+      {pagination.totalEntries === 0 ? (
+        <EmptyStateCard message={`No ${paginationLabel} found.`} />
+      ) : (
+        <>
+          {(enableSearch || enableSort) && (
+            <div
+              className={`flex flex-row w-full ${enableSearch ? 'justify-between' : 'justify-end'}`}
+            >
+              {enableSearch && (
+                <Search handleSearchChange={handleSearchChange} />
+              )}
+              {enableSort && options && (
+                <Sort options={options} handleSortChange={handleSortChange} />
+              )}
+            </div>
           )}
-        </div>
-        <div className="flex flex-col w-full">{children}</div>
-        <PaginationComponent
-          totalEntries={pagination.totalEntries ?? 0}
-          currentPage={pagination.currentPage ?? 0}
-          totalPages={pagination.totalPages ?? 0}
-          limit={pagination.limit ?? 0}
-          onPageChange={onPageChange}
-          onLimitChange={onLimitChange}
-          label={paginationLabel}
-          listContainerRef={listContainerRef}
-        />
-      </div>
-    </>
+          <div className="flex flex-col w-full">{children}</div>
+          <PaginationComponent
+            totalEntries={pagination.totalEntries ?? 0}
+            currentPage={pagination.currentPage ?? 0}
+            totalPages={pagination.totalPages ?? 0}
+            limit={pagination.limit ?? 0}
+            onPageChange={onPageChange}
+            onLimitChange={onLimitChange}
+            label={paginationLabel}
+            listContainerRef={listContainerRef}
+          />
+        </>
+      )}
+    </div>
   )
 }

--- a/apps/portal/app/components/list/positions-on-claim.tsx
+++ b/apps/portal/app/components/list/positions-on-claim.tsx
@@ -1,4 +1,4 @@
-import { ClaimPositionRow, EmptyStateCard } from '@0xintuition/1ui'
+import { ClaimPositionRow } from '@0xintuition/1ui'
 import { PositionPresenter, PositionSortColumn } from '@0xintuition/api'
 
 import { formatBalance } from '@lib/utils/misc'
@@ -22,10 +22,6 @@ export function PositionsOnClaim({
     { value: 'Updated At', sortBy: PositionSortColumn.UPDATED_AT },
     { value: 'Created At', sortBy: PositionSortColumn.CREATED_AT },
   ]
-
-  if (!positions.length) {
-    return <EmptyStateCard message="No positions found." />
-  }
 
   return (
     <List<PositionSortColumn>

--- a/apps/portal/app/components/list/positions-on-identity.tsx
+++ b/apps/portal/app/components/list/positions-on-identity.tsx
@@ -1,4 +1,4 @@
-import { EmptyStateCard, Identity, IdentityPosition } from '@0xintuition/1ui'
+import { Identity, IdentityPosition } from '@0xintuition/1ui'
 import { PositionPresenter, PositionSortColumn } from '@0xintuition/api'
 
 import { formatBalance } from '@lib/utils/misc'
@@ -22,10 +22,6 @@ export function PositionsOnIdentity({
     { value: 'Updated At', sortBy: 'UpdatedAt' },
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
-
-  if (!positions.length) {
-    return <EmptyStateCard message="No positions found." />
-  }
 
   return (
     <List<PositionSortColumn>

--- a/apps/portal/app/components/nested-layout.tsx
+++ b/apps/portal/app/components/nested-layout.tsx
@@ -18,7 +18,7 @@ export function NestedLayout({
       <div className="flex px-10 py-10 w-[400px] flex-shrink-0 min-h-screen">
         <div className="flex flex-col items-center w-full">{children}</div>
       </div>
-      <div className="flex flex-col flex-grow h-screen min-h-screen gap-8 pr-10 py-10">
+      <div className="flex flex-col flex-grow h-screen min-h-screen gap-6 pr-10 py-10">
         {options && (
           <div className="flex flex-row justify-end">
             <SegmentedNav options={options} />

--- a/apps/portal/app/components/skeleton.tsx
+++ b/apps/portal/app/components/skeleton.tsx
@@ -10,7 +10,7 @@ export function DataHeaderSkeleton() {
 
 export function PaginatedListSkeleton() {
   return (
-    <div className="flex flex-col w-full gap-5 my-5">
+    <div className="flex flex-col w-full gap-6">
       <div className="flex items-center justify-between">
         <Skeleton className="w-44 h-10" />
         <Skeleton className="w-44 h-10" />
@@ -23,7 +23,7 @@ export function PaginatedListSkeleton() {
 
 export function TabsSkeleton({ numOfTabs }: { numOfTabs: number }) {
   return (
-    <div className="flex items-center gap-2.5 mb-5">
+    <div className="flex items-center gap-2.5">
       {Array.from({ length: numOfTabs }).map((_, index) => (
         <Skeleton key={index} className="w-44 h-10 rounded" />
       ))}
@@ -33,8 +33,10 @@ export function TabsSkeleton({ numOfTabs }: { numOfTabs: number }) {
 
 export function ActivitySkeleton() {
   return (
-    <div className="flex flex-col w-full">
-      <Skeleton className="w-full h-[564px]" />
+    <div className="flex flex-col w-full gap-6">
+      <Skeleton className="w-full h-48" />
+      <Skeleton className="w-full h-48" />
+      <Skeleton className="w-full h-48" />
     </div>
   )
 }

--- a/apps/portal/app/routes/app+/activity+/global.tsx
+++ b/apps/portal/app/routes/app+/activity+/global.tsx
@@ -31,7 +31,7 @@ export default function GlobalActivityFeed() {
   const { activity } = useLiveLoader<typeof loader>(['attest', 'create'])
 
   return (
-    <div className="m-8 flex flex-col items-center gap-4">
+    <div className="mx-8 flex flex-col items-center">
       <Suspense fallback={<ActivitySkeleton />}>
         <Await
           resolve={Promise.all([activity])}

--- a/apps/portal/app/routes/app+/activity+/personal.tsx
+++ b/apps/portal/app/routes/app+/activity+/personal.tsx
@@ -39,7 +39,7 @@ export default function PersonalActivityFeed() {
   const { activity } = useLiveLoader<typeof loader>(['attest', 'create'])
 
   return (
-    <div className="m-8 flex flex-col items-center gap-4">
+    <div className="mx-8 flex flex-col items-center gap-6">
       <Suspense fallback={<ActivitySkeleton />}>
         <Await
           resolve={Promise.all([activity])}

--- a/apps/portal/app/routes/app+/explore+/_index+/claims.tsx
+++ b/apps/portal/app/routes/app+/explore+/_index+/claims.tsx
@@ -68,7 +68,7 @@ export default function ExploreClaims() {
   const { claims, identities, claimsPagination } =
     useLoaderData<typeof loader>()
   return (
-    <div className="m-8 flex flex-col items-center gap-4">
+    <div className="m-8 flex flex-col items-center gap-6">
       <ExploreSearch variant="claim" identities={identities} />
       <ClaimsList
         claims={claims}

--- a/apps/portal/app/routes/app+/explore+/_index+/identities.tsx
+++ b/apps/portal/app/routes/app+/explore+/_index+/identities.tsx
@@ -53,7 +53,7 @@ export default function ExploreIdentities() {
   const { identities, pagination } = useLoaderData<typeof loader>()
 
   return (
-    <div className="m-8 flex flex-col items-center gap-4">
+    <div className="m-8 flex flex-col items-center gap-6">
       <ExploreSearch variant="identity" />
       <IdentitiesList
         identities={identities}

--- a/apps/portal/app/routes/app+/explore+/_index+/index.tsx
+++ b/apps/portal/app/routes/app+/explore+/_index+/index.tsx
@@ -12,7 +12,7 @@ export default function ExploreClaims() {
   logger('message from profile overview loader', message)
 
   return (
-    <div className="m-8 flex flex-col items-center gap-4">
+    <div className="m-8 flex flex-col items-center gap-6">
       <div className="flex flex-col">Explore Index Route</div>
       <pre>This is a placeholder for the Explore Index route</pre>
       <pre>route loader: {message}</pre>

--- a/apps/portal/app/routes/app+/explore+/_index+/lists.tsx
+++ b/apps/portal/app/routes/app+/explore+/_index+/lists.tsx
@@ -55,7 +55,7 @@ export default function ExploreLists() {
   const { listClaims, pagination } = useLoaderData<typeof loader>()
 
   return (
-    <div className="m-8 flex flex-col items-center w-full">
+    <div className="m-8 flex flex-col items-center gap-6 w-full">
       <ExploreSearch variant="list" />
       <ListClaimsList
         listClaims={listClaims}

--- a/apps/portal/app/routes/app+/explore+/_index+/users.tsx
+++ b/apps/portal/app/routes/app+/explore+/_index+/users.tsx
@@ -53,7 +53,7 @@ export default function ExploreUsers() {
   const { identities, pagination } = useLoaderData<typeof loader>()
 
   return (
-    <div className="m-8 flex flex-col items-center gap-4">
+    <div className="m-8 flex flex-col items-center gap-6">
       <ExploreSearch variant="user" />
       <IdentitiesList
         identities={identities}

--- a/apps/portal/app/routes/app+/identity+/$id+/data-about.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id+/data-about.tsx
@@ -56,8 +56,8 @@ export default function ProfileDataAbout() {
 
   return (
     <div className="flex-col justify-start items-start flex w-full gap-6">
-      <div className="flex flex-col w-full pb-4">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+      <div className="flex flex-col w-full pb-4 gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
@@ -104,8 +104,8 @@ export default function ProfileDataAbout() {
           </Await>
         </Suspense>
       </div>
-      <div className="flex flex-col pt-4 w-full">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+      <div className="flex flex-col w-full pb-4 gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"

--- a/apps/portal/app/routes/app+/profile+/$wallet+/connections.tsx
+++ b/apps/portal/app/routes/app+/profile+/$wallet+/connections.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Suspense } from 'react'
 
 import {
-  ErrorStateCard,
+  EmptyStateCard,
   Tabs,
   TabsContent,
   TabsList,
@@ -68,7 +68,7 @@ const TabContent = ({
     return null
   }
   return (
-    <TabsContent value={value} className="w-full">
+    <TabsContent value={value} className="flex flex-col w-full gap-6">
       <ConnectionsHeader
         variant={variant}
         subject={claim.subject}
@@ -89,8 +89,8 @@ export default function ProfileConnections() {
   invariant(userIdentity, NO_USER_IDENTITY_ERROR)
 
   return (
-    <div className="flex-col justify-start items-start flex w-full">
-      <div className="self-stretch justify-between items-center inline-flex mb-6">
+    <div className="flex flex-col w-full gap-6">
+      <div className="self-stretch justify-between items-center inline-flex">
         <Text
           variant="headline"
           weight="medium"
@@ -123,29 +123,22 @@ function ConnectionsContent({
   return (
     <Suspense
       fallback={
-        <>
+        <div className="flex flex-col w-full gap-6">
           <TabsSkeleton numOfTabs={2} />
           <DataHeaderSkeleton />
           <PaginatedListSkeleton />
-        </>
+        </div>
       }
     >
-      <Await
-        resolve={connectionsData}
-        errorElement={
-          <ErrorStateCard
-            message="This user has no follow claim yet. A follow claim will be
-                created when the first person follows them."
-          />
-        }
-      >
+      <Await resolve={connectionsData} errorElement={<></>}>
         {(resolvedConnectionsData) => {
           if (!resolvedConnectionsData) {
             return (
-              <Text>
-                This user has no follow claim yet. A follow claim will be
-                created when the first person follows them.
-              </Text>
+              <EmptyStateCard
+                message={
+                  'This user has no follow claim yet. A follow claim will be created when the first person follows them.'
+                }
+              />
             )
           }
           const {
@@ -161,7 +154,7 @@ function ConnectionsContent({
               defaultValue={ConnectionsHeaderVariants.followers}
               className="w-full"
             >
-              <TabsList className="mb-4">
+              <TabsList className="mb-6">
                 <TabsTrigger
                   value={ConnectionsHeaderVariants.followers}
                   label="Followers"

--- a/apps/portal/app/routes/app+/profile+/$wallet+/data-about.tsx
+++ b/apps/portal/app/routes/app+/profile+/$wallet+/data-about.tsx
@@ -59,8 +59,8 @@ export default function ProfileDataAbout() {
 
   return (
     <div className="flex-col justify-start items-start flex w-full gap-6">
-      <div className="flex flex-col w-full pb-4">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+      <div className="flex flex-col w-full pb-4 gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
@@ -107,12 +107,12 @@ export default function ProfileDataAbout() {
           </Await>
         </Suspense>
       </div>
-      <div className="flex flex-col pt-4 w-full">
+      <div className="flex flex-col pt-4 w-full gap-6">
         <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
-            className="theme-secondary-foreground w-full mb-6"
+            className="theme-secondary-foreground w-full"
           >
             Positions on this Identity
           </Text>

--- a/apps/portal/app/routes/app+/profile+/$wallet+/data-created.tsx
+++ b/apps/portal/app/routes/app+/profile+/$wallet+/data-created.tsx
@@ -102,14 +102,13 @@ const TabContent = ({
   children?: ReactNode
 }) => {
   return (
-    <TabsContent value={value} className="w-full">
+    <TabsContent value={value} className="flex flex-col w-full gap-6">
       <DataCreatedHeader
         variant={variant}
         userIdentity={userIdentity}
         userTotals={userTotals}
         totalResults={totalResults}
         totalStake={totalStake}
-        className="mb-6"
       />
       {children}
     </TabsContent>
@@ -133,9 +132,9 @@ export default function ProfileDataCreated() {
   invariant(userTotals, NO_USER_TOTALS_ERROR)
 
   return (
-    <>
-      <div className="flex-col justify-start items-start flex w-full">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+    <div className="flex-col justify-start items-start flex w-full gap-6">
+      <div className="flex flex-col w-full gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
@@ -158,7 +157,7 @@ export default function ProfileDataCreated() {
               errorElement={<></>}
             >
               {([resolvedIdentities, resolvedClaims]) => (
-                <TabsList className="mb-4">
+                <TabsList className="mb-6">
                   <TabsTrigger
                     value={DataCreatedHeaderVariants.activeIdentities}
                     label="Identities"
@@ -177,10 +176,10 @@ export default function ProfileDataCreated() {
           </Suspense>
           <Suspense
             fallback={
-              <>
+              <div className="flex flex-col w-full gap-6">
                 <DataHeaderSkeleton />
                 <PaginatedListSkeleton />
-              </>
+              </div>
             }
           >
             <Await
@@ -245,8 +244,8 @@ export default function ProfileDataCreated() {
           </Suspense>
         </Tabs>
       </div>
-      <div className="flex-col justify-start items-start flex w-full">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+      <div className="flex flex-col w-full gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
@@ -265,7 +264,7 @@ export default function ProfileDataCreated() {
               errorElement={<></>}
             >
               {([resolvedIdentities, resolvedClaims]) => (
-                <TabsList className="mb-4">
+                <TabsList className="mb-6">
                   <TabsTrigger
                     value={DataCreatedHeaderVariants.createdIdentities}
                     label="Identities"
@@ -284,10 +283,10 @@ export default function ProfileDataCreated() {
           </Suspense>
           <Suspense
             fallback={
-              <>
+              <div className="flex flex-col w-full gap-6">
                 <DataHeaderSkeleton />
                 <PaginatedListSkeleton />
-              </>
+              </div>
             }
           >
             <Await
@@ -360,6 +359,6 @@ export default function ProfileDataCreated() {
           </Suspense>
         </Tabs>
       </div>
-    </>
+    </div>
   )
 }

--- a/apps/portal/app/routes/app+/profile+/_index+/connections.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/connections.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Suspense } from 'react'
 
 import {
-  ErrorStateCard,
+  EmptyStateCard,
   Tabs,
   TabsContent,
   TabsList,
@@ -63,7 +63,7 @@ const TabContent = ({
     return null
   }
   return (
-    <TabsContent value={value} className="w-full">
+    <TabsContent value={value} className="flex flex-col w-full gap-6">
       <ConnectionsHeader
         variant={variant}
         subject={claim.subject}
@@ -86,8 +86,8 @@ export default function ProfileConnections() {
   invariant(userIdentity, NO_USER_IDENTITY_ERROR)
 
   return (
-    <div className="flex-col justify-start items-start flex w-full">
-      <div className="self-stretch justify-between items-center inline-flex mb-6">
+    <div className="flex flex-col w-full gap-6">
+      <div className="self-stretch justify-between items-center inline-flex">
         <Text
           variant="headline"
           weight="medium"
@@ -122,29 +122,22 @@ function ConnectionsContent({
   return (
     <Suspense
       fallback={
-        <>
+        <div className="flex flex-col w-full gap-6">
           <TabsSkeleton numOfTabs={2} />
           <DataHeaderSkeleton />
           <PaginatedListSkeleton />
-        </>
+        </div>
       }
     >
-      <Await
-        resolve={connectionsData}
-        errorElement={
-          <ErrorStateCard
-            message="This user has no follow claim yet. A follow claim will be
-                created when the first person follows them."
-          />
-        }
-      >
+      <Await resolve={connectionsData} errorElement={<></>}>
         {(resolvedConnectionsData) => {
           if (!resolvedConnectionsData) {
             return (
-              <Text>
-                This user has no follow claim yet. A follow claim will be
-                created when the first person follows them.
-              </Text>
+              <EmptyStateCard
+                message={
+                  'This user has no follow claim yet. A follow claim will be created when the first person follows them.'
+                }
+              />
             )
           }
           const {
@@ -160,7 +153,7 @@ function ConnectionsContent({
               defaultValue={ConnectionsHeaderVariants.followers}
               className="w-full"
             >
-              <TabsList className="mb-4">
+              <TabsList className="mb-6">
                 <TabsTrigger
                   value={ConnectionsHeaderVariants.followers}
                   label="Followers"

--- a/apps/portal/app/routes/app+/profile+/_index+/data-about.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/data-about.tsx
@@ -54,8 +54,8 @@ export default function ProfileDataAbout() {
 
   return (
     <div className="flex-col justify-start items-start flex w-full gap-6">
-      <div className="flex flex-col w-full pb-4">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+      <div className="flex flex-col w-full pb-4 gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
@@ -102,8 +102,8 @@ export default function ProfileDataAbout() {
           </Await>
         </Suspense>
       </div>
-      <div className="flex flex-col pt-4 w-full">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+      <div className="flex flex-col pt-4 w-full gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"

--- a/apps/portal/app/routes/app+/profile+/_index+/data-created.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/data-created.tsx
@@ -100,14 +100,13 @@ const TabContent = ({
   children?: ReactNode
 }) => {
   return (
-    <TabsContent value={value} className="w-full">
+    <TabsContent value={value} className="flex flex-col w-full gap-6">
       <DataCreatedHeader
         variant={variant}
         userIdentity={userIdentity}
         userTotals={userTotals}
         totalResults={totalResults}
         totalStake={totalStake}
-        className="mb-6"
       />
       {children}
     </TabsContent>
@@ -133,9 +132,9 @@ export default function ProfileDataCreated() {
   invariant(userTotals, NO_USER_TOTALS_ERROR)
 
   return (
-    <>
-      <div className="flex-col justify-start items-start flex w-full">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+    <div className="flex-col justify-start items-start flex w-full gap-6">
+      <div className="flex flex-col w-full gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
@@ -158,7 +157,7 @@ export default function ProfileDataCreated() {
               errorElement={<></>}
             >
               {([resolvedIdentities, resolvedClaims]) => (
-                <TabsList className="mb-4">
+                <TabsList className="mb-6">
                   <TabsTrigger
                     value={DataCreatedHeaderVariants.activeIdentities}
                     label="Identities"
@@ -177,10 +176,10 @@ export default function ProfileDataCreated() {
           </Suspense>
           <Suspense
             fallback={
-              <>
+              <div className="flex flex-col w-full gap-6">
                 <DataHeaderSkeleton />
                 <PaginatedListSkeleton />
-              </>
+              </div>
             }
           >
             <Await
@@ -245,8 +244,8 @@ export default function ProfileDataCreated() {
           </Suspense>
         </Tabs>
       </div>
-      <div className="flex-col justify-start items-start flex w-full">
-        <div className="self-stretch justify-between items-center inline-flex mb-6">
+      <div className="flex flex-col w-full gap-6">
+        <div className="self-stretch justify-between items-center inline-flex">
           <Text
             variant="headline"
             weight="medium"
@@ -265,7 +264,7 @@ export default function ProfileDataCreated() {
               errorElement={<></>}
             >
               {([resolvedIdentities, resolvedClaims]) => (
-                <TabsList className="mb-4">
+                <TabsList className="mb-6">
                   <TabsTrigger
                     value={DataCreatedHeaderVariants.createdIdentities}
                     label="Identities"
@@ -284,10 +283,10 @@ export default function ProfileDataCreated() {
           </Suspense>
           <Suspense
             fallback={
-              <>
+              <div className="flex flex-col w-full gap-6">
                 <DataHeaderSkeleton />
                 <PaginatedListSkeleton />
-              </>
+              </div>
             }
           >
             <Await
@@ -360,6 +359,6 @@ export default function ProfileDataCreated() {
           </Suspense>
         </Tabs>
       </div>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Spacing was wonky after adding in skeletons, empty/error state cards, etc. Handling the EmptyStateCard in the List now rather than on each individual list. Adjusted spacing on all routes with lists to account for this.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
