### PR TITLE
ENG-3746 fix(portal): removed broken user id check from chapter 2

### DIFF
--- a/apps/portal/app/routes/app+/quest+/chapter+/1-2-stake_identity.tsx
+++ b/apps/portal/app/routes/app+/quest+/chapter+/1-2-stake_identity.tsx
@@ -101,11 +101,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
       })
       userQuests = data
     }
+
     const dependsOnUserQuest = userQuests.find(
-      (userQuest) =>
-        userQuest.quest_id === quest.depends_on_quest &&
-        user.id === userQuest.user_id,
+      (userQuest) => userQuest.quest_id === quest.depends_on_quest,
     )
+
     const dependsOnIdentityId =
       dependsOnUserQuest?.quest_completion_object_id ?? stakeAtomFallbackAtomId
     identity = await fetchWrapper(request, {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

There was a check in Chapter 2 that was comparing the user_id and privy_id, and because they did not match (they never would), it was always falling back to the fallback atom rather than using the atom created in the previous quest.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)

 
 **PR Summary by Typo**
------------

 **Summary:**
- Updated dependency check in `1-2-stake_identity.tsx` to rely on quest ID instead of user ID.
- Introduced `dependsOnIdentityId` variable for storing dependent quest completion object ID.

**Key Points:**
- Replaced user ID comparison with quest ID check in dependency check.
- Introduced new variable `dependsOnIdentityId` for storing quest completion object ID.

**Changes:**
1. **Dependency check:**
   - Changed comparison to only check for quest ID.

2. **Variables:**
   - Introduced `dependsOnIdentityId` for storing quest completion object ID.

**Categories:**
1. **Dependency check:**
   - Changed comparison to quest ID.

2. **Variables:**
   - Introduced `dependsOnIdentityId`.
   - Assigned to quest completion object ID or fallback ID. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>