### PR TITLE
ENG-0000 fix(portal): reintroduce x api key

### DIFF
--- a/apps/portal/app/lib/utils/misc.tsx
+++ b/apps/portal/app/lib/utils/misc.tsx
@@ -106,6 +106,10 @@ export function getAuthHeaders(token?: string) {
     headers.authorization = `Bearer ${token}`
   }
 
+  if (!token) {
+    headers['x-api-key'] = process.env.API_KEY as string
+  }
+
   return headers
 }
 


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Reintroduces x-api-key header if accessToken is null/undefined to help debug the issue on deployment.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
