### PR TITLE
ENG-0000 fix(portal): use readonly links on data created created tables

### DIFF
--- a/apps/portal/app/components/list/identities.tsx
+++ b/apps/portal/app/components/list/identities.tsx
@@ -24,6 +24,7 @@ export function IdentitiesList({
   enalbeHeader = true,
   enableSearch = true,
   enableSort = true,
+  readOnly = false,
 }: {
   variant?: 'explore' | 'positions'
   identities: IdentityPresenter[]
@@ -32,6 +33,7 @@ export function IdentitiesList({
   enalbeHeader?: boolean
   enableSearch?: boolean
   enableSort?: boolean
+  readOnly?: boolean
 }) {
   const options: SortOption<SortColumn>[] = [
     { value: 'Total ETH', sortBy: 'AssetsSum' },
@@ -83,7 +85,7 @@ export function IdentitiesList({
                 )
               }
               totalFollowers={identity.num_positions}
-              link={getAtomLink(identity)}
+              link={getAtomLink(identity, readOnly)}
               ipfsLink={getAtomIpfsLink(identity)}
               tags={
                 identity.tags?.map((tag) => ({

--- a/apps/portal/app/routes/readonly+/profile+/$wallet+/data-created.tsx
+++ b/apps/portal/app/routes/readonly+/profile+/$wallet+/data-created.tsx
@@ -38,7 +38,6 @@ import {
   getUserClaims,
   getUserIdentities,
 } from '@lib/services/users'
-import logger from '@lib/utils/logger'
 import { formatBalance, invariant } from '@lib/utils/misc'
 import { defer, LoaderFunctionArgs } from '@remix-run/node'
 import { Await, useRouteLoaderData } from '@remix-run/react'
@@ -140,8 +139,6 @@ export default function ReadOnlyProfileDataCreated() {
     ) ?? {}
   invariant(userIdentity, NO_USER_IDENTITY_ERROR)
   invariant(userTotals, NO_USER_TOTALS_ERROR)
-
-  logger('$wallet data-created render')
 
   return (
     <div className="flex-col justify-start items-start flex w-full gap-12">
@@ -358,8 +355,9 @@ export default function ReadOnlyProfileDataCreated() {
                         identities={resolvedIdentities.data}
                         pagination={resolvedIdentities.pagination}
                         paramPrefix="createdIdentities"
-                        enableSearch
-                        enableSort
+                        enableSearch={true}
+                        enableSort={true}
+                        readOnly={true}
                       />
                     </TabContent>
                   )}
@@ -401,8 +399,9 @@ export default function ReadOnlyProfileDataCreated() {
                         claims={resolvedClaims.data}
                         pagination={resolvedClaims.pagination}
                         paramPrefix="createdClaims"
-                        enableSearch
-                        enableSort
+                        enableSearch={true}
+                        enableSort={true}
+                        readOnly={true}
                       />
                     </TabContent>
                   )}


### PR DESCRIPTION
Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds the readOnly prop + passes in to the getAtomLink for the Identities and Claims in the data created route (on profile) _Created_ tables

## Screen Captures

![readonly-data-created-fix](https://github.com/user-attachments/assets/56cdb865-9117-49b2-81f3-0120fab3f9e6)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
