### PR TITLE
ENG-4667 fix(portal): remove creator card from list detail

### DIFF
--- a/apps/portal/app/routes/app+/list+/$id.tsx
+++ b/apps/portal/app/routes/app+/list+/$id.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, InfoCard, ProfileCard } from '@0xintuition/1ui'
+import { Button, Icon, ProfileCard } from '@0xintuition/1ui'
 import {
   ClaimPresenter,
   ClaimsService,
@@ -127,6 +127,9 @@ export default function ListDetails() {
         }}
         className="hover:cursor-pointer w-full"
       />
+      {/*
+      Reintroduce this card once we figure out how to handle the 'creator' of the list.
+
       <InfoCard
         variant="user"
         username={claim.creator?.display_name ?? claim.creator?.wallet ?? ''}
@@ -139,7 +142,7 @@ export default function ListDetails() {
         ipfsLink={`${BLOCK_EXPLORER_URL}/address/${claim.creator?.wallet}`}
         timestamp={claim.created_at}
         className="w-full"
-      />
+      /> */}
       <Button
         variant="secondary"
         onClick={() => {


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

This PR removes the creator card from the list detail page as it is misleading. It shows the creator as the person who created the hastag claim that is being used to generate the list, which is technically incorrect because there is no "list" object created by any user. This will change once we add the ability to save queries, as list are just queries at the end of the day.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
