### PR TITLE
ENG-0000 fix(portal): fix home loop

### DIFF
--- a/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
@@ -130,7 +130,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   )
 
   if (!userIdentity) {
-    throw redirect('/invite') // this is an actual 404 and should redirect to /create
+    throw redirect('/invite')
   }
 
   if (!userIdentity.creator) {

--- a/apps/portal/app/routes/app.tsx
+++ b/apps/portal/app/routes/app.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { UserPresenter, UsersService } from '@0xintuition/api'
 
 import PrivyLogout from '@client/privy-logout'
+import { getIdentityOrPending } from '@lib/services/identities'
 import { invariant } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs, redirect } from '@remix-run/node'
 import { Outlet, useLoaderData, useLocation } from '@remix-run/react'
@@ -34,6 +35,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
       wallet,
     },
   })
+
+  const { identity: userIdentity, isPending } = await getIdentityOrPending(
+    request,
+    wallet,
+  )
+
+  if (!userIdentity || !isPending) {
+    if (!wallet) {
+      throw redirect('/login')
+    } else {
+      throw redirect('/invite')
+    }
+  }
 
   // TODO: Figure out why SiteWideBanner has no access to window.ENV values [ENG-3367]
   const featureFlags = getFeatureFlags()


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Fixes the loop when logging in where users were sent to Home just to be redirected back to log in. Forgot to move the redirect login from Profile to Home when we switched the rest of the redirect logic to now bring users to Home on login. Added a better check at the app layer. Can improve on this further but going to save that for post launch.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
