### PR TITLE
ENG-3253 fix(portal): skips identities that have bad/malformed data in the list page

### DIFF
--- a/apps/portal/app/components/list/identities.tsx
+++ b/apps/portal/app/components/list/identities.tsx
@@ -44,33 +44,38 @@ export function IdentitiesList({
       enableSearch={enableSearch}
       enableSort={enableSort}
     >
-      {identities.map((identity) => (
-        <div
-          key={identity.id}
-          className={`grow shrink basis-0 self-stretch p-6 bg-background first:border-t-px first:rounded-t-xl last:rounded-b-xl theme-border border-t-0 flex-col justify-start items-start gap-5 inline-flex`}
-        >
-          <IdentityContentRow
-            variant={identity.is_user ? Identity.user : Identity.nonUser}
-            avatarSrc={getAtomImage(identity)}
-            name={getAtomLabel(identity)}
-            id={identity.user?.wallet ?? identity.identity_id}
-            amount={
-              +formatBalance(
-                BigInt(
-                  variant === 'explore'
-                    ? identity.assets_sum
-                    : identity.user_assets || '',
-                ),
-                18,
-                4,
-              )
-            }
-            totalFollowers={identity.num_positions}
-            link={getAtomLink(identity)}
-            ipfsLink={getAtomIpfsLink(identity)}
-          />
-        </div>
-      ))}
+      {identities.map((identity) => {
+        if (!identity || typeof identity !== 'object') {
+          return null
+        }
+        return (
+          <div
+            key={identity.id}
+            className={`grow shrink basis-0 self-stretch p-6 bg-background first:border-t-px first:rounded-t-xl last:rounded-b-xl theme-border border-t-0 flex-col justify-start items-start gap-5 inline-flex`}
+          >
+            <IdentityContentRow
+              variant={identity.is_user ? Identity.user : Identity.nonUser}
+              avatarSrc={getAtomImage(identity)}
+              name={getAtomLabel(identity)}
+              id={identity.user?.wallet ?? identity.identity_id}
+              amount={
+                +formatBalance(
+                  BigInt(
+                    variant === 'explore'
+                      ? identity.assets_sum
+                      : identity.user_assets || '',
+                  ),
+                  18,
+                  4,
+                )
+              }
+              totalFollowers={identity.num_positions}
+              link={getAtomLink(identity)}
+              ipfsLink={getAtomIpfsLink(identity)}
+            />
+          </div>
+        )
+      })}
     </List>
   )
 }


### PR DESCRIPTION
… that the app doesnt break when they appear in a list

## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds a check that skips bad identities instead of crashing the whole page. We can likely add this in other lists but adding this here because it was where we first saw it -- likely from some of the generated identities

## Screen Captures

![list-skip-problem-identities](https://github.com/user-attachments/assets/9a06984d-5fe0-42fb-9e79-8431ee831332)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
