### PR TITLE
ENG-0000 fix(portal): fix nftPoints math

### DIFF
--- a/apps/portal/app/components/points-card/points-card.tsx
+++ b/apps/portal/app/components/points-card/points-card.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 
-import { Text, TextVariant } from '@0xintuition/1ui'
+import {
+  Text,
+  TextVariant,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@0xintuition/1ui'
 
 import { truncateNumber } from '@lib/utils/misc'
 
@@ -20,28 +27,38 @@ const PointsRow: React.FC<{
   disabled?: boolean
 }> = ({ name, points, totalPoints, disabled = false }) => {
   return (
-    <div className="grid grid-cols-7 items-center gap-2">
-      <Text
-        variant={TextVariant.body}
-        className={`col-span-2 ${disabled ? 'text-primary/40' : ''}`}
-      >
-        {name}
-      </Text>
-      <div className="col-span-4 h-[6px] w-full bg-muted rounded-sm mx-auto">
-        <div
-          className="h-full bg-primary rounded-sm"
-          style={{
-            width: `${totalPoints === 0 ? 0 : (points / totalPoints) * 100}%`,
-          }}
-        />
-      </div>
-      <Text
-        variant={TextVariant.body}
-        className={`col-span-1 text-right ${disabled ? 'text-primary/40' : ''}`}
-      >
-        {truncateNumber(points)}
-      </Text>
-    </div>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="grid grid-cols-7 items-center gap-2">
+            <Text
+              variant={TextVariant.body}
+              className={`col-span-2 ${disabled ? 'text-primary/40' : ''}`}
+            >
+              {name}
+            </Text>
+            <div className="col-span-4 h-[6px] w-full bg-muted rounded-sm mx-auto">
+              <div
+                className="h-full bg-primary rounded-sm"
+                style={{
+                  width: `${totalPoints === 0 ? 0 : (points / totalPoints) * 100}%`,
+                }}
+              />
+            </div>
+
+            <Text
+              variant={TextVariant.body}
+              className={`col-span-1 text-right ${disabled ? 'text-primary/40' : ''}`}
+            >
+              {truncateNumber(points)}
+            </Text>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          {(totalPoints === 0 ? 0 : (points / totalPoints) * 100).toFixed(1)}%
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Fixed the NFT point math to account for minters who were no longer holding their relics.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)

 
 **PR Summary by Typo**
------------

 **Summary**

This pull request introduces new variables for tracking minted and held relics, removing the calculation of NFT mint and hold points in the `Quests` component.

**Key Points**

* Calculation of NFT mint and hold points removed
* New variables for minted and held relics introduced
* `Quests` component affected in `apps/portal/app/routes/app+/quest+/index.tsx` 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>