### PR TITLE
ENG-4677 feat(repo): graphql render deployment for qa

### DIFF
--- a/apps/portal/app/components/follow/follow-modal.tsx
+++ b/apps/portal/app/components/follow/follow-modal.tsx
@@ -5,7 +5,7 @@ import { ClaimPresenter, IdentityPresenter } from '@0xintuition/api'
 
 import { multivaultAbi } from '@lib/abis/multivault'
 import { useFollowMutation } from '@lib/hooks/mutations/useFollowMutation'
-import { useCreateConfig } from '@lib/hooks/useCreateConfig'
+import { useCreateClaimConfig } from '@lib/hooks/useCreateClaimConfig'
 import { useGetWalletBalance } from '@lib/hooks/useGetWalletBalance'
 import { transactionReducer } from '@lib/hooks/useTransactionReducer'
 import { useGenericTxState } from '@lib/utils/use-tx-reducer'
@@ -75,7 +75,8 @@ export default function FollowModal({
 
   const { address } = useAccount()
 
-  const { data: configData, isLoading: isLoadingConfig } = useCreateConfig()
+  const { data: configData, isLoading: isLoadingConfig } =
+    useCreateClaimConfig()
 
   const {
     mutateAsync: follow,
@@ -94,7 +95,7 @@ export default function FollowModal({
         vaultId: vault_id,
         claim,
         identity,
-        tripleCost: BigInt(configData?.tripleCost ?? '0'),
+        tripleCost: BigInt(configData?.fees.tripleCost ?? '0'),
         userVaultId,
       })
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,55 +1,69 @@
 services:
   - type: web
-    name: data-populator
+    name: portal
     env: docker
     region: oregon
     rootDir: .
-    dockerfilePath: ./apps/data-populator/Dockerfile
+    dockerfilePath: ./apps/portal/Dockerfile
     dockerContext: .
     envVars:
       - key: NODE_ENV
         value: production
       - key: PORT
         value: 8080
-      - key: PINATA_JWT_KEY
+      - key: ALCHEMY_MAINNET_API_KEY
         sync: false
-      - key: PINATA_GATEWAY_KEY
+      - key: ALCHEMY_API_KEY
         sync: false
-      - key: IPFS_GATEWAY
+      - key: ALCHEMY_MAINNET_RPC_URL
         sync: false
-      - key: PRIVATE_KEY
+      - key: ALCHEMY_BASE_SEPOLIA_RPC_URL
         sync: false
-      - key: PRIVATE_KEY_DEV
+      - key: ALCHEMY_BASE_RPC_URL
         sync: false
-      - key: ADDITIONAL_STAKE_ATOM
-        value: 100000000000
-      - key: ADDITIONAL_STAKE_TRIPLE
-        value: 100000000000
+      - key: WALLETCONNECT_PROJECT_ID
+        sync: false
+      - key: SESSION_SECRET
+        sync: false
+      - key: API_URL
+        sync: false
+      - key: API_KEY
+        sync: false
+      - key: PRIVY_APP_ID
+        sync: false
+      - key: PRIVY_APP_SECRET
+        sync: false
+      - key: PRIVY_VERIFICATION_KEY
+        sync: false
       - key: CLOUDINARY_CLOUD_NAME
         sync: false
       - key: CLOUDINARY_API_KEY
         sync: false
       - key: CLOUDINARY_API_SECRET
         sync: false
-      - key: SUPABASE_URL
+      - key: SENTRY_AUTH_TOKEN
         sync: false
-      - key: SUPABASE_KEY
+      - key: SENTRY_DSN
+        sync: false
+      - key: SENTRY_ORG
+        sync: false
+      - key: SENTRY_PROJECT
+        sync: false
+      - key: ORIGIN_URL
+        sync: false
+      - key: PHOSPHOR_API_KEY
+        sync: false
+      - key: PHOSPHOR_ADMIN_API_URL
+        sync: false
+      - key: PHOSPHOR_COLLECTION_ID
+        sync: false
+      - key: GTM_TRACKING_ID
+        sync: false
+      - key: FF_FULL_LOCKDOWN_ENABLED
+        sync: false
+      - key: FF_INCIDENT_BANNER_ENABLED
+        sync: false
+      - key: FF_GENERIC_BANNER_ENABLED
         sync: false
       - key: VITE_DEPLOY_ENV
-        sync: false
-      - key: VITE_ALCHEMY_API_KEY
-        sync: false
-      - key: ALCHEMY_API_KEY
-        sync: false
-      - key: VITE_ORIGIN_URL
-        value: https://portal.intuition.systems
-      - key: ORIGIN_URL
-        value: https://portal.intuition.systems
-      - key: PRIVY_APP_ID
-        sync: false
-      - key: PRIVY_AUTH_URL
-        sync: false
-      - key: PRIVY_APP_SECRET
-        sync: false
-      - key: PRIVY_VERIFICATION_KEY
         sync: false


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- This updates the `render.yaml` file to deploy a GraphQL version of Portal for QA during the migration
- This is only temporary -- since this'll live only on that feature branch we'll want to create a unified `render.yaml` for this and Data Populator when we merge back into `main` -- we'd likely want to completely remove the GraphQL Render deployment at that point. We'll revert the `render.yaml` back to the Data Populator version (or unify the two if we want to go that route for future deployments)
- I tested the deployment from this branch and it works -- once we merge this in to the `feature/graphql-migration` branch I can update the deployment target to that branch for ongoing QA

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
