### PR TITLE
ENG-3385 fix(portal): fix create identity form not closing after clicking view or close

### DIFF
--- a/apps/portal/app/components/create-identity/create-identity-form.tsx
+++ b/apps/portal/app/components/create-identity/create-identity-form.tsx
@@ -184,7 +184,7 @@ function CreateIdentityForm({
     undefined,
   )
   const [imageUploadError, setImageUploadError] = useState<string | null>(null)
-  const [initialDeposit, setInitialDeposit] = useState<string>('')
+  const [initialDeposit, setInitialDeposit] = useState<string>('0')
   const [isContract, setIsContract] = useState(false)
 
   const loaderFetcher = useFetcher<CreateLoaderData>()
@@ -505,7 +505,7 @@ function CreateIdentityForm({
       />
       <div className="h-full flex flex-col">
         {state.status === 'idle' ? (
-          <div className="w-full h-[690px] flex-col justify-start items-start inline-flex gap-7">
+          <div className="w-full h-[660px] flex-col justify-start items-start inline-flex gap-7">
             <div className="flex flex-col w-full gap-1.5">
               <div className="self-stretch flex-col justify-start items-start flex">
                 <div className="flex w-full items-center justify-between">
@@ -762,7 +762,7 @@ function CreateIdentityForm({
             </div>
           </div>
         ) : state.status === 'review-transaction' ? (
-          <div className="h-[460px] flex flex-col">
+          <div className="h-[600px] flex flex-col">
             <CreateIdentityReview
               dispatch={dispatch}
               identity={reviewIdentity}
@@ -794,7 +794,7 @@ function CreateIdentityForm({
             </div>
           </div>
         ) : (
-          <div className="h-[460px]  flex flex-col">
+          <div className="h-[600px] flex flex-col">
             <TransactionState
               status={state.status}
               txHash={state.txHash}
@@ -812,7 +812,7 @@ function CreateIdentityForm({
                           `${PATHS.IDENTITY}/${transactionResponseData.id}`,
                         )
                       }
-                      handleClose
+                      handleClose()
                     }}
                   >
                     {successAction === TransactionSuccessAction.VIEW


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Modal wasn't closing after clicking View Identity or Close after the transaction successfully completed. Wasn't calling handleClose correctly. Made a couple slight tweaks to sizing after running through some tests with this, as large(er) descriptions were causing the review screen to overflow, and there was a bit too much bottom padding on the main form.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
