### PR TITLE
ENG-3100 fix(portal): logout if no active wallet

### DIFF
--- a/apps/portal/app/.client/privy-logout.tsx
+++ b/apps/portal/app/.client/privy-logout.tsx
@@ -13,7 +13,7 @@ export default function PrivyLogout({ wallet }: { wallet: string }) {
   useEffect(() => {
     let mounted = true
     const handleLogout = async () => {
-      if (mounted && address && address !== wallet && isConnected && ready) {
+      if (mounted && address !== wallet && ready) {
         await logout()
         disconnect()
         submit(null, {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Fixed the check in PrivyLogout. It was requiring address, but if noone is connected, address is undefined, so it won't log the user out. 

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
