### PR TITLE
ENG-0000 feat(portal,1ui): Add navlink nav state

### DIFF
--- a/apps/portal/app/components/sidebar-nav.tsx
+++ b/apps/portal/app/components/sidebar-nav.tsx
@@ -162,10 +162,14 @@ export default function SidebarNav({
                     to={sidebarNavItem.route}
                     prefetch="intent"
                   >
-                    <SidebarNavItem
-                      iconName={sidebarNavItem.iconName}
-                      label={sidebarNavItem.label}
-                    />
+                    {({ isActive, isPending }) => (
+                      <SidebarNavItem
+                        iconName={sidebarNavItem.iconName}
+                        label={sidebarNavItem.label}
+                        aria-selected={isActive || isPending}
+                        isLoading={isPending}
+                      />
+                    )}
                   </NavLink>
                 ))}
               </div>

--- a/packages/1ui/src/components/SidebarLayout/components/SidebarNavItem.tsx
+++ b/packages/1ui/src/components/SidebarLayout/components/SidebarNavItem.tsx
@@ -23,12 +23,14 @@ export interface SidebarNavItemProps
   iconName: IconNameType | ReactNode
   label: string
   onClick?: () => void
+  isLoading?: boolean
 }
 
 export const SidebarNavItem = ({
   iconName,
   label,
   onClick,
+  isLoading = false,
   ...props
 }: SidebarNavItemProps) => {
   const { isMobileView, isCollapsed, setIsCollapsed } =
@@ -41,6 +43,7 @@ export const SidebarNavItem = ({
       onClick && onClick()
       isMobileView && setIsCollapsed(true)
     },
+    isLoading,
     ...props,
   }
 
@@ -60,7 +63,7 @@ export const SidebarNavItem = ({
             {...buttonProps}
             className="justify-center"
           >
-            {ImageComponent}
+            {!isLoading && ImageComponent}
           </Button>
         </TooltipTrigger>
         <TooltipContent side="right" sideOffset={16}>
@@ -73,7 +76,7 @@ export const SidebarNavItem = ({
       size={isMobileView ? ButtonSize.xl : ButtonSize.lg}
       {...buttonProps}
     >
-      {ImageComponent}
+      {!isLoading && ImageComponent}
       {label}
     </Button>
   )


### PR DESCRIPTION
## Affected Packages

Apps

- [X] portal

Packages

- [X] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Only if we want it.  Added navstate tracking for nav links so user can easily see what is loading and what route is active.  Lists will no longer be in side nav so ignore the duplicate loading in demo video.


## Screen Captures

https://github.com/user-attachments/assets/154ed5be-0c8d-4b05-8a5c-a7c29d60a790

## Declaration

- [X] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
