### PR TITLE
ENG-3370 fix(portal): remove https prefix from create identity form and better sizing

### DIFF
--- a/apps/portal/app/components/create-identity/create-identity-form.tsx
+++ b/apps/portal/app/components/create-identity/create-identity-form.tsx
@@ -504,7 +504,7 @@ function CreateIdentityForm({
       />
       <div className="h-full flex flex-col">
         {state.status === 'idle' ? (
-          <div className="w-full h-full flex-col justify-start items-start inline-flex gap-7">
+          <div className="w-full h-[690px] flex-col justify-start items-start inline-flex gap-7">
             <div className="flex flex-col w-full gap-1.5">
               <div className="self-stretch flex-col justify-start items-start flex">
                 <div className="flex w-full items-center justify-between">
@@ -666,8 +666,7 @@ function CreateIdentityForm({
               </Label>
               <Input
                 {...getInputProps(fields.external_reference, { type: 'text' })}
-                placeholder="www.url.com"
-                startAdornment="http://"
+                placeholder="https://www.url.com"
                 onChange={(e) =>
                   setFormState((prev) => ({
                     ...prev,
@@ -723,7 +722,7 @@ function CreateIdentityForm({
               />
               <Text
                 variant={TextVariant.caption}
-                className="text-center text-primary/70"
+                className="text-center text-primary/70 mt-0.5"
               >
                 Note: You will not be chraged an entry fee for this initial
                 deposit.
@@ -737,7 +736,11 @@ function CreateIdentityForm({
                   type="button"
                   variant="primary"
                   onClick={() => {
-                    dispatch({ type: 'REVIEW_TRANSACTION' })
+                    const result = form.valid
+                    console.log('result', result)
+                    if (result) {
+                      dispatch({ type: 'REVIEW_TRANSACTION' })
+                    }
                   }}
                   disabled={
                     !address ||
@@ -755,7 +758,7 @@ function CreateIdentityForm({
             </div>
           </div>
         ) : state.status === 'review-transaction' ? (
-          <div className="h-full flex flex-col">
+          <div className="h-[460px] flex flex-col">
             <CreateIdentityReview
               dispatch={dispatch}
               identity={reviewIdentity}
@@ -787,7 +790,7 @@ function CreateIdentityForm({
             </div>
           </div>
         ) : (
-          <div className="h-full flex flex-col">
+          <div className="h-[460px]  flex flex-col">
             <TransactionState
               status={state.status}
               txHash={state.txHash}

--- a/apps/portal/app/components/create-identity/create-identity-modal.tsx
+++ b/apps/portal/app/components/create-identity/create-identity-modal.tsx
@@ -25,7 +25,7 @@ export default function CreateIdentityModal({
     >
       <DialogContent
         onOpenAutoFocus={(event) => event.preventDefault()} // prevent tooltip from being auto-launched
-        className="flex flex-col h-[780px] max-sm:min-w-0"
+        className="flex flex-col max-sm:min-w-0"
       >
         <IdentityForm
           onClose={onClose}

--- a/apps/portal/app/consts/general.ts
+++ b/apps/portal/app/consts/general.ts
@@ -34,6 +34,7 @@ export const ACCEPTED_IMAGE_MIME_TYPES = [
   'image/jpeg',
   'image/jpg',
   'image/png',
+  'image/webp',
 ]
 export const ACCEPTED_IMAGE_TYPES = ['jpeg', 'jpg', 'png']
 


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Removed the https prefix from the add link input in the create identity form. Added a check to make sure the link is at least prefixed with something ending in ://. We can make it more robust later if we want. 

Also improved the sizing in the review and transaction states, as it was way too big during those states.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
