### PR TITLE
ENG-0000 fix(portal): removes the alert dialog from add identities list

### DIFF
--- a/apps/portal/app/components/list/add-identities-list-modal.tsx
+++ b/apps/portal/app/components/list/add-identities-list-modal.tsx
@@ -1,9 +1,6 @@
 import { Dialog, DialogContent } from '@0xintuition/1ui'
 import { IdentityPresenter } from '@0xintuition/api'
 
-import AlertDialog from '@components/alert-dialog'
-import useHandleCloseAttempt from '@lib/hooks/useHandleCloseAttempt'
-
 import { AddIdentitiesListForm } from './add-identities-list-form'
 
 export interface AddIdentitiesListModalProps {
@@ -23,35 +20,24 @@ export default function AddIdentitiesListModal({
   onClose,
   onSuccess,
 }: AddIdentitiesListModalProps) {
-  const {
-    showAlertDialog,
-    setShowAlertDialog,
-    setIsTransactionComplete,
-    handleCloseAttempt,
-  } = useHandleCloseAttempt(onClose)
-
   return (
     <>
-      <Dialog open={open} onOpenChange={handleCloseAttempt}>
+      <Dialog
+        open={open}
+        onOpenChange={() => {
+          onClose?.()
+        }}
+      >
         <DialogContent className="h-[550px]">
           <AddIdentitiesListForm
             identity={identity}
             userWallet={userWallet}
             claimId={claimId}
             onClose={onClose}
-            onSuccess={() => {
-              setIsTransactionComplete(true)
-              onSuccess?.()
-            }}
+            onSuccess={onSuccess}
           />
         </DialogContent>
       </Dialog>
-      <AlertDialog
-        open={showAlertDialog}
-        onOpenChange={setShowAlertDialog}
-        setShowAlertDialog={setShowAlertDialog}
-        onClose={onClose}
-      />
-    </>
+    </> // TODO: [ENG-3436] -- Add AlertDialog interaction back in
   )
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Removes the Alert Dialog onClose from the Add Identities List to fix the collision issue we're seeing
- Adds a TODO for us to handle this in a future point

## Screen Captures

![add-identities-list-alert-dialog](https://github.com/user-attachments/assets/be20959d-2592-44d8-8676-c0097be6497f)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
