### PR TITLE
ENG-3737 fix(portal): add skip button to onboarding videos

### DIFF
--- a/apps/portal/app/components/relic-onboarding-video/relic-onboarding-video.tsx
+++ b/apps/portal/app/components/relic-onboarding-video/relic-onboarding-video.tsx
@@ -24,8 +24,10 @@ import { AnimatePresence, motion } from 'framer-motion'
 
 export default function RelicOnboadingVideo({
   variant,
+  link,
 }: {
   variant: 'v1' | 'v2' | 'v3'
+  link: string
 }) {
   const [isMuted, setIsMuted] = useState(false)
   const videoVolume = 0.33
@@ -42,7 +44,7 @@ export default function RelicOnboadingVideo({
   const navigate = useNavigate()
 
   const handleVideoEnd = () => {
-    navigate('/the-big-bang')
+    navigate(link)
   }
 
   const getVolumeIcon = () => {

--- a/apps/portal/app/consts/paths.ts
+++ b/apps/portal/app/consts/paths.ts
@@ -32,4 +32,5 @@ export const PATHS = {
   PRIVACY: '/privacy',
   // Other
   MAINTENANCE: '/maintenance',
+  THE_BIG_BANG: '/the-big-bang',
 }

--- a/apps/portal/app/routes/create.tsx
+++ b/apps/portal/app/routes/create.tsx
@@ -412,7 +412,7 @@ export default function Profile() {
                 <BridgeToBase />
               </motion.div>
             ) : (
-              <RelicOnboadingVideo variant="v3" />
+              <RelicOnboadingVideo variant="v3" link={PATHS.QUEST} />
             )}
           </AnimatePresence>
         </div>

--- a/apps/portal/app/routes/invite.tsx
+++ b/apps/portal/app/routes/invite.tsx
@@ -296,7 +296,7 @@ export default function InviteRoute() {
                 </div>
               </motion.div>
             ) : (
-              <RelicOnboadingVideo variant="v2" />
+              <RelicOnboadingVideo variant="v2" link={PATHS.THE_BIG_BANG} />
             )}
           </AnimatePresence>
         </div>


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Added a skip button to the relic onboarding videos. Also abstracted the video into a component that we can reuse throughout the flow.

Also did some testing for ENG-3744 and was unable to repro the issue. No changes were made related to this.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
