### PR TITLE
ENG-0000 fix(portal): reintroduce hardcoded apiurl

### DIFF
--- a/apps/portal/app/.server/auth.ts
+++ b/apps/portal/app/.server/auth.ts
@@ -111,8 +111,7 @@ export async function handlePrivyRedirect({
 }
 
 export async function setupAPI(request: Request) {
-  const apiUrl =
-    typeof window !== 'undefined' ? window.ENV?.API_URL : process.env.API_URL
+  const apiUrl = 'https://dev.api.intuition.systems'
 
   OpenAPI.BASE = apiUrl
   const accessToken = getPrivyAccessToken(request)


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Reverting using ENV variable for apiUrl to test if that is the issue with deployed app

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
