### PR TITLE
ENG-4386 fix(portal): harden headers in entrypoint

### DIFF
--- a/apps/portal/app/entry.server.tsx
+++ b/apps/portal/app/entry.server.tsx
@@ -70,6 +70,7 @@ function handleBotRequest(
           const stream = createReadableStreamFromReadable(body)
 
           responseHeaders.set('Content-Type', 'text/html')
+          responseHeaders.set('X-Frame-Options', 'SAMEORIGIN')
 
           resolve(
             new Response(stream, {
@@ -120,11 +121,6 @@ function handleBrowserRequest(
           const stream = createReadableStreamFromReadable(body)
 
           responseHeaders.set('X-Frame-Options', 'SAMEORIGIN')
-          responseHeaders.set('X-Content-Type-Options', 'nosniff')
-          responseHeaders.set(
-            'Referrer-Policy',
-            'strict-origin-when-cross-origin',
-          )
 
           resolve(
             new Response(stream, {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Modifies `entry.server.tsx` to explicitly add/set our `X-Frame-Options` policy to `SAMEORIGIN`
- There are other header modifications we can make, but I wanted to focus on this one specifically and then we can evaluate the larger surface area of the others -- I've detailed this in a doc for us to review and then implement outside of the scope of this PR

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
