### PR TITLE
ENG-3198 feat(portal): clicking list name navigates to list details

### DIFF
--- a/apps/portal/app/components/list/list-claims.tsx
+++ b/apps/portal/app/components/list/list-claims.tsx
@@ -110,6 +110,7 @@ export function ListClaimsList<T extends SortColumnType = ClaimSortColumn>({
                   identitiesCount={claim.object.tag_count ?? 0}
                   isSaved={claim.user_assets_for !== '0'}
                   savedAmount={claim.user_assets_for}
+                  navigateLink={`/app/list/${claim.claim_id}${sourceUserAddress ? `?user=${sourceUserAddress}` : ''}`}
                   onViewClick={() =>
                     navigate(
                       `/app/list/${claim.claim_id}${sourceUserAddress ? `?user=${sourceUserAddress}` : ''}`,

--- a/apps/portal/app/components/list/list-identity-card-portal.tsx
+++ b/apps/portal/app/components/list/list-identity-card-portal.tsx
@@ -9,6 +9,8 @@ import {
   Trunctacular,
 } from '@0xintuition/1ui'
 
+import { Link } from '@remix-run/react'
+
 export interface ListIdentityCardPortalProps {
   displayName: string
   imgSrc?: string
@@ -18,6 +20,7 @@ export interface ListIdentityCardPortalProps {
   onViewClick?: () => void
   isSaved?: boolean
   currency?: CurrencyType
+  navigateLink?: string
 }
 
 export const ListIdentityCardPortal: React.FC<ListIdentityCardPortalProps> = ({
@@ -25,6 +28,7 @@ export const ListIdentityCardPortal: React.FC<ListIdentityCardPortalProps> = ({
   imgSrc,
   identitiesCount,
   onViewClick,
+  navigateLink,
 }) => {
   return (
     <div className="flex flex-col items-center justify-between gap-2 h-72 max-sm:h-fit max-sm:gap-px">
@@ -35,13 +39,25 @@ export const ListIdentityCardPortal: React.FC<ListIdentityCardPortalProps> = ({
         className="mb-2 w-16 h-16"
       />
       <div className="text-center flex-grow flex flex-col justify-between items-center gap-4">
-        <Trunctacular
-          value={displayName}
-          variant={TextVariant.bodyLarge}
-          weight={TextWeight.medium}
-          className="text-primary/80"
-          maxStringLength={20}
-        />
+        {navigateLink ? (
+          <Link to={navigateLink}>
+            <Trunctacular
+              value={displayName}
+              variant={TextVariant.bodyLarge}
+              weight={TextWeight.medium}
+              className="text-primary/80"
+              maxStringLength={20}
+            />
+          </Link>
+        ) : (
+          <Trunctacular
+            value={displayName}
+            variant={TextVariant.bodyLarge}
+            weight={TextWeight.medium}
+            className="text-primary/80"
+            maxStringLength={20}
+          />
+        )}
         <Text variant={TextVariant.body} className="text-secondary/50">
           {identitiesCount} identities
         </Text>


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds a `navigationLink` prop and makes the List name navigate to the List Details page 
- Kept the `onClickNavigate` separate incase we want to change that functionality to go elsewhere from clicking the name

## Screen Captures

![list-click-navigation](https://github.com/user-attachments/assets/c09f5598-0db5-44d2-ab44-819e423d4314)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
