### PR TITLE
ENG-3857 fix(portal): never round up with stake actions

### DIFF
--- a/apps/portal/app/components/stake/stake-actions.tsx
+++ b/apps/portal/app/components/stake/stake-actions.tsx
@@ -20,11 +20,7 @@ export default function StakeActions({
   price,
 }: StakeActionsProps) {
   const formatDecimal = (value: number): string => {
-    return value.toLocaleString('fullwide', {
-      useGrouping: false,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 18,
-    })
+    return (Math.floor(value * 1e18) / 1e18).toFixed(18).replace(/\.?0+$/, '')
   }
 
   const calculateAndSetValue = (percentage: number) => {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Updated the number formatting to assure that the value generated from interacting with staking action buttons doesn't round up, as it was previously causing users to experience "insufficient funds" errors.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)

 
 **PR Summary by Typo**
------------

 **Summary**

This pull request simplifies the formatting of decimal numbers in `StakeActions.tsx` by replacing `toLocaleString` with a custom implementation using `Math.floor()`, `toFixed()`, and `replace()`. It also removes the use of `useGrouping` and `minimumFractionDigits` options from the `formatDecimal` function.

**Key Points**

1. Replaces `toLocaleString` with custom decimal formatting.
2. Uses `Math.floor()`, `toFixed()`, and `replace()` for formatting.
3. Removes `useGrouping` and `minimumFractionDigits` options. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>