### PR TITLE
ENG-3180 fix(portal): increase max chars on profile card header name

### DIFF
--- a/packages/1ui/src/components/ProfileCard/ProfileCard.spec.tsx
+++ b/packages/1ui/src/components/ProfileCard/ProfileCard.spec.tsx
@@ -192,15 +192,11 @@ describe('ProfileCard', () => {
               </span>
             </span>
             <div>
-              <button
-                data-state="closed"
+              <h6
+                class="text-xl font-medium text-primary"
               >
-                <h6
-                  class="text-xl font-medium text-primary"
-                >
-                  Blockchai...
-                </h6>
-              </button>
+                Blockchain Corp
+              </h6>
               <div
                 class="flex flex-row gap-1 items-center"
               >

--- a/packages/1ui/src/components/ProfileCard/components/ProfileCardHeader.tsx
+++ b/packages/1ui/src/components/ProfileCard/components/ProfileCardHeader.tsx
@@ -26,6 +26,7 @@ const ProfileCardHeader = ({
           variant="headline"
           weight="medium"
           className="text-primary"
+          maxStringLength={24}
         />
         <div className="flex flex-row gap-1 items-center">
           {link && id && (


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Increased max chars on display name in the ProfileCardHeader

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
