### PR TITLE
ENG-0000 fix(portal): fix verbiage in smart contract atom creation

### DIFF
--- a/apps/portal/app/components/create-identity/create-caip10-account-form.tsx
+++ b/apps/portal/app/components/create-identity/create-caip10-account-form.tsx
@@ -318,11 +318,18 @@ export function CAIP10AccountForm({
                 }}
                 value={formState.chainId}
               >
-                <SelectTrigger className="w-52 max-lg:w-full">
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select a chain" />
                 </SelectTrigger>
                 <SelectContent>
-                  {Object.values(chains).map((chain) => (
+                  {[
+                    chains.base,
+                    chains.mainnet,
+                    ...Object.values(chains).filter(
+                      (chain) =>
+                        chain !== chains.base && chain !== chains.mainnet,
+                    ),
+                  ].map((chain) => (
                     <SelectItem key={chain.id} value={chain.id.toString()}>
                       {chain.name}
                     </SelectItem>


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

In smart contract atom creation (CAIP10), removed ID from Chain ID on the dropdown, since you don't have to manually enter the chain ID anymore and can select the chain from a dropdown. Also adds Mainnet and Base to the top of the list.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
