### PR TITLE
ENG-3652 chore(portal): add tooltips to points card

### DIFF
--- a/apps/portal/app/components/points-card/points-card.tsx
+++ b/apps/portal/app/components/points-card/points-card.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 
-import { Text, TextVariant } from '@0xintuition/1ui'
+import {
+  Text,
+  TextVariant,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@0xintuition/1ui'
 
 import { truncateNumber } from '@lib/utils/misc'
 
@@ -20,28 +27,38 @@ const PointsRow: React.FC<{
   disabled?: boolean
 }> = ({ name, points, totalPoints, disabled = false }) => {
   return (
-    <div className="grid grid-cols-7 items-center gap-2">
-      <Text
-        variant={TextVariant.body}
-        className={`col-span-2 ${disabled ? 'text-primary/40' : ''}`}
-      >
-        {name}
-      </Text>
-      <div className="col-span-4 h-[6px] w-full bg-muted rounded-sm mx-auto">
-        <div
-          className="h-full bg-primary rounded-sm"
-          style={{
-            width: `${totalPoints === 0 ? 0 : (points / totalPoints) * 100}%`,
-          }}
-        />
-      </div>
-      <Text
-        variant={TextVariant.body}
-        className={`col-span-1 text-right ${disabled ? 'text-primary/40' : ''}`}
-      >
-        {truncateNumber(points)}
-      </Text>
-    </div>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="grid grid-cols-7 items-center gap-2">
+            <Text
+              variant={TextVariant.body}
+              className={`col-span-2 ${disabled ? 'text-primary/40' : ''}`}
+            >
+              {name}
+            </Text>
+            <div className="col-span-4 h-[6px] w-full bg-muted rounded-sm mx-auto">
+              <div
+                className="h-full bg-primary rounded-sm"
+                style={{
+                  width: `${totalPoints === 0 ? 0 : (points / totalPoints) * 100}%`,
+                }}
+              />
+            </div>
+
+            <Text
+              variant={TextVariant.body}
+              className={`col-span-1 text-right ${disabled ? 'text-primary/40' : ''}`}
+            >
+              {truncateNumber(points)}
+            </Text>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          {(totalPoints === 0 ? 0 : (points / totalPoints) * 100).toFixed(1)}%
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Adds tooltips to the rows of the PointsCard to give users more context into the distribution of their points.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)

 
 **PR Summary by Typo**
------------

 **Summary**

Introduced `@0xintuition/1ui` Tooltip component for displaying percentage information in PointsCard, replacing text-based display.

**Key Points**

1. Replaced text-based percentage display with `@0xintuition/1ui` Tooltip.
2. Improved user experience by providing visual representation of percentage data. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>