### PR TITLE
ENG-4667 feat(portal): replace fetchers with react query hooks in follow modal

### DIFF
--- a/apps/portal/app/components/follow/follow-button.tsx
+++ b/apps/portal/app/components/follow/follow-button.tsx
@@ -28,6 +28,7 @@ interface FollowButtonProps {
   user_assets: string
   setValidationErrors: (errors: string[]) => void
   setShowErrors: (show: boolean) => void
+  isLoadingConfig: boolean
   className?: string
 }
 
@@ -45,6 +46,7 @@ const FollowButton: React.FC<FollowButtonProps> = ({
   setValidationErrors,
   setShowErrors,
   className,
+  isLoadingConfig,
 }) => {
   const { switchChain } = useSwitchChain()
 
@@ -141,7 +143,8 @@ const FollowButton: React.FC<FollowButtonProps> = ({
         val === '' ||
         state.status === 'confirm' ||
         state.status === 'transaction-pending' ||
-        state.status === 'awaiting'
+        state.status === 'awaiting' ||
+        isLoadingConfig
       }
       className={cn(`w-40`, className)}
     >

--- a/apps/portal/app/components/follow/follow-form.tsx
+++ b/apps/portal/app/components/follow/follow-form.tsx
@@ -22,7 +22,6 @@ import {
   getAtomLabel,
   getAtomLink,
 } from '@lib/utils/misc'
-import { type FetcherWithComponents } from '@remix-run/react'
 import {
   TransactionActionType,
   TransactionStateType,
@@ -42,8 +41,6 @@ interface FollowFormProps {
   mode: string | undefined
   dispatch: (action: TransactionActionType) => void
   state: TransactionStateType
-  fetchReval: FetcherWithComponents<unknown>
-  formRef: React.RefObject<HTMLFormElement>
   showErrors: boolean
   setShowErrors: (show: boolean) => void
   validationErrors: string[]
@@ -62,8 +59,6 @@ export default function FollowForm({
   mode,
   dispatch,
   state,
-  fetchReval,
-  formRef,
   showErrors,
   setShowErrors,
   validationErrors,
@@ -71,14 +66,6 @@ export default function FollowForm({
 }: FollowFormProps) {
   return (
     <>
-      <fetchReval.Form
-        hidden
-        ref={formRef}
-        action={`/actions/reval`}
-        method="post"
-      >
-        <input type="hidden" name="eventName" value="attest" />
-      </fetchReval.Form>
       {state.status === 'idle' ? (
         <>
           <DialogHeader>

--- a/apps/portal/app/components/follow/unfollow-button.tsx
+++ b/apps/portal/app/components/follow/unfollow-button.tsx
@@ -20,6 +20,7 @@ interface UnfollowButtonProps {
   dispatch: (action: TransactionActionType) => void
   state: TransactionStateType
   user_conviction: string
+  isLoadingConfig: boolean
   className?: string
 }
 
@@ -30,6 +31,7 @@ const UnfollowButton: React.FC<UnfollowButtonProps> = ({
   dispatch,
   state,
   user_conviction,
+  isLoadingConfig,
   className,
 }) => {
   const { switchChain } = useSwitchChain()
@@ -106,7 +108,8 @@ const UnfollowButton: React.FC<UnfollowButtonProps> = ({
         !address ||
         state.status === 'confirm' ||
         state.status === 'transaction-pending' ||
-        state.status === 'awaiting'
+        state.status === 'awaiting' ||
+        isLoadingConfig
       }
       className={cn(`w-40`, className)}
     >

--- a/apps/portal/app/components/home/home-stats-header.tsx
+++ b/apps/portal/app/components/home/home-stats-header.tsx
@@ -15,7 +15,7 @@ export function HomeStatsHeader({ ...props }: HomeStatsHeaderProps) {
   const { data: systemStats } = useGetStatsQuery(
     {},
     {
-      queryKey: ['GetStats'],
+      queryKey: ['get-stats'],
     },
   )
 

--- a/apps/portal/app/lib/hooks/mutations/useFollowMutation.tsx
+++ b/apps/portal/app/lib/hooks/mutations/useFollowMutation.tsx
@@ -1,0 +1,89 @@
+import { ClaimPresenter, IdentityPresenter } from '@0xintuition/api'
+
+import { multivaultAbi } from '@lib/abis/multivault'
+import { useCreateTriple } from '@lib/hooks/useCreateTriple'
+import { useDepositTriple } from '@lib/hooks/useDepositTriple'
+import { useRedeemTriple } from '@lib/hooks/useRedeemTriple'
+import { getSpecialPredicate } from '@lib/utils/app'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { CURRENT_ENV } from 'app/consts'
+import { Abi, parseUnits } from 'viem'
+
+interface FollowMutationParams {
+  val: string
+  userWallet: string
+  vaultId: string
+  claim?: ClaimPresenter
+  identity?: IdentityPresenter
+  userVaultId?: string
+  tripleCost?: bigint
+}
+
+export function useFollowMutation(
+  contract: string,
+  claim: ClaimPresenter,
+  user_conviction: string,
+  mode: 'follow' | 'unfollow',
+) {
+  const queryClient = useQueryClient()
+  const depositHook = useDepositTriple(contract)
+  const redeemHook = useRedeemTriple(contract)
+  const createHook = useCreateTriple()
+
+  const activeHook = !claim
+    ? createHook
+    : mode === 'follow'
+      ? depositHook
+      : redeemHook
+  const {
+    writeContractAsync,
+    receipt: txReceipt,
+    awaitingWalletConfirmation,
+    awaitingOnChainConfirmation,
+    isError,
+    reset,
+  } = activeHook
+
+  return {
+    ...useMutation({
+      mutationFn: async (params: FollowMutationParams) => {
+        const { val, userWallet, vaultId, claim, userVaultId, tripleCost } =
+          params
+        const parsedValue = parseUnits(val === '' ? '0' : val, 18)
+
+        return writeContractAsync({
+          address: contract as `0x${string}`,
+          abi: multivaultAbi as Abi,
+          functionName: !claim
+            ? 'createTriple'
+            : mode === 'follow'
+              ? 'depositTriple'
+              : 'redeemTriple',
+          args: !claim
+            ? [
+                getSpecialPredicate(CURRENT_ENV).iPredicate.vaultId,
+                getSpecialPredicate(CURRENT_ENV).amFollowingPredicate.vaultId,
+                userVaultId,
+              ]
+            : mode === 'follow'
+              ? [userWallet as `0x${string}`, vaultId]
+              : [user_conviction, userWallet as `0x${string}`, vaultId],
+          value:
+            !claim && tripleCost
+              ? tripleCost + parsedValue
+              : mode === 'follow'
+                ? parsedValue
+                : undefined,
+        })
+      },
+      onSuccess: async () => {
+        queryClient.invalidateQueries({ queryKey: ['get-stats'] })
+      },
+    }),
+    txReceipt,
+    awaitingWalletConfirmation,
+    awaitingOnChainConfirmation,
+    isError,
+    reset,
+  }
+}

--- a/apps/portal/app/lib/hooks/mutations/useStakeMutation.tsx
+++ b/apps/portal/app/lib/hooks/mutations/useStakeMutation.tsx
@@ -72,7 +72,7 @@ export function useStakeMutation(contract: string, mode: 'deposit' | 'redeem') {
         })
       },
       onSuccess: async () => {
-        queryClient.invalidateQueries({ queryKey: ['GetStats'] })
+        queryClient.invalidateQueries({ queryKey: ['get-stats'] })
       },
     }),
     txReceipt,


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Added useFollowMutation hook which handles the transaction and updating queries based on their queryKeys.
- Removed fetchReval fetcher in favor of this new method.
- Renamed GetStats query key to get-stats to follow standard.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
