### PR TITLE
ENG-0000 fix(portal): fix max button math

### DIFF
--- a/apps/portal/app/components/stake/stake-actions.tsx
+++ b/apps/portal/app/components/stake/stake-actions.tsx
@@ -66,11 +66,10 @@ export default function StakeActions({
           if (action === 'deposit') {
             setVal(walletBalance)
           } else if (userConviction && price) {
-            const userConvictionValue = BigInt(userConviction)
-            const priceValue = BigInt(price)
-            const maxEthInWei = userConvictionValue * priceValue
-            const maxEth = formatUnits(maxEthInWei, 36)
-            setVal(maxEth)
+            const userConvictionValue = formatUnits(BigInt(userConviction), 18)
+            const priceValue = formatUnits(BigInt(price), 18)
+            const maxEth = +userConvictionValue * +priceValue
+            setVal(maxEth.toString())
           }
         }}
       >


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Reverted back to decimal math instead of big int math as it was causing issues, raising insufficient funds errors, due to the result having more than 18 decimals.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
