### PR TITLE
ENG-3811 fix(portal): fix default sortBy values on position related paginated lists

### DIFF
--- a/apps/portal/app/lib/services/connections.ts
+++ b/apps/portal/app/lib/services/connections.ts
@@ -59,6 +59,7 @@ export async function getConnectionsData({
     direction: followingDirection,
   } = getStandardPageParams({
     searchParams,
+    defaultSortByValue: 'UserAssets',
     paramPrefix: 'following',
   })
 
@@ -109,7 +110,7 @@ export async function getConnectionsData({
     } = getStandardPageParams({
       searchParams,
       paramPrefix: 'followers',
-      defaultSortByValue: PositionSortColumn.ASSETS,
+      defaultSortByValue: 'Assets',
     })
 
     const followersSearch =

--- a/apps/portal/app/lib/services/users.ts
+++ b/apps/portal/app/lib/services/users.ts
@@ -22,10 +22,13 @@ export async function getUserIdentities({
 }) {
   const { page, limit, sortBy, direction } = getStandardPageParams({
     searchParams,
+    defaultSortByValue: 'UserAssets',
     paramPrefix: 'activeIdentities',
   })
   const identitiesSearch =
     (searchParams.get('activeIdentitiesSearch') as string) || null
+
+  console.log('sortBy', sortBy)
 
   const result = await fetchWrapper(request, {
     method: UsersService.getUserIdentities,
@@ -100,6 +103,7 @@ export async function getUserClaims({
 }) {
   const { page, limit, sortBy, direction } = getStandardPageParams({
     searchParams,
+    defaultSortByValue: 'UserAssets',
     paramPrefix: 'activeClaims',
   })
   const claimsSearch =

--- a/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
@@ -186,8 +186,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
     followClaim = followClaimResponse.data[0]
   }
 
-  console.log('followClaim', followClaim)
-
   return json({
     privyUser: user,
     userWallet,


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Fixed the default sortBy value on position related paginated lists. It was sorting to AssetsSum when it should have been sorting by UserAssets (or Assets in the case of any data returned from /positions route).

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
