### PR TITLE
ENG-0000 fix(portal): Fix iq points rendering NaN in ProfileCard

### DIFF
--- a/packages/1ui/src/components/ProfileCard/components/ProfileCardStatItem.tsx
+++ b/packages/1ui/src/components/ProfileCard/components/ProfileCardStatItem.tsx
@@ -12,12 +12,13 @@ const ProfileCardStatItem = ({
   label,
   valueClassName = 'text-primary-300',
 }: ProfileCardStatItemProps) => {
-  const formattedValue = typeof value === 'number' ? formatNumber(value) : value
+  const formattedValue =
+    typeof value === 'number' ? formatNumber(+value.toFixed(0)) : value
 
   return (
     <div className="flex items-center space-x-1">
       <Text variant="body" weight="medium" className={valueClassName}>
-        {(+formattedValue).toFixed(0)}
+        {formattedValue}
       </Text>
       <Text variant="body" className="text-muted-foreground">
         {label}


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] portal

Packages

- [x] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Previous PR did the formatting in the wrong location which was causing IQ Points to render NaN in some cases in the ProfileCard.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
