### PR TITLE
ENG-4314 feat(portal): add back button to login header

### DIFF
--- a/apps/portal/app/routes/actions+/clear-onboarding-cookie.tsx
+++ b/apps/portal/app/routes/actions+/clear-onboarding-cookie.tsx
@@ -1,0 +1,23 @@
+import { ActionFunctionArgs, json } from '@remix-run/node'
+import { onboardingModalCookie } from '@server/onboarding'
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData()
+  if (formData.get('action') === 'clearOnboardingCookie') {
+    return json(
+      { success: true },
+      {
+        headers: {
+          'Set-Cookie': await onboardingModalCookie.serialize(
+            {},
+            {
+              expires: new Date(0),
+              maxAge: 0,
+            },
+          ),
+        },
+      },
+    )
+  }
+  return json({ success: false })
+}

--- a/apps/portal/app/routes/login.tsx
+++ b/apps/portal/app/routes/login.tsx
@@ -20,7 +20,13 @@ import {
   LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node'
-import { Link, useLoaderData, useNavigate, useSubmit } from '@remix-run/react'
+import {
+  Link,
+  useFetcher,
+  useLoaderData,
+  useNavigate,
+  useSubmit,
+} from '@remix-run/react'
 import { getFeatureFlags } from '@server/env'
 import { verifyPrivyAccessToken } from '@server/privy'
 import { PATHS } from 'app/consts'
@@ -73,7 +79,15 @@ export default function Login() {
     submit(formData, { method: 'post' })
   }
 
+  const fetcher = useFetcher()
   const navigate = useNavigate()
+  const handleBackNavigation = () => {
+    fetcher.submit(
+      { action: 'clearOnboardingCookie' },
+      { method: 'post', action: '/actions/clear-onboarding-cookie' },
+    )
+    navigate(PATHS.THE_BIG_BANG)
+  }
 
   return (
     <div>
@@ -82,7 +96,7 @@ export default function Login() {
         <div className="flex flex-row justify-between w-full">
           <div className="flex flex-row gap-2">
             <Button
-              onClick={() => navigate(PATHS.THE_BIG_BANG)}
+              onClick={handleBackNavigation}
               variant={ButtonVariant.text}
               size={ButtonSize.icon}
               className="p-0"

--- a/apps/portal/app/routes/login.tsx
+++ b/apps/portal/app/routes/login.tsx
@@ -1,4 +1,11 @@
-import { Text } from '@0xintuition/1ui'
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Icon,
+  IconName,
+  Text,
+} from '@0xintuition/1ui'
 
 import PrivyLoginButton from '@client/privy-login-button'
 import { BuiltOnBase } from '@components/built-on-base'
@@ -13,7 +20,7 @@ import {
   LoaderFunctionArgs,
   redirect,
 } from '@remix-run/node'
-import { Link, useLoaderData, useSubmit } from '@remix-run/react'
+import { Link, useLoaderData, useNavigate, useSubmit } from '@remix-run/react'
 import { getFeatureFlags } from '@server/env'
 import { verifyPrivyAccessToken } from '@server/privy'
 import { PATHS } from 'app/consts'
@@ -66,12 +73,24 @@ export default function Login() {
     submit(formData, { method: 'post' })
   }
 
+  const navigate = useNavigate()
+
   return (
     <div>
       <SiteWideBanner featureFlags={featureFlags} />
       <div className="flex flex-col justify-between h-screen w-full p-8">
         <div className="flex flex-row justify-between w-full">
-          <HeaderLogo />
+          <div className="flex flex-row gap-2">
+            <Button
+              onClick={() => navigate(PATHS.THE_BIG_BANG)}
+              variant={ButtonVariant.text}
+              size={ButtonSize.icon}
+              className="p-0"
+            >
+              <Icon name={IconName.arrowLeft} className="h-4 w-4" />
+            </Button>
+            <HeaderLogo />
+          </div>
           <div className="justify-end">
             <BuiltOnBase />
           </div>


### PR DESCRIPTION
## Affected Packages

Apps

- [x] portal

Packages

- [ ] 1ui
- [ ] api
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Added a back button the header on the login route which navigates to the big bang (carousel) so that users can revisit that experience.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
