### PR TITLE
ENG-3236 fix(portal): fix https links in popovers

### DIFF
--- a/apps/portal/app/lib/utils/misc.tsx
+++ b/apps/portal/app/lib/utils/misc.tsx
@@ -368,6 +368,9 @@ export const getAtomIpfsLink = (atom: IdentityPresenter | null | undefined) => {
   if (atom.is_user === true) {
     return `${BLOCK_EXPLORER_URL}/address/${atom.identity_id}`
   }
+  if (atom.identity_id?.startsWith('https')) {
+    return atom.identity_id
+  }
   return `${IPFS_GATEWAY_URL}/${atom.identity_id?.replace('ipfs://', '')}`
 }
 


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Fixes https links in pop overs, like the schema.org links, so that they don't get prefixed with the IPFS gateway.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
