### PR TITLE
ENG-4054 fix(portal): adds in a missing read only list check

### DIFF
--- a/apps/portal/app/components/detail-info-card.tsx
+++ b/apps/portal/app/components/detail-info-card.tsx
@@ -16,7 +16,7 @@ import {
 } from '@0xintuition/1ui'
 import { ClaimPresenter } from '@0xintuition/api'
 
-import { PATHS } from '@consts/paths'
+import { getListUrl } from '@lib/utils/misc'
 
 export interface DetailInfoCardProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -29,6 +29,7 @@ export interface DetailInfoCardProps
   link: string
   ipfsLink: string
   timestamp: string
+  readOnly?: boolean
 }
 
 const DetailInfoCard = ({
@@ -42,6 +43,7 @@ const DetailInfoCard = ({
   ipfsLink,
   timestamp,
   className,
+  readOnly = false,
   ...props
 }: DetailInfoCardProps) => {
   const formattedDate = new Intl.DateTimeFormat('en-US', {
@@ -64,7 +66,7 @@ const DetailInfoCard = ({
             List
           </Text>
           <div className="flex justify-start items-center gap-1">
-            <a href={`${PATHS.LIST}/${list.claim_id}`}>
+            <a href={getListUrl(list.claim_id, '', readOnly)}>
               <IdentityTag
                 variant={list.object?.user ? Identity.user : Identity.nonUser}
                 imgSrc={list.object?.image ?? ''}

--- a/apps/portal/app/routes/readonly+/identity+/$id.tsx
+++ b/apps/portal/app/routes/readonly+/identity+/$id.tsx
@@ -154,6 +154,7 @@ export default function ReadOnlyIdentityDetails() {
         ipfsLink={`${BLOCK_EXPLORER_URL}/address/${identity.creator?.wallet}`}
         timestamp={identity.created_at}
         className="w-full"
+        readOnly={true}
       />
       <ReadOnlyBanner
         variant={BannerVariant.warning}


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Missed one embedded check in the `DetailInfoCard` on readonly identity route

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
