### PR TITLE
ENG-3392 feat(portal): handle pending user identities on personal profile routes

### DIFF
--- a/apps/portal/app/lib/services/identities.ts
+++ b/apps/portal/app/lib/services/identities.ts
@@ -26,6 +26,7 @@ export async function getIdentityOrPending(
           args: { identifier: id },
         })) as unknown as IdentityPresenter // we're handling the missing identity properties via not rendering anything that relies on any missing properties. otherwise we'd need to set defaults which i'm wary of
         logger(`IDENTITY ${id} IS PENDING`)
+        logger('pendingIdentity', pendingIdentity)
         return { identity: pendingIdentity, isPending: true }
       } catch (pendingError) {
         logger('catching pendingError')


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds in pending checks to user profile and profile index
- Similar checks for another user's profile -- I tested this with a pending identity (isPending: true) but that wasn't a 'full' pending identity. This removes the redirect loop for identities in that state. I also forced it with an actual pending identity and saw the refresh UI.

## Screen Captures

![image](https://github.com/user-attachments/assets/794ddd8c-7eaa-4c74-b5b7-933d0f1a439e)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
