### PR TITLE
ENG-3185 feat(portal): doubles the max length for truncated tags in review

### DIFF
--- a/apps/portal/app/components/tags/tags-review.tsx
+++ b/apps/portal/app/components/tags/tags-review.tsx
@@ -14,7 +14,6 @@ import { IdentityPresenter } from '@0xintuition/api'
 import { multivaultAbi } from '@lib/abis/multivault'
 import { useBatchCreateTriple } from '@lib/hooks/useBatchCreateTriple'
 import { useLoaderFetcher } from '@lib/hooks/useLoaderFetcher'
-import logger from '@lib/utils/logger'
 import { CreateLoaderData } from '@routes/resources+/create'
 import {
   CREATE_RESOURCE_ROUTE,
@@ -77,10 +76,6 @@ export default function TagsReview({
     ) {
       try {
         dispatch({ type: 'APPROVE_TRANSACTION' })
-        logger('[BEGIN ONCHAIN CREATE')
-        logger('subjectVaultIds:', subjectIdentityVaultIds)
-        logger('predicateHasTagVaultIds:', predicateHasTagVaultIds)
-        logger('objectTagVaultIds:', objectTagVaultIds)
         const txHash = await writeBatchCreateTriple({
           address: MULTIVAULT_CONTRACT_ADDRESS,
           abi: multivaultAbi,

--- a/packages/1ui/src/components/Tags/Tags.tsx
+++ b/packages/1ui/src/components/Tags/Tags.tsx
@@ -68,7 +68,7 @@ const TagWithValue = ({
 }: TagWithValueProps) => {
   const TagContent = (
     <>
-      <Trunctacular value={label ? label : ''} />
+      <Trunctacular value={label ? label : ''} maxStringLength={24} />
       {value && (
         <>
           <span className="h-[2px] w-[2px] bg-primary mx-1" />


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Doubles the max string length for truncated tags in review. Max is now 24 -- we can see how this feels and increase if we need.

## Screen Captures

![add-tags-review-truncation](https://github.com/user-attachments/assets/b103c3c6-0e80-4acb-9c7b-a23f89bdb8a2)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
