### PR TITLE
ENG-3113 feat(portal): add create button to EmptyStateCard for identities and claims

### DIFF
--- a/apps/portal/app/components/list/list.tsx
+++ b/apps/portal/app/components/list/list.tsx
@@ -45,7 +45,6 @@ export function List<T extends SortColumnType>({
   const listContainerRef = useRef<HTMLDivElement>(null)
 
   const setCreateIdentityModalActive = useSetAtom(globalCreateIdentityModalAtom)
-
   const setCreateClaimModalActive = useSetAtom(globalCreateClaimModalAtom)
 
   return (
@@ -62,23 +61,23 @@ export function List<T extends SortColumnType>({
       )}
       {pagination && pagination.totalEntries === 0 ? (
         <EmptyStateCard message={`No ${paginationLabel} found.`}>
-          {paginationLabel === 'identities' ? (
+          {paginationLabel.includes('identities') ? (
             <Button
               variant={ButtonVariant.primary}
               onClick={() => {
                 setCreateIdentityModalActive(true)
               }}
             >
-              <Icon name="fingerprint" /> Create Identity
+              <Icon name="fingerprint" className="h-4 w-4" /> Create an Identity
             </Button>
-          ) : paginationLabel === 'claims' ? (
+          ) : paginationLabel.includes('claims') ? (
             <Button
               variant={ButtonVariant.primary}
               onClick={() => {
                 setCreateClaimModalActive(true)
               }}
             >
-              <Icon name="claim" /> Create Claim
+              <Icon name="claim" className="h-4 w-4" /> Make a Claim
             </Button>
           ) : null}
         </EmptyStateCard>

--- a/apps/portal/app/routes/app+/profile+/$wallet+/index.tsx
+++ b/apps/portal/app/routes/app+/profile+/$wallet+/index.tsx
@@ -1,6 +1,13 @@
 import { Suspense } from 'react'
 
-import { EmptyStateCard, ErrorStateCard, Text } from '@0xintuition/1ui'
+import {
+  Button,
+  ButtonVariant,
+  EmptyStateCard,
+  ErrorStateCard,
+  Icon,
+  Text,
+} from '@0xintuition/1ui'
 import {
   ClaimSortColumn,
   ClaimsService,
@@ -27,6 +34,7 @@ import { getIdentityOrPending } from '@lib/services/identities'
 import { getUserSavedLists } from '@lib/services/lists'
 import { getPositionsOnIdentity } from '@lib/services/positions'
 import { getUserIdentities } from '@lib/services/users'
+import { globalCreateClaimModalAtom } from '@lib/state/store'
 import { formatBalance, invariant } from '@lib/utils/misc'
 import { defer, LoaderFunctionArgs } from '@remix-run/node'
 import { Await, useParams, useRouteLoaderData } from '@remix-run/react'
@@ -38,6 +46,7 @@ import {
   NO_WALLET_ERROR,
   PATHS,
 } from 'app/consts'
+import { useSetAtom } from 'jotai'
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const userWallet = await requireUserWallet(request)
@@ -117,6 +126,8 @@ export default function ProfileOverview() {
   const params = useParams()
   const { wallet } = params
 
+  const setCreateClaimModalActive = useSetAtom(globalCreateClaimModalAtom)
+
   return (
     <div className="flex flex-col gap-12">
       <div className="flex flex-col gap-6">
@@ -192,7 +203,16 @@ export default function ProfileOverview() {
             {(resolvedClaims) => {
               if (!resolvedClaims || resolvedClaims.data.length === 0) {
                 return (
-                  <EmptyStateCard message="This user has no claims about their identity yet." />
+                  <EmptyStateCard message="This user has no claims about their identity yet.">
+                    <Button
+                      variant={ButtonVariant.primary}
+                      onClick={() => {
+                        setCreateClaimModalActive(true)
+                      }}
+                    >
+                      <Icon name="claim" /> Make a Claim
+                    </Button>
+                  </EmptyStateCard>
                 )
               }
               return (


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Adds a create button to EmptyStateCards for identities and claims. Also adds the create button to "Top Claims about..." on profile wallet route. 

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
