### PR TITLE
ENG-0000 fix(portal): adds redirect to /create if the userIdentity is an actual 404

### DIFF
--- a/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
@@ -113,7 +113,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   )
 
   if (!userIdentity) {
-    throw new Response('Not Found', { status: 404 })
+    throw redirect('/create') // this is an actual 404 and should redirect to /create
   }
 
   if (!userIdentity.creator) {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds a redirect to `/create` when a user is an actual 404 (not pending, which returns a partial userIdentity)

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
