### PR TITLE
ENG-0000 fix(portal): fix staking modal bugs

### DIFF
--- a/apps/portal/app/components/stake/stake-form.tsx
+++ b/apps/portal/app/components/stake/stake-form.tsx
@@ -42,6 +42,9 @@ interface StakeFormProps {
   walletBalance: string
   identity?: IdentityPresenter
   claim?: ClaimPresenter
+  user_conviction: string
+  conviction_price: string
+  user_assets: string
   vaultDetails: VaultDetailsType
   direction?: 'for' | 'against'
   val: string
@@ -64,6 +67,9 @@ export default function StakeForm({
   walletBalance,
   identity,
   claim,
+  user_conviction,
+  conviction_price,
+  user_assets,
   vaultDetails,
   direction,
   val,
@@ -195,14 +201,13 @@ export default function StakeForm({
                     e.preventDefault()
                     setStakeModalState({ ...stakeModalState, mode: 'redeem' })
                   }}
+                  disabled={user_conviction === '0'}
                 />
               </TabsList>
             </Tabs>
             <div className="pt-2.5">
               <ActivePositionCard
-                value={Number(
-                  formatBalance(vaultDetails?.user_assets ?? 0, 18),
-                )}
+                value={Number(formatBalance(user_assets ?? 0, 18))}
                 claimPosition={
                   direction !== undefined
                     ? direction === 'for'
@@ -228,8 +233,8 @@ export default function StakeForm({
                   setVal={setVal}
                   walletBalance={walletBalance ?? '0'}
                   minDeposit={vaultDetails.min_deposit ?? '0'}
-                  userConviction={vaultDetails.user_conviction ?? '0'}
-                  price={vaultDetails.conviction_price ?? '0'}
+                  userConviction={user_conviction}
+                  price={conviction_price}
                 />
               </div>
             </div>

--- a/apps/portal/app/components/stake/stake-modal.tsx
+++ b/apps/portal/app/components/stake/stake-modal.tsx
@@ -103,6 +103,16 @@ export default function StakeModal({
           claim.against_conviction_price
   }
 
+  let user_assets: string = '0'
+  if (identityShouldOverride) {
+    user_assets = vaultDetails.user_assets ?? identity.user_assets
+  } else if (claim) {
+    user_assets =
+      direction === 'for'
+        ? vaultDetails.user_assets ?? claim.user_assets_for
+        : vaultDetails.user_assets_against ?? claim.user_assets_against
+  }
+
   const { min_deposit } = vaultDetails
 
   const depositHook = useDepositAtom(contract)
@@ -355,6 +365,9 @@ export default function StakeModal({
             identity={identity}
             claim={claim}
             vaultDetails={vaultDetails}
+            user_conviction={user_conviction}
+            conviction_price={conviction_price}
+            user_assets={user_assets}
             direction={direction ? direction : undefined}
             val={val}
             setVal={setVal}


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Changes got overwritten somehow that set values based on whether it was an identity or claim in the modal. Because of this position and redeem functionality was busted. Fixed the problem by passing the appropriate values down from the modal.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
