### PR TITLE
ENG-0000 feat(repo): Update data-populator main page UI

### DIFF
--- a/apps/data-populator/app/components/csv-uploader.tsx
+++ b/apps/data-populator/app/components/csv-uploader.tsx
@@ -1,0 +1,86 @@
+import { useRef } from 'react'
+
+import { FileText, Upload } from 'lucide-react'
+
+export interface CsvUploaderProps {
+  file: File | null
+  setFile: (file: File | null) => void
+  onFileChange: (file: File) => Promise<void>
+}
+
+export default function CsvUploader({
+  file,
+  setFile,
+  onFileChange,
+}: CsvUploaderProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const processFile = async (selectedFile: File) => {
+    if (selectedFile.type === 'text/csv') {
+      try {
+        setFile(selectedFile)
+        await onFileChange(selectedFile)
+      } catch (error) {
+        console.error('Error processing CSV:', error)
+        alert('Error processing the CSV file.')
+      }
+    } else {
+      alert('Please select a valid CSV file.')
+    }
+  }
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const selectedFile = event.target.files?.[0]
+    if (selectedFile) {
+      await processFile(selectedFile)
+    }
+  }
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+  }
+
+  const handleDrop = async (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const droppedFile = event.dataTransfer.files[0]
+    if (droppedFile) {
+      await processFile(droppedFile)
+    }
+  }
+
+  return (
+    <div
+      className="border border-dashed border-border/30 rounded-lg p-6 text-center cursor-pointer hover:border-border/80 hover:bg-primary/5 transition-colors"
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      onClick={() => fileInputRef.current?.click()}
+    >
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        accept=".csv"
+        className="hidden"
+      />
+      {file ? (
+        <div className="flex flex-col items-center gap-1">
+          <FileText className="w-10 h-10 text-primary mb-2" />
+          <p className="text-sm font-medium">{file.name}</p>
+          <p className="text-xs text-gray-500">
+            {(file.size / 1024).toFixed(2)} KB
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center">
+          <Upload className="w-10 h-10 text-gray-400 mb-2" />
+          <p className="text-sm font-medium">
+            Drag and drop your CSV file here
+          </p>
+          <p className="text-xs text-gray-500">or click to browse</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/data-populator/app/components/header.tsx
+++ b/apps/data-populator/app/components/header.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 
 import {
   Button,
+  ButtonSize,
+  ButtonVariant,
   Text,
   Tooltip,
   TooltipContent,
@@ -12,17 +14,11 @@ import PrivyLogoutButton from '@client/privy-logout-button'
 import { getTooltip, TooltipKey } from '@lib/utils/tooltips'
 import { Link } from '@remix-run/react'
 import { CURRENT_ENV } from 'app/consts'
-import { HelpCircle, History, Moon, Settings, Sun } from 'lucide-react'
+import { HelpCircle, History } from 'lucide-react'
 import { ClientOnly } from 'remix-utils/client-only'
 
-export function Header({
-  onOpenOptions,
-  onOpenHistory,
-}: {
-  onOpenOptions: () => void
-  onOpenHistory: () => void
-}) {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+export function Header({ onOpenHistory }: { onOpenHistory: () => void }) {
+  const [, setTheme] = useState<'light' | 'dark'>('light')
   const [tooltipsEnabled, setTooltipsEnabled] = useState(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('tooltipsEnabled')
@@ -40,10 +36,6 @@ export function Header({
     }
   }, [])
 
-  const handleToggleTheme = () => {
-    const newTheme = theme === 'light' ? 'dark' : 'light'
-    setTheme(newTheme)
-  }
   const toggleTooltips = () => {
     setTooltipsEnabled((prev: boolean) => {
       const newValue = !prev
@@ -53,7 +45,7 @@ export function Header({
   }
 
   return (
-    <header className="sticky top-0 z-40 w-full border-b bg-background">
+    <header className="sticky top-0 z-40 w-full border-b border-primary/30 bg-background">
       <div className="container flex h-16 items-center justify-between">
         <div className="flex items-center gap-4">
           <Link to="/" className="flex items-center space-x-2">
@@ -67,10 +59,10 @@ export function Header({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Text
-                  className={`px-2 py-1 rounded-md ${
+                  className={`px-2 py-1 rounded-lg text-sm tracking-widest font-medium ${
                     CURRENT_ENV === 'production'
-                      ? 'text-green-500 bg-green-500/10'
-                      : 'text-cyan-500 bg-cyan-500/10'
+                      ? 'text-accent bg-accent/15 border border-accent/20'
+                      : 'text-warning bg-warning/15 border border-warning/20'
                   }`}
                 >
                   {CURRENT_ENV === 'production' ? 'MAINNET' : 'TESTNET'}
@@ -102,10 +94,10 @@ export function Header({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  variant="ghost"
-                  size="icon"
+                  variant={ButtonVariant.secondary}
+                  size={ButtonSize.iconLg}
                   onClick={toggleTooltips}
-                  className="text-blue-500"
+                  className="text-accent"
                 >
                   <HelpCircle className="h-5 w-5" />
                 </Button>
@@ -115,34 +107,12 @@ export function Header({
               </TooltipContent>
             </Tooltip>
           ) : (
-            <Button variant="ghost" size="icon" onClick={toggleTooltips}>
+            <Button
+              variant={ButtonVariant.secondary}
+              size={ButtonSize.iconLg}
+              onClick={toggleTooltips}
+            >
               <HelpCircle className="h-5 w-5" />
-            </Button>
-          )}
-
-          {/* Theme Toggle Button */}
-          {tooltipsEnabled ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" disabled>
-                  {theme === 'light' ? (
-                    <Moon className="h-5 w-5" />
-                  ) : (
-                    <Sun className="h-5 w-5" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {getTooltip(TooltipKey.THEME_TOGGLE)}
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <Button variant="ghost" size="icon" disabled>
-              {theme === 'light' ? (
-                <Moon className="h-5 w-5" />
-              ) : (
-                <Sun className="h-5 w-5" />
-              )}
             </Button>
           )}
 
@@ -150,7 +120,11 @@ export function Header({
           {tooltipsEnabled ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" onClick={onOpenHistory}>
+                <Button
+                  variant={ButtonVariant.secondary}
+                  size={ButtonSize.iconLg}
+                  onClick={onOpenHistory}
+                >
                   <History className="h-5 w-5" />
                 </Button>
               </TooltipTrigger>
@@ -159,26 +133,12 @@ export function Header({
               </TooltipContent>
             </Tooltip>
           ) : (
-            <Button variant="ghost" size="icon" onClick={onOpenHistory}>
+            <Button
+              variant={ButtonVariant.secondary}
+              size={ButtonSize.iconLg}
+              onClick={onOpenHistory}
+            >
               <History className="h-5 w-5" />
-            </Button>
-          )}
-
-          {/* Settings Button */}
-          {tooltipsEnabled ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" disabled>
-                  <Settings className="h-5 w-5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {getTooltip(TooltipKey.OPTIONS_MENU)}
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <Button variant="ghost" size="icon" disabled>
-              <Settings className="h-5 w-5" />
             </Button>
           )}
 

--- a/apps/data-populator/app/components/header.tsx
+++ b/apps/data-populator/app/components/header.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
+  cn,
   Text,
   Tooltip,
   TooltipContent,
@@ -78,10 +79,10 @@ export function Header({ onOpenHistory }: { onOpenHistory: () => void }) {
             </Tooltip>
           ) : (
             <Text
-              className={`px-2 py-1 rounded-md ${
+              className={`px-2 py-1 rounded-lg text-sm tracking-widest font-medium ${
                 CURRENT_ENV === 'production'
-                  ? 'text-green-500 bg-green-500/10'
-                  : 'text-cyan-500 bg-cyan-500/10'
+                  ? 'text-accent bg-accent/15 border border-accent/20'
+                  : 'text-warning bg-warning/15 border border-warning/20'
               }`}
             >
               {CURRENT_ENV === 'production' ? 'MAINNET' : 'TESTNET'}
@@ -97,7 +98,9 @@ export function Header({ onOpenHistory }: { onOpenHistory: () => void }) {
                   variant={ButtonVariant.secondary}
                   size={ButtonSize.iconLg}
                   onClick={toggleTooltips}
-                  className="text-accent"
+                  className={cn(
+                    'transition text-accent !bg-accent/10 border-accent/60 hover:text-accent hover:bg-accent/5 hover:border-accent/80',
+                  )}
                 >
                   <HelpCircle className="h-5 w-5" />
                 </Button>

--- a/apps/data-populator/app/components/ui/tabs.tsx
+++ b/apps/data-populator/app/components/ui/tabs.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import React from 'react'
+
+import { cn } from '@0xintuition/1ui'
+
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted/70 p-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/apps/data-populator/app/lib/utils/tooltips.ts
+++ b/apps/data-populator/app/lib/utils/tooltips.ts
@@ -40,8 +40,7 @@ const tooltipMap: Record<TooltipKey, string> = {
   [TooltipKey.LOAD_CSV]:
     'Loads a .csv file from disk and performs basic proofreading - see documentation for formatting requirements.',
   [TooltipKey.ADD_ROW]: 'Add a new row matching the existing schema',
-  [TooltipKey.DELETE_ROWS]:
-    'This will delete the rows you have currently selected using the checkboxes on the right',
+  [TooltipKey.DELETE_ROWS]: 'Delete the selected row(s)',
   [TooltipKey.PUBLISH_ATOMS]:
     'Begins the process of uploading the selected atoms to the Intuition System',
   [TooltipKey.SAVE_CSV]:
@@ -57,10 +56,10 @@ const tooltipMap: Record<TooltipKey, string> = {
   [TooltipKey.ATOMS_TAB]: 'View and manage atoms. Begin your journey here.',
   [TooltipKey.TAGGING_TAB]:
     'View and manage tags. Select some Atoms you want to tag and go here to tag them.',
-  [TooltipKey.ATOM_LIVE]: 'This atom is live on the Intuition System',
-  [TooltipKey.ATOM_NOT_PUBLISHED]: 'Atom ready to publish',
-  [TooltipKey.TAG_LIVE]: 'This tag is live on the Intuition System',
-  [TooltipKey.TAG_NOT_PUBLISHED]: 'Tag ready to publish',
+  [TooltipKey.ATOM_LIVE]: 'Atom already exists',
+  [TooltipKey.ATOM_NOT_PUBLISHED]: 'New atom ready to publish',
+  [TooltipKey.TAG_LIVE]: 'Tag already exists',
+  [TooltipKey.TAG_NOT_PUBLISHED]: 'New tag ready to publish',
 }
 
 export function getTooltip(key: TooltipKey): string {

--- a/apps/data-populator/app/routes/app+/index.tsx
+++ b/apps/data-populator/app/routes/app+/index.tsx
@@ -20,7 +20,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  Text,
   Textarea,
+  TextVariant,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -28,9 +30,11 @@ import {
 
 import { useBatchCreateAtom } from '@client/useBatchCreateAtom'
 import { useBatchCreateTriple } from '@client/useBatchCreateTriple'
+import CsvUploader from '@components/csv-uploader'
 import { ProgressModal } from '@components/progress-modal'
 import { ProofreadModal } from '@components/proofread-modal'
 import { Progress } from '@components/ui/progress'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@components/ui/tabs'
 import {
   BatchAtomsRequest,
   checkAndFilterURIs,
@@ -75,10 +79,15 @@ import { motion } from 'framer-motion'
 import {
   CircleEllipsis,
   CloudCog,
+  FileText,
   Loader2,
   Minus,
   Plus,
   Save,
+  Send,
+  Shapes,
+  Tag,
+  Upload,
 } from 'lucide-react'
 import { Thing, WithContext } from 'schema-dts'
 
@@ -323,14 +332,18 @@ type FormatChangeDialog = {
 }
 
 // Add this type and constant before the CSVEditor component
-type ViewTab = 'atoms' | 'tagging'
+type ViewTab = 'select' | 'upload' | 'publish' | 'tag'
 
 const tabs = [
-  { id: 'atoms' as ViewTab, label: 'Atoms' },
-  { id: 'tagging' as ViewTab, label: 'Tagging' },
+  { id: 'select', label: 'Select Type', icon: Shapes, cta: 'Select Type' },
+  { id: 'upload', label: 'Upload', icon: Upload, cta: 'Select Files' },
+  { id: 'publish', label: 'Publish', icon: Send, cta: 'Go Live' },
+  { id: 'tag', label: 'Tag', icon: Tag, cta: 'Add Tags' },
 ]
 
 export default function CSVEditor() {
+  const [file, setFile] = useState<File | null>(null)
+  const [activeTab, setActiveTab] = useState<ViewTab>('select')
   const [selectedType, setSelectedType] = useState<AtomDataTypeKey>('CSV')
 
   // State variables for managing CSV data, UI interactions, and atom-related operations
@@ -538,17 +551,12 @@ export default function CSVEditor() {
       newFormat: null,
     })
 
-  // Update loadCSV to use the format change dialog
-  const loadCSV = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) {
-      return
-    }
-
+  // Update loadCSV to take a File directly
+  const loadCSV = async (file: File) => {
     const text = await file.text()
     const headers = text.split('\n')[0].split(',')
     const detectedType = detectAtomDataType(headers)
-    const rows = await parseCsv(new File([text], file.name), detectedType)
+    const rows = await parseCsv(file, detectedType)
 
     if (detectedType !== selectedType && isCSVDataModified) {
       setFormatChangeDialog({
@@ -572,6 +580,16 @@ export default function CSVEditor() {
         setBatchCreateAtomSelectedType(detectedType)
       }
       processLoadedData(rows, detectedType)
+    }
+  }
+
+  // Update the file input handler
+  const handleFileInput = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const selectedFile = event.target.files?.[0]
+    if (selectedFile) {
+      await loadCSV(selectedFile)
     }
   }
 
@@ -1168,450 +1186,285 @@ export default function CSVEditor() {
     setFormatChangeDialog({ isOpen: false, newFormat: null })
   }
 
-  // Add this state near the top of your other state declarations
-  const [activeTab, setActiveTab] = useState<ViewTab>('atoms')
-
-  // Update the return statement to include the tabs and conditional rendering
   return (
     <>
-      {/* Animated Tabs */}
-      <div className="bg-gray-800 p-4 mb-4">
-        <div className="flex space-x-1">
-          {tabs.map((tab) =>
-            (tooltipsEnabled ? (
-              <Tooltip key={tab.id}>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={() => setActiveTab(tab.id)}
-                    className={`${
-                      activeTab === tab.id ? '' : 'hover:text-white/60'
-                    } relative rounded-full px-3 py-1.5 text-sm font-medium text-white outline-sky-400 transition focus-visible:outline-2 w-24 text-center`}
-                    style={{
-                      WebkitTapHighlightColor: 'transparent',
-                    }}
-                  >
-                    {activeTab === tab.id && (
-                      <motion.span
-                        layoutId="bubble"
-                        className="absolute inset-0 z-10 bg-white mix-blend-difference"
-                        style={{ borderRadius: 9999 }}
-                        transition={{
-                          type: 'spring',
-                          bounce: 0.2,
-                          duration: 0.6,
-                        }}
-                      />
-                    )}
-                    {tab.label}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {getTooltip(
-                    tab.id === 'atoms'
-                      ? TooltipKey.ATOMS_TAB
-                      : TooltipKey.TAGGING_TAB,
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`${
-                  activeTab === tab.id ? '' : 'hover:text-white/60'
-                } relative rounded-full px-3 py-1.5 text-sm font-medium text-white outline-sky-400 transition focus-visible:outline-2 w-24 text-center`}
-                style={{
-                  WebkitTapHighlightColor: 'transparent',
-                }}
-              >
-                {activeTab === tab.id && (
-                  <motion.span
-                    layoutId="bubble"
-                    className="absolute inset-0 z-10 bg-white mix-blend-difference"
-                    style={{ borderRadius: 9999 }}
-                    transition={{ type: 'spring', bounce: 0.2, duration: 0.6 }}
-                  />
-                )}
+      <div className="container mx-auto p-0 theme-border rounded-lg my-4">
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as ViewTab)}
+          className="w-full"
+        >
+          <TabsList className="grid w-full grid-cols-4 rounded-b-none">
+            {tabs.map((tab, index) => (
+              <TabsTrigger key={tab.id} value={tab.id} className="relative">
+                <span className="absolute top-0 left-0 w-6 h-6 flex items-center justify-center bg-primary text-primary-foreground rounded-full text-xs font-bold -translate-x-1/2 -translate-y-1/2">
+                  {index + 1}
+                </span>
                 {tab.label}
-              </button>
-            )),
-          )}
-        </div>
-      </div>
-
-      {/* Main content */}
-      <div className="container mx-auto p-4 space-y-6 relative">
-        {/* Atoms View Content */}
-        {activeTab === 'atoms' && (
-          <>
-            {/* File input */}
-            <input
-              type="file"
-              ref={fileInputRef}
-              onChange={loadCSV}
-              style={{ display: 'none' }}
-              accept=".csv"
-            />
-
-            {/* Atoms View Buttons */}
-            <div className="flex space-x-4 h-8 mt-2">
-              {tooltipsEnabled ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button onClick={() => fileInputRef.current?.click()}>
-                      Load CSV
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {getTooltip(TooltipKey.LOAD_CSV)}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <Button onClick={() => fileInputRef.current?.click()}>
-                  Load CSV
-                </Button>
-              )}
-
-              {tooltipsEnabled ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button onClick={addNewRow} disabled={isLoading}>
-                      {isLoading ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Plus className="h-4 w-4" />
-                      )}
-                      Add New Row
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {getTooltip(TooltipKey.ADD_ROW)}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <Button onClick={addNewRow} disabled={isLoading}>
-                  {isLoading ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Plus className="h-4 w-4" />
-                  )}
-                  Add New Row
-                </Button>
-              )}
-
-              {tooltipsEnabled ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      onClick={deleteSelectedRows}
-                      disabled={selectedRows.length === 0 || isLoading}
-                    >
-                      {isLoading ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Minus className="h-4 w-4" />
-                      )}
-                      Delete Selected Row{selectedRows.length > 1 ? 's' : ''}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {getTooltip(TooltipKey.DELETE_ROWS)}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <Button
-                  onClick={deleteSelectedRows}
-                  disabled={selectedRows.length === 0 || isLoading}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          <TabsContent value="select" className="p-5">
+            <div className="space-y-5">
+              <div className="space-y-2">
+                <Text variant={TextVariant.headline}>Select Data Type</Text>
+                <Text
+                  variant={TextVariant.body}
+                  className="text-muted-foreground"
                 >
-                  {isLoading ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Minus className="h-4 w-4" />
-                  )}
-                  Delete Selected Row{selectedRows.length > 1 ? 's' : ''}
-                </Button>
-              )}
-
-              {tooltipsEnabled ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      onClick={handlePublishAtoms}
-                      disabled={selectedRows.length === 0 || isLoading}
+                  To start, select the type of atom data you are uploading. Use{' '}
+                  {'<Thing>'} for atom with metadata, or CAIP-10 for a smart
+                  contract, or URI for a raw URI (advanced). Refer to{' '}
+                  <a href="#" target="_blank" className="underline">
+                    documentation
+                  </a>{' '}
+                  for more details.
+                </Text>
+              </div>
+              <div className="">
+                <div className="flex items-center mb-4">
+                  <div className="space-y-2">
+                    <Select
+                      value={selectedType}
+                      onValueChange={handleFormatChange}
                     >
-                      {isLoading ? 'Processing...' : 'Publish Selected Atoms'}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {getTooltip(TooltipKey.PUBLISH_ATOMS)}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
+                      <SelectTrigger className="w-[180px]">
+                        <SelectValue placeholder="Select type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(atomDataTypes).map(([key, type]) => (
+                          <SelectItem key={key} value={key}>
+                            {type.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </div>
+              <div className="flex justify-end">
                 <Button
-                  onClick={handlePublishAtoms}
-                  disabled={selectedRows.length === 0 || isLoading}
+                  onClick={() => setActiveTab('upload')}
+                  disabled={!selectedType}
                 >
-                  {isLoading ? 'Processing...' : 'Publish Selected Atoms'}
+                  Continue
                 </Button>
-              )}
-
-              {tooltipsEnabled ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button onClick={saveCSV} disabled={!isCSVDataModified}>
-                      <Save className="h-4 w-4" /> Save CSV
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {getTooltip(TooltipKey.SAVE_CSV)}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <Button onClick={saveCSV} disabled={!isCSVDataModified}>
-                  <Save className="h-4 w-4" /> Save CSV
-                </Button>
-              )}
+              </div>
             </div>
+          </TabsContent>
+          <TabsContent value="upload" className="p-5">
+            <div className="space-y-5">
+              <div className="space-y-2">
+                <Text variant={TextVariant.headline}>Upload CSV</Text>
+                <Text
+                  variant={TextVariant.body}
+                  className="text-muted-foreground"
+                >
+                  Upload a CSV file to begin. Once the file is uploaded, we will
+                  will automatically perform some basic proofreading. <br />
+                  Refer to{' '}
+                  <a href="#" target="_blank" className="underline">
+                    documentation
+                  </a>{' '}
+                  for formatting requirements.
+                </Text>
+              </div>
+              <CsvUploader
+                file={file}
+                setFile={setFile}
+                onFileChange={loadCSV}
+              />
+              <div className="flex justify-end">
+                <Button
+                  onClick={() => setActiveTab('publish')}
+                  disabled={!file}
+                >
+                  Continue
+                </Button>
+              </div>
+            </div>
+          </TabsContent>
+          <TabsContent value="publish" className="p-5">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Text variant={TextVariant.headline}>Publish Atoms</Text>
+                <Text
+                  variant={TextVariant.body}
+                  className="text-muted-foreground"
+                >
+                  Begin the process by uploading atoms to Intuition.
+                  Pre-existing atoms will automatically be omitted from
+                  publishing. <br />
+                  Refer to{' '}
+                  <a href="#" target="_blank" className="underline">
+                    documentation
+                  </a>{' '}
+                  for more details.
+                </Text>
+              </div>
+              <div className="border border-dashed border-warning/30 rounded-lg p-6 text-center text-warning bg-warning/15">
+                Placeholder for validation
+              </div>
+              <div className="flex justify-end">
+                {tooltipsEnabled ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        onClick={handlePublishAtoms}
+                        disabled={selectedRows.length === 0 || isLoading}
+                      >
+                        {isLoading ? 'Processing...' : 'Publish Selected Atoms'}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {getTooltip(TooltipKey.PUBLISH_ATOMS)}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <Button
+                    onClick={handlePublishAtoms}
+                    disabled={selectedRows.length === 0 || isLoading}
+                  >
+                    {isLoading ? 'Processing...' : 'Publish Selected Atoms'}
+                  </Button>
+                )}
+              </div>
+            </div>
+          </TabsContent>
+          <TabsContent value="tag" className="p-5">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Text variant={TextVariant.headline}>Tag Atoms</Text>
+                <Text
+                  variant={TextVariant.body}
+                  className="text-muted-foreground"
+                >
+                  Organize your published atoms by adding tags via triples. The
+                  tag atoms must be published first, and the tag must be
+                  created.
+                  <br />
+                  Refer to{' '}
+                  <a href="#" target="_blank" className="underline">
+                    documentation
+                  </a>{' '}
+                  for more details.
+                </Text>
+              </div>
+              <>
+                {/* Move buttons to top */}
 
-            {/* Progress bar */}
-            {isLoading && <Progress value={undefined} className="w-full" />}
+                {/* Tag status indicator */}
+                <div className="flex items-center space-x-2 mt-4">
+                  {isCheckingTag ? (
+                    <Loader2 className="animate-spin text-blue-500 w-6 h-6" />
+                  ) : tagExists ? (
+                    tooltipsEnabled ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <CloudCog className="text-blue-500 w-6 h-6" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {getTooltip(TooltipKey.TAG_LIVE)}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <CloudCog className="text-blue-500 w-6 h-6" />
+                    )
+                  ) : isCheckingTag === false ? (
+                    tooltipsEnabled ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <CircleEllipsis className="text-green-500 w-6 h-6" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {getTooltip(TooltipKey.TAG_NOT_PUBLISHED)}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <CircleEllipsis className="text-green-500 w-6 h-6" />
+                    )
+                  ) : null}
+                </div>
 
-            {/* CSV data table */}
-            {csvData.length > 0 && (
-              <div className="mt-4">
-                <div className="flex items-center space-x-2 mb-4">
+                {/* Tag input fields */}
+                <div className="grid grid-cols-2 gap-4 mt-4">
+                  {Object.keys(newTag).map((key) => (
+                    <div key={key}>
+                      <label
+                        htmlFor={key}
+                        className="block text-sm font-medium text-gray-700"
+                      >
+                        {key}
+                      </label>
+                      <Input
+                        id={key}
+                        value={newTag[key]}
+                        onChange={(e) =>
+                          setNewTag((prev) => ({
+                            ...prev,
+                            [key]: e.target.value,
+                          }))
+                        }
+                        disabled={key === '@context' || key === '@type'}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </>
+              <div className="flex justify-end">
+                <div className="flex space-x-4 h-8 mt-2">
                   {tooltipsEnabled ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <div className="flex items-center space-x-2">
-                          <span className="text-sm font-medium">Type:</span>
-                          <Select
-                            value={selectedType}
-                            onValueChange={handleFormatChange}
-                          >
-                            <SelectTrigger className="w-[180px]">
-                              <SelectValue placeholder="Select type" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {Object.entries(atomDataTypes).map(
-                                ([key, type]) => (
-                                  <SelectItem key={key} value={key}>
-                                    {type.name}
-                                  </SelectItem>
-                                ),
-                              )}
-                            </SelectContent>
-                          </Select>
-                        </div>
+                        <Button
+                          className="h-8"
+                          onClick={handleCreateTag}
+                          disabled={tagExists}
+                        >
+                          Create Tag
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>
-                        {getTooltip(TooltipKey.ATOM_TYPE)}
+                        {getTooltip(TooltipKey.CREATE_TAG)}
                       </TooltipContent>
                     </Tooltip>
                   ) : (
-                    <div className="flex items-center space-x-2">
-                      <span className="text-sm font-medium">Type:</span>
-                      <Select
-                        value={selectedType}
-                        onValueChange={handleFormatChange}
-                      >
-                        <SelectTrigger className="w-[180px]">
-                          <SelectValue placeholder="Select type" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {Object.entries(atomDataTypes).map(([key, type]) => (
-                            <SelectItem key={key} value={key}>
-                              {type.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
+                    <Button
+                      className="h-8"
+                      onClick={handleCreateTag}
+                      disabled={tagExists}
+                    >
+                      Create Tag
+                    </Button>
                   )}
-                </div>
-                <div className="overflow-x-auto">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-8"></TableHead>{' '}
-                        {/* New column for checkmark */}
-                        {csvData[0].map((header, index) => (
-                          <TableHead
-                            key={index}
-                            className={`cursor-pointer hover:bg-gray-100 ${
-                              header === '@context'
-                                ? 'w-40'
-                                : header === '@type'
-                                  ? 'w-24'
-                                  : header === 'name'
-                                    ? 'w-48'
-                                    : header === 'image'
-                                      ? 'w-64'
-                                      : ''
-                            }`}
-                            onClick={() => handleSort(index)}
-                          >
-                            <div className="flex items-center space-x-2">
-                              <span>{header}</span>
-                              {sortState.column === index && (
-                                <span>
-                                  {sortState.direction === 'asc' ? '▲' : '▼'}
-                                </span>
-                              )}
-                            </div>
-                          </TableHead>
-                        ))}
-                        <TableHead
-                          className="cursor-pointer hover:bg-gray-100 w-16"
-                          onClick={toggleAllRows}
+                  {tooltipsEnabled ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          className="h-8"
+                          onClick={handleCreateAndTagAtoms}
+                          disabled={
+                            selectedRows.length === 0 ||
+                            !tagExists ||
+                            isTagging ||
+                            navigation.state === 'submitting'
+                          }
                         >
-                          <div className="flex items-center space-x-2">
-                            <Checkbox
-                              checked={
-                                selectedRows.length === csvData.length - 1
-                              }
-                              onCheckedChange={toggleAllRows}
-                              className="w-4 h-4"
-                            />
-                          </div>
-                        </TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {(sortedIndices.length > 0
-                        ? sortedIndices
-                        : csvData.slice(1).map((_, i) => i + 1)
-                      ).map((rowIndex, displayIndex) => (
-                        <TableRow key={rowIndex}>
-                          <TableCell className="w-8 p-0">
-                            {loadingRows.has(rowIndex - 1) ? (
-                              <Loader2 className="animate-spin text-blue-500 w-6 h-6" />
-                            ) : existingAtoms.has(rowIndex - 1) ? (
-                              tooltipsEnabled ? (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <CloudCog className="text-blue-500 w-6 h-6" />
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    {getTooltip(TooltipKey.ATOM_LIVE)}
-                                  </TooltipContent>
-                                </Tooltip>
-                              ) : (
-                                <CloudCog className="text-blue-500 w-6 h-6" />
-                              )
-                            ) : loadingRows.has(rowIndex - 1) === false ? (
-                              tooltipsEnabled ? (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <CircleEllipsis className="text-green-500 w-6 h-6" />
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    {getTooltip(TooltipKey.ATOM_NOT_PUBLISHED)}
-                                  </TooltipContent>
-                                </Tooltip>
-                              ) : (
-                                <CircleEllipsis className="text-green-500 w-6 h-6" />
-                              )
-                            ) : null}
-                          </TableCell>
-                          {csvData[rowIndex].map((cell, cellIndex) => (
-                            <TableCell
-                              key={cellIndex}
-                              className={`p-0 ${
-                                csvData[0][cellIndex] === '@context'
-                                  ? 'w-40'
-                                  : csvData[0][cellIndex] === '@type'
-                                    ? 'w-24'
-                                    : csvData[0][cellIndex] === 'name'
-                                      ? 'w-48'
-                                      : csvData[0][cellIndex] === 'image'
-                                        ? 'w-64'
-                                        : ''
-                              } ${
-                                cellHighlights.some(
-                                  (highlight) =>
-                                    highlight.rowIndex === displayIndex &&
-                                    highlight.cellIndex === cellIndex,
-                                )
-                                  ? 'border-yellow-400 border-2'
-                                  : ''
-                              }`}
-                            >
-                              <div className="flex items-center">
-                                <Textarea
-                                  value={cell}
-                                  onChange={(e) =>
-                                    handleCellEdit(
-                                      rowIndex,
-                                      cellIndex,
-                                      e.target.value,
-                                    )
-                                  }
-                                  onFocus={handleFocus}
-                                  onBlur={(e) =>
-                                    handleCellBlur(e, rowIndex, cellIndex)
-                                  }
-                                  onPaste={(e) =>
-                                    handleCellPaste(e, rowIndex, cellIndex)
-                                  }
-                                  placeholder={
-                                    !cell &&
-                                    atomDataTypes[selectedType]
-                                      .defaultDescriptions[
-                                      csvData[0][cellIndex]
-                                    ]
-                                      ? atomDataTypes[selectedType]
-                                          .defaultDescriptions[
-                                          csvData[0][cellIndex]
-                                        ]
-                                      : ''
-                                  }
-                                  className={`w-full border-none focus:outline-none focus:ring-0 resize-none overflow-hidden h-8 ${
-                                    !cell ? 'text-gray-400 italic' : ''
-                                  }`}
-                                  readOnly={
-                                    csvData[0][cellIndex] === '@context' ||
-                                    csvData[0][cellIndex] === '@type'
-                                  }
-                                />
-                                {csvData[0][cellIndex] === 'image' &&
-                                  thumbnails[rowIndex] && (
-                                    <img
-                                      src={thumbnails[rowIndex]}
-                                      alt="Thumbnail"
-                                      className="w-8 h-8 object-cover ml-2 flex-shrink-0"
-                                    />
-                                  )}
-                              </div>
-                            </TableCell>
-                          ))}
-                          <TableCell className="w-16">
-                            <Checkbox
-                              checked={selectedRows.includes(rowIndex - 1)}
-                              onCheckedChange={() =>
-                                toggleRowSelection(rowIndex - 1)
-                              }
-                              className="w-4 h-4"
-                            />
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              </div>
-            )}
-          </>
-        )}
-
-        {/* Tagging View Content */}
-        {activeTab === 'tagging' && (
-          <>
-            {/* Move buttons to top */}
-            <div className="flex space-x-4 h-8 mt-2">
-              {tooltipsEnabled ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
+                          {isTagging || navigation.state === 'submitting' ? (
+                            <>
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              Tagging...
+                            </>
+                          ) : (
+                            getCreateTagButtonText()
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {getTooltip(TooltipKey.TAG_ATOMS)}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
                     <Button
                       className="h-8"
                       onClick={handleCreateAndTagAtoms}
@@ -1631,118 +1484,271 @@ export default function CSVEditor() {
                         getCreateTagButtonText()
                       )}
                     </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {getTooltip(TooltipKey.TAG_ATOMS)}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <Button
-                  className="h-8"
-                  onClick={handleCreateAndTagAtoms}
-                  disabled={
-                    selectedRows.length === 0 ||
-                    !tagExists ||
-                    isTagging ||
-                    navigation.state === 'submitting'
-                  }
-                >
-                  {isTagging || navigation.state === 'submitting' ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Tagging...
-                    </>
-                  ) : (
-                    getCreateTagButtonText()
                   )}
-                </Button>
-              )}
-
-              {tooltipsEnabled ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      className="h-8"
-                      onClick={handleCreateTag}
-                      disabled={tagExists}
-                    >
-                      Create Tag
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {getTooltip(TooltipKey.CREATE_TAG)}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <Button
-                  className="h-8"
-                  onClick={handleCreateTag}
-                  disabled={tagExists}
-                >
-                  Create Tag
-                </Button>
-              )}
-            </div>
-
-            {/* Tag status indicator */}
-            <div className="flex items-center space-x-2 mt-4">
-              {isCheckingTag ? (
-                <Loader2 className="animate-spin text-blue-500 w-6 h-6" />
-              ) : tagExists ? (
-                tooltipsEnabled ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <CloudCog className="text-blue-500 w-6 h-6" />
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {getTooltip(TooltipKey.TAG_LIVE)}
-                    </TooltipContent>
-                  </Tooltip>
-                ) : (
-                  <CloudCog className="text-blue-500 w-6 h-6" />
-                )
-              ) : isCheckingTag === false ? (
-                tooltipsEnabled ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <CircleEllipsis className="text-green-500 w-6 h-6" />
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {getTooltip(TooltipKey.TAG_NOT_PUBLISHED)}
-                    </TooltipContent>
-                  </Tooltip>
-                ) : (
-                  <CircleEllipsis className="text-green-500 w-6 h-6" />
-                )
-              ) : null}
-            </div>
-
-            {/* Tag input fields */}
-            <div className="grid grid-cols-2 gap-4 mt-4">
-              {Object.keys(newTag).map((key) => (
-                <div key={key}>
-                  <label
-                    htmlFor={key}
-                    className="block text-sm font-medium text-gray-700"
-                  >
-                    {key}
-                  </label>
-                  <Input
-                    id={key}
-                    value={newTag[key]}
-                    onChange={(e) =>
-                      setNewTag((prev) => ({
-                        ...prev,
-                        [key]: e.target.value,
-                      }))
-                    }
-                    disabled={key === '@context' || key === '@type'}
-                  />
                 </div>
-              ))}
+              </div>
             </div>
-          </>
-        )}
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      {/* Main content */}
+      <div className="container mx-auto p-4 space-y-6 relative">
+        <>
+          <div className="flex space-x-4 h-8 mt-2">
+            {tooltipsEnabled ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button onClick={addNewRow} disabled={isLoading}>
+                    {isLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Plus className="h-4 w-4" />
+                    )}
+                    Add New Row
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {getTooltip(TooltipKey.ADD_ROW)}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Button onClick={addNewRow} disabled={isLoading}>
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                Add New Row
+              </Button>
+            )}
+
+            {tooltipsEnabled ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    onClick={deleteSelectedRows}
+                    disabled={selectedRows.length === 0 || isLoading}
+                  >
+                    {isLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Minus className="h-4 w-4" />
+                    )}
+                    Delete Selected Row{selectedRows.length > 1 ? 's' : ''}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {getTooltip(TooltipKey.DELETE_ROWS)}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Button
+                onClick={deleteSelectedRows}
+                disabled={selectedRows.length === 0 || isLoading}
+              >
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Minus className="h-4 w-4" />
+                )}
+                Delete Selected Row{selectedRows.length > 1 ? 's' : ''}
+              </Button>
+            )}
+
+            {tooltipsEnabled ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button onClick={saveCSV} disabled={!isCSVDataModified}>
+                    <Save className="h-4 w-4" /> Save CSV
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {getTooltip(TooltipKey.SAVE_CSV)}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Button onClick={saveCSV} disabled={!isCSVDataModified}>
+                <Save className="h-4 w-4" /> Save CSV
+              </Button>
+            )}
+          </div>
+
+          {/* Progress bar */}
+          {isLoading && <Progress value={undefined} className="w-full" />}
+
+          {/* CSV data table */}
+          {csvData.length > 0 && (
+            <div className="mt-4">
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-8"></TableHead>{' '}
+                      {/* New column for checkmark */}
+                      {csvData[0].map((header, index) => (
+                        <TableHead
+                          key={index}
+                          className={`cursor-pointer hover:bg-gray-100 ${
+                            header === '@context'
+                              ? 'w-40'
+                              : header === '@type'
+                                ? 'w-24'
+                                : header === 'name'
+                                  ? 'w-48'
+                                  : header === 'image'
+                                    ? 'w-64'
+                                    : ''
+                          }`}
+                          onClick={() => handleSort(index)}
+                        >
+                          <div className="flex items-center space-x-2">
+                            <span>{header}</span>
+                            {sortState.column === index && (
+                              <span>
+                                {sortState.direction === 'asc' ? '▲' : '▼'}
+                              </span>
+                            )}
+                          </div>
+                        </TableHead>
+                      ))}
+                      <TableHead
+                        className="cursor-pointer hover:bg-gray-100 w-16"
+                        onClick={toggleAllRows}
+                      >
+                        <div className="flex items-center space-x-2">
+                          <Checkbox
+                            checked={selectedRows.length === csvData.length - 1}
+                            onCheckedChange={toggleAllRows}
+                            className="w-4 h-4"
+                          />
+                        </div>
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(sortedIndices.length > 0
+                      ? sortedIndices
+                      : csvData.slice(1).map((_, i) => i + 1)
+                    ).map((rowIndex, displayIndex) => (
+                      <TableRow key={rowIndex}>
+                        <TableCell className="w-8 p-0">
+                          {loadingRows.has(rowIndex - 1) ? (
+                            <Loader2 className="animate-spin text-blue-500 w-6 h-6" />
+                          ) : existingAtoms.has(rowIndex - 1) ? (
+                            tooltipsEnabled ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <CloudCog className="text-blue-500 w-6 h-6" />
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  {getTooltip(TooltipKey.ATOM_LIVE)}
+                                </TooltipContent>
+                              </Tooltip>
+                            ) : (
+                              <CloudCog className="text-blue-500 w-6 h-6" />
+                            )
+                          ) : loadingRows.has(rowIndex - 1) === false ? (
+                            tooltipsEnabled ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <CircleEllipsis className="text-green-500 w-6 h-6" />
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  {getTooltip(TooltipKey.ATOM_NOT_PUBLISHED)}
+                                </TooltipContent>
+                              </Tooltip>
+                            ) : (
+                              <CircleEllipsis className="text-green-500 w-6 h-6" />
+                            )
+                          ) : null}
+                        </TableCell>
+                        {csvData[rowIndex].map((cell, cellIndex) => (
+                          <TableCell
+                            key={cellIndex}
+                            className={`p-0 ${
+                              csvData[0][cellIndex] === '@context'
+                                ? 'w-40'
+                                : csvData[0][cellIndex] === '@type'
+                                  ? 'w-24'
+                                  : csvData[0][cellIndex] === 'name'
+                                    ? 'w-48'
+                                    : csvData[0][cellIndex] === 'image'
+                                      ? 'w-64'
+                                      : ''
+                            } ${
+                              cellHighlights.some(
+                                (highlight) =>
+                                  highlight.rowIndex === displayIndex &&
+                                  highlight.cellIndex === cellIndex,
+                              )
+                                ? 'border-yellow-400 border-2'
+                                : ''
+                            }`}
+                          >
+                            <div className="flex items-center">
+                              <Textarea
+                                value={cell}
+                                onChange={(e) =>
+                                  handleCellEdit(
+                                    rowIndex,
+                                    cellIndex,
+                                    e.target.value,
+                                  )
+                                }
+                                onFocus={handleFocus}
+                                onBlur={(e) =>
+                                  handleCellBlur(e, rowIndex, cellIndex)
+                                }
+                                onPaste={(e) =>
+                                  handleCellPaste(e, rowIndex, cellIndex)
+                                }
+                                placeholder={
+                                  !cell &&
+                                  atomDataTypes[selectedType]
+                                    .defaultDescriptions[csvData[0][cellIndex]]
+                                    ? atomDataTypes[selectedType]
+                                        .defaultDescriptions[
+                                        csvData[0][cellIndex]
+                                      ]
+                                    : ''
+                                }
+                                className={`w-full border-none focus:outline-none focus:ring-0 resize-none overflow-hidden h-8 ${
+                                  !cell ? 'text-gray-400 italic' : ''
+                                }`}
+                                readOnly={
+                                  csvData[0][cellIndex] === '@context' ||
+                                  csvData[0][cellIndex] === '@type'
+                                }
+                              />
+                              {csvData[0][cellIndex] === 'image' &&
+                                thumbnails[rowIndex] && (
+                                  <img
+                                    src={thumbnails[rowIndex]}
+                                    alt="Thumbnail"
+                                    className="w-8 h-8 object-cover ml-2 flex-shrink-0"
+                                  />
+                                )}
+                            </div>
+                          </TableCell>
+                        ))}
+                        <TableCell className="w-16">
+                          <Checkbox
+                            checked={selectedRows.includes(rowIndex - 1)}
+                            onCheckedChange={() =>
+                              toggleRowSelection(rowIndex - 1)
+                            }
+                            className="w-4 h-4"
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          )}
+        </>
       </div>
 
       {/* Add this confirmation modal dialog */}

--- a/apps/data-populator/app/routes/app+/index.tsx
+++ b/apps/data-populator/app/routes/app+/index.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   Button,
+  ButtonVariant,
   Checkbox,
+  cn,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -69,17 +71,12 @@ import type { SortDirection } from '@lib/utils/sort'
 import { getNextSortDirection, sortData } from '@lib/utils/sort'
 import { getTooltip, TooltipKey } from '@lib/utils/tooltips'
 import { json, type ActionFunctionArgs } from '@remix-run/node'
+import { useActionData, useNavigation } from '@remix-run/react'
 import {
-  useActionData,
-  useFetcher,
-  useNavigation,
-  useSubmit,
-} from '@remix-run/react'
-import { motion } from 'framer-motion'
-import {
-  CircleEllipsis,
-  CloudCog,
-  FileText,
+  BookCheck,
+  CirclePlus,
+  Download,
+  FileType,
   Loader2,
   Minus,
   Plus,
@@ -87,6 +84,7 @@ import {
   Send,
   Shapes,
   Tag,
+  Trash,
   Upload,
 } from 'lucide-react'
 import { Thing, WithContext } from 'schema-dts'
@@ -1188,16 +1186,23 @@ export default function CSVEditor() {
 
   return (
     <>
-      <div className="container mx-auto p-0 theme-border rounded-lg my-4">
+      <div className="container mx-auto p-0 border border-primary/30 rounded-lg my-4">
         <Tabs
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as ViewTab)}
           className="w-full"
         >
-          <TabsList className="grid w-full grid-cols-4 rounded-b-none">
+          <TabsList className="grid w-full grid-cols-4 rounded-b-none border-b border-primary/10">
             {tabs.map((tab, index) => (
               <TabsTrigger key={tab.id} value={tab.id} className="relative">
-                <span className="absolute top-0 left-0 w-6 h-6 flex items-center justify-center bg-primary text-primary-foreground rounded-full text-xs font-bold -translate-x-1/2 -translate-y-1/2">
+                <span
+                  className={cn(
+                    'absolute top-0 left-0 w-6 h-6 flex items-center justify-center rounded-full text-xs font-bold -translate-x-1/2 -translate-y-1/2',
+                    activeTab === tab.id
+                      ? 'bg-accent text-foreground'
+                      : 'bg-muted text-foreground/70 border border-primary/10',
+                  )}
+                >
                   {index + 1}
                 </span>
                 {tab.label}
@@ -1207,7 +1212,10 @@ export default function CSVEditor() {
           <TabsContent value="select" className="p-5">
             <div className="space-y-5">
               <div className="space-y-2">
-                <Text variant={TextVariant.headline}>Select Data Type</Text>
+                <div className="flex items-center space-x-2">
+                  <FileType className="w-6 h-6" strokeWidth={1.5} />
+                  <Text variant={TextVariant.headline}>Select Data Type</Text>
+                </div>
                 <Text
                   variant={TextVariant.body}
                   className="text-muted-foreground"
@@ -1356,32 +1364,38 @@ export default function CSVEditor() {
                 {/* Tag status indicator */}
                 <div className="flex items-center space-x-2 mt-4">
                   {isCheckingTag ? (
-                    <Loader2 className="animate-spin text-blue-500 w-6 h-6" />
+                    <Loader2 className="animate-spin text-blue-500 w-5 h-5" />
                   ) : tagExists ? (
                     tooltipsEnabled ? (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <CloudCog className="text-blue-500 w-6 h-6" />
+                          <BookCheck className="text-success w-5 h-5" />
                         </TooltipTrigger>
                         <TooltipContent>
                           {getTooltip(TooltipKey.TAG_LIVE)}
                         </TooltipContent>
                       </Tooltip>
                     ) : (
-                      <CloudCog className="text-blue-500 w-6 h-6" />
+                      <BookCheck className="text-success w-5 h-5" />
                     )
                   ) : isCheckingTag === false ? (
                     tooltipsEnabled ? (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <CircleEllipsis className="text-green-500 w-6 h-6" />
+                          <CirclePlus
+                            className="text-accent w-5 h-5"
+                            strokeWidth={1.5}
+                          />
                         </TooltipTrigger>
                         <TooltipContent>
                           {getTooltip(TooltipKey.TAG_NOT_PUBLISHED)}
                         </TooltipContent>
                       </Tooltip>
                     ) : (
-                      <CircleEllipsis className="text-green-500 w-6 h-6" />
+                      <CirclePlus
+                        className="text-accent w-5 h-5"
+                        strokeWidth={1.5}
+                      />
                     )
                   ) : null}
                 </div>
@@ -1493,262 +1507,319 @@ export default function CSVEditor() {
       </div>
 
       {/* Main content */}
-      <div className="container mx-auto p-4 space-y-6 relative">
-        <>
-          <div className="flex space-x-4 h-8 mt-2">
-            {tooltipsEnabled ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button onClick={addNewRow} disabled={isLoading}>
-                    {isLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Plus className="h-4 w-4" />
-                    )}
-                    Add New Row
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {getTooltip(TooltipKey.ADD_ROW)}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <Button onClick={addNewRow} disabled={isLoading}>
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Plus className="h-4 w-4" />
-                )}
-                Add New Row
-              </Button>
-            )}
+      <div className="container mx-auto p-0 space-y-6 relative">
+        <div className="flex space-x-4 h-8 mt-2"></div>
 
-            {tooltipsEnabled ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={deleteSelectedRows}
-                    disabled={selectedRows.length === 0 || isLoading}
-                  >
-                    {isLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Minus className="h-4 w-4" />
-                    )}
-                    Delete Selected Row{selectedRows.length > 1 ? 's' : ''}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {getTooltip(TooltipKey.DELETE_ROWS)}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <Button
-                onClick={deleteSelectedRows}
-                disabled={selectedRows.length === 0 || isLoading}
-              >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Minus className="h-4 w-4" />
-                )}
-                Delete Selected Row{selectedRows.length > 1 ? 's' : ''}
-              </Button>
-            )}
+        {/* Progress bar */}
+        {isLoading && <Progress value={undefined} className="w-full" />}
 
-            {tooltipsEnabled ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button onClick={saveCSV} disabled={!isCSVDataModified}>
-                    <Save className="h-4 w-4" /> Save CSV
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {getTooltip(TooltipKey.SAVE_CSV)}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <Button onClick={saveCSV} disabled={!isCSVDataModified}>
-                <Save className="h-4 w-4" /> Save CSV
-              </Button>
-            )}
-          </div>
-
-          {/* Progress bar */}
-          {isLoading && <Progress value={undefined} className="w-full" />}
-
-          {/* CSV data table */}
-          {csvData.length > 0 && (
-            <div className="mt-4">
-              <div className="overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-8"></TableHead>{' '}
-                      {/* New column for checkmark */}
-                      {csvData[0].map((header, index) => (
-                        <TableHead
-                          key={index}
-                          className={`cursor-pointer hover:bg-gray-100 ${
-                            header === '@context'
-                              ? 'w-40'
-                              : header === '@type'
-                                ? 'w-24'
-                                : header === 'name'
-                                  ? 'w-48'
-                                  : header === 'image'
-                                    ? 'w-64'
-                                    : ''
-                          }`}
-                          onClick={() => handleSort(index)}
+        {/* CSV data table */}
+        {csvData.length > 0 && (
+          <div className="overflow-x-auto rounded-lg border border-primary/30">
+            <div className="w-full border-b border-primary/15 bg-gradient-to-r from-primary/10 to-primary/5">
+              <div className="w-full flex justify-between items-center px-4 py-2 h-12">
+                <div className="text-sm tracking-wide uppercase">
+                  {selectedRows.length > 0 ? (
+                    <>
+                      <span className="text-foreground">
+                        {selectedRows.length}
+                      </span>
+                      <span className="text-foreground/70"> Selected</span>
+                    </>
+                  ) : (
+                    <>
+                      <span className="text-foreground/70">Rows</span>{' '}
+                      {csvData.length - 1}
+                    </>
+                  )}
+                </div>
+                <div className="flex items-center space-x-2">
+                  {tooltipsEnabled ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant={ButtonVariant.secondary}
+                          onClick={saveCSV}
+                          disabled={!isCSVDataModified}
                         >
-                          <div className="flex items-center space-x-2">
-                            <span>{header}</span>
-                            {sortState.column === index && (
-                              <span>
-                                {sortState.direction === 'asc' ? '▲' : '▼'}
-                              </span>
+                          <Download className="h-4 w-4" /> Save CSV
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {getTooltip(TooltipKey.SAVE_CSV)}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={saveCSV}
+                      disabled={!isCSVDataModified}
+                    >
+                      <Save className="h-4 w-4" /> Save CSV
+                    </Button>
+                  )}
+                  <div className={`${selectedRows.length > 0 ? '' : 'hidden'}`}>
+                    {tooltipsEnabled ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant={ButtonVariant.secondary}
+                            onClick={deleteSelectedRows}
+                            disabled={selectedRows.length === 0 || isLoading}
+                          >
+                            {isLoading ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <Trash className="h-4 w-4" />
                             )}
-                          </div>
-                        </TableHead>
-                      ))}
+                            Delete Row
+                            {selectedRows.length > 1 ? 's' : ''}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {getTooltip(TooltipKey.DELETE_ROWS)}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <Button
+                        variant={ButtonVariant.secondary}
+                        onClick={deleteSelectedRows}
+                        disabled={selectedRows.length === 0 || isLoading}
+                      >
+                        {isLoading ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash className="h-4 w-4" />
+                        )}
+                        Delete Row{selectedRows.length > 1 ? 's' : ''}
+                      </Button>
+                    )}
+                  </div>
+                  {tooltipsEnabled ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant={ButtonVariant.secondary}
+                          onClick={addNewRow}
+                          disabled={isLoading}
+                        >
+                          {isLoading ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Plus className="h-4 w-4" />
+                          )}
+                          Add New Row
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {getTooltip(TooltipKey.ADD_ROW)}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={addNewRow}
+                      disabled={isLoading}
+                    >
+                      {isLoading ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Plus className="h-4 w-4" />
+                      )}
+                      Add New Row
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead
+                      className="cursor-pointer w-12"
+                      onClick={toggleAllRows}
+                    >
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          checked={selectedRows.length === csvData.length - 1}
+                          onCheckedChange={toggleAllRows}
+                          className="w-4 h-4"
+                        />
+                      </div>
+                    </TableHead>
+                    {/* New column for checkmark */}
+                    {csvData[0].map((header, index) => (
                       <TableHead
-                        className="cursor-pointer hover:bg-gray-100 w-16"
-                        onClick={toggleAllRows}
+                        key={index}
+                        className={`cursor-pointer ${
+                          header === '@context'
+                            ? 'w-40'
+                            : header === '@type'
+                              ? 'w-24'
+                              : header === 'name'
+                                ? 'w-48'
+                                : header === 'image'
+                                  ? 'w-64'
+                                  : ''
+                        }`}
+                        onClick={() => handleSort(index)}
                       >
                         <div className="flex items-center space-x-2">
-                          <Checkbox
-                            checked={selectedRows.length === csvData.length - 1}
-                            onCheckedChange={toggleAllRows}
-                            className="w-4 h-4"
-                          />
+                          <span>{header}</span>
+                          {sortState.column === index && (
+                            <span>
+                              {sortState.direction === 'asc' ? '▲' : '▼'}
+                            </span>
+                          )}
                         </div>
                       </TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {(sortedIndices.length > 0
-                      ? sortedIndices
-                      : csvData.slice(1).map((_, i) => i + 1)
-                    ).map((rowIndex, displayIndex) => (
-                      <TableRow key={rowIndex}>
-                        <TableCell className="w-8 p-0">
+                    ))}
+                    <TableHead className="w-8"></TableHead>{' '}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(sortedIndices.length > 0
+                    ? sortedIndices
+                    : csvData.slice(1).map((_, i) => i + 1)
+                  ).map((rowIndex, displayIndex) => (
+                    <TableRow key={rowIndex}>
+                      <TableCell className="w-12">
+                        <Checkbox
+                          checked={selectedRows.includes(rowIndex - 1)}
+                          onCheckedChange={() =>
+                            toggleRowSelection(rowIndex - 1)
+                          }
+                          className="w-4 h-4"
+                        />
+                      </TableCell>
+
+                      {csvData[rowIndex].map((cell, cellIndex) => (
+                        <TableCell
+                          key={cellIndex}
+                          className={`p-0 ${
+                            csvData[0][cellIndex] === '@context'
+                              ? 'w-40'
+                              : csvData[0][cellIndex] === '@type'
+                                ? 'w-24'
+                                : csvData[0][cellIndex] === 'name'
+                                  ? 'w-48'
+                                  : csvData[0][cellIndex] === 'image'
+                                    ? 'w-64'
+                                    : ''
+                          } ${
+                            cellHighlights.some(
+                              (highlight) =>
+                                highlight.rowIndex === displayIndex &&
+                                highlight.cellIndex === cellIndex,
+                            )
+                              ? 'border-warning border'
+                              : ''
+                          }`}
+                        >
+                          <div className="flex items-center p-1">
+                            <Textarea
+                              value={cell}
+                              disabled={
+                                csvData[0][cellIndex] === '@context' ||
+                                csvData[0][cellIndex] === '@type'
+                              }
+                              onChange={(e) =>
+                                handleCellEdit(
+                                  rowIndex,
+                                  cellIndex,
+                                  e.target.value,
+                                )
+                              }
+                              onFocus={handleFocus}
+                              onBlur={(e) =>
+                                handleCellBlur(e, rowIndex, cellIndex)
+                              }
+                              onPaste={(e) =>
+                                handleCellPaste(e, rowIndex, cellIndex)
+                              }
+                              placeholder={
+                                !cell &&
+                                atomDataTypes[selectedType].defaultDescriptions[
+                                  csvData[0][cellIndex]
+                                ]
+                                  ? atomDataTypes[selectedType]
+                                      .defaultDescriptions[
+                                      csvData[0][cellIndex]
+                                    ]
+                                  : ''
+                              }
+                              className={`w-full bg-transparent hover:bg-primary/5 focus-visible:bg-primary/5 border-none focus:outline-none focus:ring-0 focus-visible:ring-1 focus-visible:ring-primary/60 resize-none overflow-hidden h-8 ${
+                                !cell ? 'text-gray-400 italic' : ''
+                              }`}
+                              readOnly={
+                                csvData[0][cellIndex] === '@context' ||
+                                csvData[0][cellIndex] === '@type'
+                              }
+                            />
+                            {csvData[0][cellIndex] === 'image' &&
+                              thumbnails[rowIndex] && (
+                                <img
+                                  src={thumbnails[rowIndex]}
+                                  alt="Thumbnail"
+                                  className="w-8 h-8 object-cover ml-2 flex-shrink-0"
+                                />
+                              )}
+                          </div>
+                        </TableCell>
+                      ))}
+                      <TableCell className="w-8 p-0">
+                        <div className="flex items-center justify-center h-full">
                           {loadingRows.has(rowIndex - 1) ? (
-                            <Loader2 className="animate-spin text-blue-500 w-6 h-6" />
+                            <Loader2 className="animate-spin text-accent w-5 h-5" />
                           ) : existingAtoms.has(rowIndex - 1) ? (
                             tooltipsEnabled ? (
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <CloudCog className="text-blue-500 w-6 h-6" />
+                                  <BookCheck
+                                    className="text-success w-5 h-5"
+                                    strokeWidth={1.5}
+                                  />
                                 </TooltipTrigger>
                                 <TooltipContent>
                                   {getTooltip(TooltipKey.ATOM_LIVE)}
                                 </TooltipContent>
                               </Tooltip>
                             ) : (
-                              <CloudCog className="text-blue-500 w-6 h-6" />
+                              <BookCheck
+                                className="text-success w-5 h-5"
+                                strokeWidth={1.5}
+                              />
                             )
                           ) : loadingRows.has(rowIndex - 1) === false ? (
                             tooltipsEnabled ? (
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <CircleEllipsis className="text-green-500 w-6 h-6" />
+                                  <CirclePlus
+                                    className="text-accent w-5 h-5"
+                                    strokeWidth={1.5}
+                                  />
                                 </TooltipTrigger>
                                 <TooltipContent>
                                   {getTooltip(TooltipKey.ATOM_NOT_PUBLISHED)}
                                 </TooltipContent>
                               </Tooltip>
                             ) : (
-                              <CircleEllipsis className="text-green-500 w-6 h-6" />
+                              <CirclePlus
+                                className="text-accent w-5 h-5"
+                                strokeWidth={1.5}
+                              />
                             )
                           ) : null}
-                        </TableCell>
-                        {csvData[rowIndex].map((cell, cellIndex) => (
-                          <TableCell
-                            key={cellIndex}
-                            className={`p-0 ${
-                              csvData[0][cellIndex] === '@context'
-                                ? 'w-40'
-                                : csvData[0][cellIndex] === '@type'
-                                  ? 'w-24'
-                                  : csvData[0][cellIndex] === 'name'
-                                    ? 'w-48'
-                                    : csvData[0][cellIndex] === 'image'
-                                      ? 'w-64'
-                                      : ''
-                            } ${
-                              cellHighlights.some(
-                                (highlight) =>
-                                  highlight.rowIndex === displayIndex &&
-                                  highlight.cellIndex === cellIndex,
-                              )
-                                ? 'border-yellow-400 border-2'
-                                : ''
-                            }`}
-                          >
-                            <div className="flex items-center">
-                              <Textarea
-                                value={cell}
-                                onChange={(e) =>
-                                  handleCellEdit(
-                                    rowIndex,
-                                    cellIndex,
-                                    e.target.value,
-                                  )
-                                }
-                                onFocus={handleFocus}
-                                onBlur={(e) =>
-                                  handleCellBlur(e, rowIndex, cellIndex)
-                                }
-                                onPaste={(e) =>
-                                  handleCellPaste(e, rowIndex, cellIndex)
-                                }
-                                placeholder={
-                                  !cell &&
-                                  atomDataTypes[selectedType]
-                                    .defaultDescriptions[csvData[0][cellIndex]]
-                                    ? atomDataTypes[selectedType]
-                                        .defaultDescriptions[
-                                        csvData[0][cellIndex]
-                                      ]
-                                    : ''
-                                }
-                                className={`w-full border-none focus:outline-none focus:ring-0 resize-none overflow-hidden h-8 ${
-                                  !cell ? 'text-gray-400 italic' : ''
-                                }`}
-                                readOnly={
-                                  csvData[0][cellIndex] === '@context' ||
-                                  csvData[0][cellIndex] === '@type'
-                                }
-                              />
-                              {csvData[0][cellIndex] === 'image' &&
-                                thumbnails[rowIndex] && (
-                                  <img
-                                    src={thumbnails[rowIndex]}
-                                    alt="Thumbnail"
-                                    className="w-8 h-8 object-cover ml-2 flex-shrink-0"
-                                  />
-                                )}
-                            </div>
-                          </TableCell>
-                        ))}
-                        <TableCell className="w-16">
-                          <Checkbox
-                            checked={selectedRows.includes(rowIndex - 1)}
-                            onCheckedChange={() =>
-                              toggleRowSelection(rowIndex - 1)
-                            }
-                            className="w-4 h-4"
-                          />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </div>
-          )}
-        </>
+          </div>
+        )}
       </div>
 
       {/* Add this confirmation modal dialog */}

--- a/apps/data-populator/app/routes/app+/index.tsx
+++ b/apps/data-populator/app/routes/app+/index.tsx
@@ -76,6 +76,9 @@ import {
   BookCheck,
   CirclePlus,
   Download,
+  File,
+  FileSpreadsheet,
+  BookCheck,
   FileType,
   Loader2,
   Minus,
@@ -86,6 +89,7 @@ import {
   Tag,
   Trash,
   Upload,
+  TagIcon,
 } from 'lucide-react'
 import { Thing, WithContext } from 'schema-dts'
 
@@ -1263,7 +1267,10 @@ export default function CSVEditor() {
           <TabsContent value="upload" className="p-5">
             <div className="space-y-5">
               <div className="space-y-2">
-                <Text variant={TextVariant.headline}>Upload CSV</Text>
+                <div className="flex items-center space-x-2">
+                  <FileSpreadsheet className="w-6 h-6" strokeWidth={1.5} />
+                  <Text variant={TextVariant.headline}>Upload CSV</Text>
+                </div>
                 <Text
                   variant={TextVariant.body}
                   className="text-muted-foreground"
@@ -1295,7 +1302,10 @@ export default function CSVEditor() {
           <TabsContent value="publish" className="p-5">
             <div className="space-y-4">
               <div className="space-y-2">
-                <Text variant={TextVariant.headline}>Publish Atoms</Text>
+                <div className="flex items-center space-x-2">
+                  <BookCheck className="w-6 h-6" strokeWidth={1.5} />
+                  <Text variant={TextVariant.headline}>Publish Atoms</Text>
+                </div>
                 <Text
                   variant={TextVariant.body}
                   className="text-muted-foreground"
@@ -1342,7 +1352,10 @@ export default function CSVEditor() {
           <TabsContent value="tag" className="p-5">
             <div className="space-y-4">
               <div className="space-y-2">
-                <Text variant={TextVariant.headline}>Tag Atoms</Text>
+                <div className="flex items-center space-x-2">
+                  <TagIcon className="w-6 h-6" strokeWidth={1.5} />
+                  <Text variant={TextVariant.headline}>Tag Atoms</Text>
+                </div>
                 <Text
                   variant={TextVariant.body}
                   className="text-muted-foreground"

--- a/apps/data-populator/package.json
+++ b/apps/data-populator/package.json
@@ -30,6 +30,7 @@
     "@privy-io/wagmi": "0.2.12",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-scroll-area": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.0",
     "@remix-run/node": "^2.9.2",
     "@remix-run/react": "^2.9.2",
     "@remix-run/serve": "^2.9.2",

--- a/packages/1ui/src/components/Table/Table.spec.tsx
+++ b/packages/1ui/src/components/Table/Table.spec.tsx
@@ -45,37 +45,39 @@ describe('Table', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
       <DocumentFragment>
         <div
-          class="relative w-full overflow-auto"
+          class="w-full overflow-auto"
         >
           <table
-            class="w-full caption-bottom text-base"
+            class="w-full caption-bottom text-sm"
           >
             <caption
-              class="my-3 text-sm text-muted-foreground"
+              class="mt-4 text-sm text-foreground/70"
             >
               A list of your recent invoices.
             </caption>
-            <thead>
+            <thead
+              class="[&_tr]:border-b"
+            >
               <tr
-                class="border-b border-border/20 transition-colors hover:bg-primary/10 data-[state=selected]:bg-muted"
+                class="border-b border-primary/20 transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
               >
                 <th
-                  class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 border-0 border-b border-border/20 w-[100px]"
+                  class="h-12 p-4 text-left align-middle font-medium text-foreground/70 [&:has([role=checkbox])]:pr-0 hover:bg-primary-800 w-[100px]"
                 >
                   Invoice
                 </th>
                 <th
-                  class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 border-0 border-b border-border/20"
+                  class="h-12 p-4 text-left align-middle font-medium text-foreground/70 [&:has([role=checkbox])]:pr-0 hover:bg-primary-800"
                 >
                   Status
                 </th>
                 <th
-                  class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 border-0 border-b border-border/20"
+                  class="h-12 p-4 text-left align-middle font-medium text-foreground/70 [&:has([role=checkbox])]:pr-0 hover:bg-primary-800"
                 >
                   Method
                 </th>
                 <th
-                  class="h-12 px-4 align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 border-0 border-b border-border/20 text-right"
+                  class="h-12 p-4 align-middle font-medium text-foreground/70 [&:has([role=checkbox])]:pr-0 hover:bg-primary-800 text-right"
                 >
                   Amount
                 </th>
@@ -85,44 +87,44 @@ describe('Table', () => {
               class="[&_tr:last-child]:border-0"
             >
               <tr
-                class="border-b border-border/20 transition-colors hover:bg-primary/10 data-[state=selected]:bg-muted"
+                class="border-b border-primary/20 transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
               >
                 <td
-                  class="py-3 align-middle [&:has([role=checkbox])]:pr-0 font-medium"
+                  class="p-4 align-middle [&:has([role=checkbox])]:pr-0 font-medium"
                 >
                   INV001
                 </td>
                 <td
-                  class="py-3 align-middle [&:has([role=checkbox])]:pr-0"
+                  class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
                 >
                   Paid
                 </td>
                 <td
-                  class="py-3 align-middle [&:has([role=checkbox])]:pr-0"
+                  class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
                 >
                   $250.00
                 </td>
                 <td
-                  class="py-3 align-middle [&:has([role=checkbox])]:pr-0 text-right"
+                  class="p-4 align-middle [&:has([role=checkbox])]:pr-0 text-right"
                 >
                   Credit Card
                 </td>
               </tr>
             </tbody>
             <tfoot
-              class="border-t border-border/20 bg-primary/10 font-medium [&>tr]:last:border-b-0"
+              class="bg-primary font-medium text-primary-foreground"
             >
               <tr
-                class="border-b border-border/20 transition-colors hover:bg-primary/10 data-[state=selected]:bg-muted"
+                class="border-b border-primary/20 transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
               >
                 <td
-                  class="py-3 align-middle [&:has([role=checkbox])]:pr-0"
+                  class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
                   colspan="3"
                 >
                   Total
                 </td>
                 <td
-                  class="py-3 align-middle [&:has([role=checkbox])]:pr-0 text-right"
+                  class="p-4 align-middle [&:has([role=checkbox])]:pr-0 text-right"
                 >
                   $2,500.00
                 </td>

--- a/packages/1ui/src/components/Table/Table.tsx
+++ b/packages/1ui/src/components/Table/Table.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
 
-import { cn } from '../../styles'
+import { cn } from 'styles/utils'
 
 const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="w-full overflow-auto">
     <table
       ref={ref}
-      className={cn('w-full caption-bottom text-base', className)}
+      className={cn('w-full caption-bottom text-sm', className)}
       {...props}
     />
   </div>
@@ -20,7 +20,7 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={className} {...props} />
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
 ))
 TableHeader.displayName = 'TableHeader'
 
@@ -42,10 +42,7 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
-    className={cn(
-      'border-t border-border/20 bg-primary/10 font-medium [&>tr]:last:border-b-0',
-      className,
-    )}
+    className={cn('bg-primary font-medium text-primary-foreground', className)}
     {...props}
   />
 ))
@@ -58,7 +55,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      'border-b border-border/20 transition-colors hover:bg-primary/10 data-[state=selected]:bg-muted',
+      'border-b border-primary/20 transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
       className,
     )}
     {...props}
@@ -73,7 +70,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 border-0 border-b border-border/20',
+      'h-12 p-4 text-left align-middle font-medium text-foreground/70 [&:has([role=checkbox])]:pr-0 hover:bg-primary-800',
       className,
     )}
     {...props}
@@ -87,7 +84,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn('py-3 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
     {...props}
   />
 ))
@@ -99,7 +96,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn('my-3 text-sm text-muted-foreground', className)}
+    className={cn('mt-4 text-sm text-foreground/70', className)}
     {...props}
   />
 ))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@radix-ui/react-scroll-area':
         specifier: ^1.1.0
         version: 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@remix-run/node':
         specifier: ^2.9.2
         version: 2.9.2(typescript@5.4.5)
@@ -22233,7 +22236,7 @@ snapshots:
   '@storybook/components@8.1.7(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.1)(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.1)(react@18.3.1)
       '@storybook/client-logger': 8.1.7
       '@storybook/csf': 0.1.8
       '@storybook/global': 5.0.0


### PR DESCRIPTION
## Affected Packages

Apps

- [X] data populator
- [ ] portal
- [ ] template

Packages

- [X] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview
This PR low-lift polishes up main page of data-populator.  It includes a refactor of tabs so all user forms are encapsulated into a tab card, separated from the table so it can always be editted, updated.

I refrained from updating any business logic.  The only business logic change is how loadCSV is triggered when a new CSV is uploaded.

* Refactor tabs
* Restructure & polish UI

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [X] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
