### PR TITLE
ENG-0000 fix(portal): remove x api key from auth header

### DIFF
--- a/apps/portal/app/lib/utils/misc.tsx
+++ b/apps/portal/app/lib/utils/misc.tsx
@@ -106,10 +106,6 @@ export function getAuthHeaders(token?: string) {
     headers.authorization = `Bearer ${token}`
   }
 
-  if (!token) {
-    headers['x-api-key'] = process.env.API_KEY as string
-  }
-
   return headers
 }
 


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Removed x-api-key from the auth header as it shouldn't be needed on the app, and we think it might be causing some of the issues on the deployed app. Tested locally and doesn't seem to be causing any issues.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
