### PR TITLE
ENG-0000 fix(portal): removes alert dialog for the tags-modal for now

### DIFF
--- a/apps/portal/app/components/tags/tags-modal.tsx
+++ b/apps/portal/app/components/tags/tags-modal.tsx
@@ -1,9 +1,6 @@
 import { Dialog, DialogContent } from '@0xintuition/1ui'
 import { IdentityPresenter } from '@0xintuition/api'
 
-import AlertDialog from '@components/alert-dialog'
-import useHandleCloseAttempt from '@lib/hooks/useHandleCloseAttempt'
-
 import { TagsForm } from './tags-form'
 
 export interface TagsModalProps {
@@ -23,35 +20,24 @@ export default function TagsModal({
   onClose,
   onSuccess,
 }: TagsModalProps) {
-  const {
-    showAlertDialog,
-    setShowAlertDialog,
-    setIsTransactionComplete,
-    handleCloseAttempt,
-  } = useHandleCloseAttempt(onClose)
-
   return (
     <>
-      <Dialog open={open} onOpenChange={handleCloseAttempt}>
+      <Dialog
+        open={open}
+        onOpenChange={() => {
+          onClose?.()
+        }}
+      >
         <DialogContent className="h-[550px]">
           <TagsForm
             identity={identity}
             userWallet={userWallet}
             mode={mode}
             onClose={onClose}
-            onSuccess={() => {
-              setIsTransactionComplete(true)
-              onSuccess?.()
-            }}
+            onSuccess={onSuccess}
           />
         </DialogContent>
       </Dialog>
-      <AlertDialog
-        open={showAlertDialog}
-        onOpenChange={setShowAlertDialog}
-        setShowAlertDialog={setShowAlertDialog}
-        onClose={onClose}
-      />
-    </>
+    </> // TODO: [ENG-3436] -- Add AlertDialog interaction back in
   )
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Removes the AlertDialog from the Tags Modal for now -- can add back in on ENG-3436.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
