### PR TITLE
ENG-3396 fix(portal): reduce tags in identity content row

### DIFF
--- a/packages/1ui/src/components/IdentityPosition/IdentityPosition.spec.tsx
+++ b/packages/1ui/src/components/IdentityPosition/IdentityPosition.spec.tsx
@@ -240,7 +240,7 @@ describe('IdentityPosition', () => {
                         class="flex flex-row gap-2 items-center"
                       >
                         <p
-                          class="text-primary font-normal text-sm"
+                          class="text-primary text-base font-normal"
                         >
                           keyboard
                         </p>
@@ -261,7 +261,7 @@ describe('IdentityPosition', () => {
                         class="flex flex-row gap-2 items-center"
                       >
                         <p
-                          class="text-primary font-normal text-sm"
+                          class="text-primary text-base font-normal"
                         >
                           ergonomic
                         </p>
@@ -282,7 +282,7 @@ describe('IdentityPosition', () => {
                         class="flex flex-row gap-2 items-center"
                       >
                         <p
-                          class="text-primary font-normal text-sm"
+                          class="text-primary text-base font-normal"
                         >
                           wireless
                         </p>
@@ -303,7 +303,7 @@ describe('IdentityPosition', () => {
                         class="flex flex-row gap-2 items-center"
                       >
                         <p
-                          class="text-primary font-normal text-sm"
+                          class="text-primary text-base font-normal"
                         >
                           gaming
                         </p>

--- a/packages/1ui/src/components/Tags/Tags.spec.tsx
+++ b/packages/1ui/src/components/Tags/Tags.spec.tsx
@@ -38,7 +38,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   keyboard
                 </p>
@@ -59,7 +59,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   ergonomic
                 </p>
@@ -80,7 +80,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   wireless
                 </p>
@@ -101,7 +101,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   gaming
                 </p>
@@ -122,7 +122,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   mechanical
                 </p>
@@ -143,7 +143,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   tech
                 </p>
@@ -164,7 +164,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   innovation
                 </p>
@@ -185,7 +185,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   typing
                 </p>
@@ -206,7 +206,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   quality
                 </p>
@@ -227,7 +227,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   brand
                 </p>
@@ -291,7 +291,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   keyboard
                 </p>
@@ -312,7 +312,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   ergonomic
                 </p>
@@ -333,7 +333,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   wireless
                 </p>
@@ -354,7 +354,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   gaming
                 </p>
@@ -375,7 +375,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   mechanical
                 </p>
@@ -396,7 +396,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   tech
                 </p>
@@ -417,7 +417,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   innovation
                 </p>
@@ -438,7 +438,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   typing
                 </p>
@@ -459,7 +459,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   quality
                 </p>
@@ -480,7 +480,7 @@ describe('Tags', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   brand
                 </p>

--- a/packages/1ui/src/components/Tags/Tags.tsx
+++ b/packages/1ui/src/components/Tags/Tags.tsx
@@ -72,11 +72,7 @@ const TagWithValue = ({
 }: TagWithValueProps) => {
   const TagContent = (
     <div className="flex flex-row gap-2 items-center">
-      <Trunctacular
-        className="text-sm"
-        value={label ? label : ''}
-        maxStringLength={24}
-      />
+      <Trunctacular value={label ? label : ''} maxStringLength={24} />
       {value && (
         <div className="flex flex-row gap-1.5 items-center">
           <span className="h-[2px] w-[2px] bg-primary" />

--- a/packages/1ui/src/components/TagsListInput/TagsListInput.spec.tsx
+++ b/packages/1ui/src/components/TagsListInput/TagsListInput.spec.tsx
@@ -34,7 +34,7 @@ describe('TagsListInput', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   Tag Name 1
                 </p>
@@ -60,7 +60,7 @@ describe('TagsListInput', () => {
               class="flex flex-row gap-2 items-center"
             >
               <p
-                class="text-primary font-normal text-sm"
+                class="text-primary text-base font-normal"
               >
                 Tag Name 2
               </p>
@@ -86,7 +86,7 @@ describe('TagsListInput', () => {
             class="flex flex-row gap-2 items-center"
           >
             <p
-              class="text-primary font-normal text-sm"
+              class="text-primary text-base font-normal"
             >
               Tag Name 3
             </p>
@@ -197,7 +197,7 @@ describe('TagsListInput', () => {
                 class="flex flex-row gap-2 items-center"
               >
                 <p
-                  class="text-primary font-normal text-sm"
+                  class="text-primary text-base font-normal"
                 >
                   Tag Name 1
                 </p>
@@ -223,7 +223,7 @@ describe('TagsListInput', () => {
               class="flex flex-row gap-2 items-center"
             >
               <p
-                class="text-primary font-normal text-sm"
+                class="text-primary text-base font-normal"
               >
                 Tag Name 2
               </p>
@@ -249,7 +249,7 @@ describe('TagsListInput', () => {
             class="flex flex-row gap-2 items-center"
           >
             <p
-              class="text-primary font-normal text-sm"
+              class="text-primary text-base font-normal"
             >
               Tag Name 3
             </p>


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [x] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

There were too many tags in IdentityContentRow for smaller screen sizes and was causing some bad styling issues. Reduced the max to 2 in a content row like that.

@jonathanprozzi I saw that in your changes yesterday you made the entire row clickable to route to the hasTag claim. They used to be linked like that but having a link wrapping the entire row causes issues with any other links/clickables in the row, including the hover card. Couldn't copy the wallet/ipfs cid without it navigating either. Don't love that you can't click in the padding of the rows either haha. Just being nitty at this point. Avatar/name still link to claim. I made the +X more next to tags link to the identity, so they could view the other tags on that identity. Feels less clunky imo and gives more functionality.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
