### PR TITLE
ENG-0000 fix(portal): layout setup, profile overview responsiveness, create cta

### DIFF
--- a/apps/portal/app/components/sidebar-nav.tsx
+++ b/apps/portal/app/components/sidebar-nav.tsx
@@ -286,7 +286,7 @@ export default function SidebarNav({
                     <SidebarNavItem
                       iconName={IconName.brushSparkle}
                       label="Create"
-                      className="bg-for text-white rounded-full items-center justify-center"
+                      className="bg-for/50 hover:bg-for text-foreground hover:text-foreground"
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent

--- a/apps/portal/app/layouts/root-layout.tsx
+++ b/apps/portal/app/layouts/root-layout.tsx
@@ -13,7 +13,7 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children, userObject }) => {
   return (
     <div className="h-screen flex">
       <SidebarNav userObject={userObject}>
-        <div className="h-max flex-grow justify-center flex w-full">
+        <div className="h-full flex-grow justify-center flex w-full">
           {children}
         </div>
       </SidebarNav>

--- a/apps/portal/app/layouts/two-panel-layout.tsx
+++ b/apps/portal/app/layouts/two-panel-layout.tsx
@@ -16,7 +16,7 @@ const TwoPanelLayout: React.FC<TwoPanelLayoutProps> = ({
     <div className="w-full h-full flex flex-col">
       <main className="w-full flex flex-grow max-lg:flex-col">
         <div className="w-[400px] bg-primary/5 p-10 max-lg:self-center max-lg:w-full max-lg:p-6 rounded-br-xl">
-          {leftPanel}
+          <div className="sticky top-10 max-lg:top-6">{leftPanel}</div>
         </div>
         <div className="flex-1 p-10 max-lg:p-6">{rightPanel}</div>
       </main>

--- a/apps/portal/app/routes/app+/profile+/_index+/index.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/index.tsx
@@ -113,7 +113,7 @@ export default function UserProfileOverview() {
       >
         About
       </Text>
-      <div className="flex flex-row items-center gap-6 max-lg:flex-col">
+      <div className="flex flex-row items-center gap-6 max-2xl:flex-col">
         <OverviewAboutHeader
           variant="claims"
           userIdentity={userIdentity}


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- make left panel in two panel layout sticky
- fix profile overview responsiveness 
- update create cta styling

## Screen Captures

https://github.com/user-attachments/assets/95850ff3-0bc4-4df9-a8f5-80ced96daeba

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
