### PR TITLE
ENG-3086 feat(portal): user profile overview add lists

### DIFF
--- a/apps/portal/app/components/list/list-claims.tsx
+++ b/apps/portal/app/components/list/list-claims.tsx
@@ -27,7 +27,7 @@ export function ListClaimsList<T extends SortColumnType = ClaimSortColumn>({
   sourceUserAddress,
 }: {
   listClaims: ClaimPresenter[]
-  pagination: PaginationType
+  pagination?: PaginationType
   paramPrefix?: string
   enableSearch?: boolean
   enableSort?: boolean
@@ -83,9 +83,9 @@ export function ListClaimsList<T extends SortColumnType = ClaimSortColumn>({
 
   return (
     <div className="flex flex-col w-full">
-      <div className="flex flex-col w-full gap-6" ref={listContainerRef}>
+      <div className="flex flex-col w-full" ref={listContainerRef}>
         <div
-          className={`flex flex-row w-full ${enableSearch ? 'justify-between' : 'justify-end'}`}
+          className={`flex flex-row w-full ${enableSearch ? 'justify-between' : 'justify-end'} ${enableSort ? 'mb-6' : 'mb-0'}`}
         >
           {enableSearch && <Search handleSearchChange={handleSearchChange} />}
           {enableSort && options && options.length > 0 && (
@@ -116,7 +116,7 @@ export function ListClaimsList<T extends SortColumnType = ClaimSortColumn>({
               ),
           )}
         </ListGrid>
-        {pagination.currentPage < pagination.totalPages && (
+        {pagination && pagination.currentPage < pagination.totalPages && (
           <div className="flex justify-center mt-4">
             <Button onClick={handleLoadMore} disabled={isLoading}>
               {isLoading ? 'Loading...' : 'Load More'}

--- a/apps/portal/app/components/profile/overview-about-header.tsx
+++ b/apps/portal/app/components/profile/overview-about-header.tsx
@@ -30,7 +30,7 @@ interface OverviewAboutHeaderProps
   link: string
 }
 
-const OverviewAboutHeader: React.FC<OverviewAboutHeaderProps> = ({
+export function OverviewAboutHeader({
   variant,
   userIdentity,
   totalClaims,
@@ -38,7 +38,7 @@ const OverviewAboutHeader: React.FC<OverviewAboutHeaderProps> = ({
   totalStake,
   link,
   ...props
-}) => {
+}: OverviewAboutHeaderProps) {
   return (
     <div
       className="flex flex-col gap-4 w-full p-6 bg-black rounded-xl border border-neutral-300/20 max-md:items-center"
@@ -98,5 +98,3 @@ const OverviewAboutHeader: React.FC<OverviewAboutHeaderProps> = ({
     </div>
   )
 }
-
-export default OverviewAboutHeader

--- a/apps/portal/app/components/profile/overview-created-header.tsx
+++ b/apps/portal/app/components/profile/overview-created-header.tsx
@@ -19,12 +19,12 @@ interface OverviewCreatedHeaderProps
   link: string
 }
 
-const OverviewCreatedHeader: React.FC<OverviewCreatedHeaderProps> = ({
+export function OverviewCreatedHeader({
   variant,
   totalCreated,
   link,
   ...props
-}) => {
+}: OverviewCreatedHeaderProps) {
   return (
     <div
       className="flex flex-col gap-4 w-full p-6 bg-black rounded-xl border border-neutral-300/20 max-md:items-center"
@@ -54,5 +54,3 @@ const OverviewCreatedHeader: React.FC<OverviewCreatedHeaderProps> = ({
     </div>
   )
 }
-
-export default OverviewCreatedHeader

--- a/apps/portal/app/components/profile/overview-staking-header.tsx
+++ b/apps/portal/app/components/profile/overview-staking-header.tsx
@@ -12,16 +12,16 @@ interface OverviewStakingHeaderProps
   link: string
 }
 
-const OverviewStakingHeader: React.FC<OverviewStakingHeaderProps> = ({
+export function OverviewStakingHeader({
   totalClaims,
   totalIdentities,
   totalStake,
   link,
   ...props
-}) => {
+}: OverviewStakingHeaderProps): React.ReactElement {
   return (
     <div
-      className="flex flex-col gap-4 w-full p-6 bg-black rounded-xl border border-neutral-300/20 max-md:items-center"
+      className="flex flex-col gap-4 w-full p-6 bg-black rounded-xl border border-neutral-300/20"
       {...props}
     >
       <div className="flex items-center gap-1.5">
@@ -33,8 +33,8 @@ const OverviewStakingHeader: React.FC<OverviewStakingHeaderProps> = ({
           Staking
         </Text>
       </div>
-      <div className="flex w-full gap-10">
-        <div className="flex flex-col items-end max-md:items-center">
+      <div className="flex flex-col md:flex-row w-full gap-4 md:gap-10">
+        <div className="flex justify-between md:flex-col md:items-start">
           <Text
             variant="caption"
             weight="regular"
@@ -42,11 +42,11 @@ const OverviewStakingHeader: React.FC<OverviewStakingHeaderProps> = ({
           >
             Identities
           </Text>
-          <Text variant="bodyLarge" weight="medium" className="items-center">
+          <Text variant="bodyLarge" weight="medium">
             {totalIdentities}
           </Text>
         </div>
-        <div className="flex flex-col items-end max-md:items-center">
+        <div className="flex justify-between md:flex-col md:items-start">
           <Text
             variant="caption"
             weight="regular"
@@ -54,11 +54,11 @@ const OverviewStakingHeader: React.FC<OverviewStakingHeaderProps> = ({
           >
             Claims
           </Text>
-          <Text variant="bodyLarge" weight="medium" className="items-center">
+          <Text variant="bodyLarge" weight="medium">
             {totalClaims}
           </Text>
         </div>
-        <div className="flex flex-col items-end max-md:items-center">
+        <div className="flex justify-between md:flex-col md:items-start">
           <Text
             variant="caption"
             weight="regular"
@@ -68,9 +68,12 @@ const OverviewStakingHeader: React.FC<OverviewStakingHeaderProps> = ({
           </Text>
           <MonetaryValue value={totalStake} currency="ETH" />
         </div>
-        <div className="flex flex-col items-end justify-end ml-auto">
+        <div className="flex justify-center md:justify-end md:ml-auto mt-4 md:mt-0">
           <Link to={link} prefetch="intent">
-            <Button variant={ButtonVariant.secondary} className="w-max mb-1">
+            <Button
+              variant={ButtonVariant.secondary}
+              className="w-full md:w-max"
+            >
               View all positions
             </Button>
           </Link>
@@ -79,5 +82,3 @@ const OverviewStakingHeader: React.FC<OverviewStakingHeaderProps> = ({
     </div>
   )
 }
-
-export default OverviewStakingHeader


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds the Lists section to the Profile Overview
- Minor adjustments to components for responsiveness
- Adjusts the ListClaimsList and getUserSavedLists to be more flexible
- Restricts to top 6 right now, and still dedupes via a Set like we do in other List views 
- Can adjust and add a sort in but I removed since we're sorting by TVL and also only loading the Top

## Screen Captures

![profile-overview](https://github.com/user-attachments/assets/21a39d40-6d29-4d2c-b80f-3cf63278fb1d)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
