### PR TITLE
ENG-0000 fix(portal): add tag close popover on identity select

### DIFF
--- a/apps/portal/app/components/tags/add-tags.tsx
+++ b/apps/portal/app/components/tags/add-tags.tsx
@@ -78,6 +78,7 @@ export function AddTags({
     const finalUrl = `${TAG_RESOURCE_ROUTE}?${searchParams.toString()}`
 
     tagFetcher.load(finalUrl)
+    setIsPopoverOpen(false)
   }
 
   const handleSaveClick = (invalidTag: IdentityPresenter) => {

--- a/apps/portal/app/components/tags/tags-form.tsx
+++ b/apps/portal/app/components/tags/tags-form.tsx
@@ -115,6 +115,7 @@ export function TagsForm({
                         identity?.display_name ??
                         'Identity'
                       }
+                      maxStringLength={42}
                     />
                   </IdentityTag>
                 </DialogTitle>
@@ -164,7 +165,7 @@ export function TagsForm({
                 </div>
               </Tabs>
               {currentTab === 'add' && (
-                <div className="mt-auto py-4 bg-neutral-950">
+                <div className="mt-auto py-4">
                   <DialogFooter className="!justify-center !items-center">
                     <div className="flex flex-col items-center gap-1">
                       <Button


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Closes the Popover when selecting an Identity from the combobox in the Add Tags modal. Also increases the length of the identity in the modal header.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
