### PR TITLE
ENG-4447 fix(portal): fix vault_id is null after identity creation

### DIFF
--- a/apps/portal/app/components/create-identity/create-identity-form.tsx
+++ b/apps/portal/app/components/create-identity/create-identity-form.tsx
@@ -316,9 +316,6 @@ export function IdentityForm({
             data: receipt?.logs[0].data,
             topics: receipt?.logs[0].topics,
           })
-
-          console.log('decodedLog', decodedLog)
-
           const topics = decodedLog as unknown as {
             eventName: string
             args: { vaultId: string }

--- a/apps/portal/app/components/create-identity/create-identity-form.tsx
+++ b/apps/portal/app/components/create-identity/create-identity-form.tsx
@@ -59,7 +59,7 @@ import {
   TransactionSuccessAction,
   TransactionSuccessActionType,
 } from 'app/types'
-import { parseUnits, toHex } from 'viem'
+import { decodeEventLog, parseUnits, toHex } from 'viem'
 import { useAccount, usePublicClient, useWalletClient } from 'wagmi'
 
 interface IdentityFormProps {
@@ -108,6 +108,7 @@ export function IdentityForm({
   )
   const [imageUploadError, setImageUploadError] = useState<string | null>(null)
   const [initialDeposit, setInitialDeposit] = useState<string>('')
+  const [vaultId, setVaultId] = useState<string | undefined>(undefined)
   const [transactionResponseData, setTransactionResponseData] =
     useState<IdentityPresenter | null>(null)
 
@@ -310,6 +311,20 @@ export function IdentityForm({
           const receipt = await publicClient.waitForTransactionReceipt({
             hash: txHash,
           })
+          const decodedLog = decodeEventLog({
+            abi: multivaultAbi,
+            data: receipt?.logs[0].data,
+            topics: receipt?.logs[0].topics,
+          })
+
+          console.log('decodedLog', decodedLog)
+
+          const topics = decodedLog as unknown as {
+            eventName: string
+            args: { vaultId: string }
+          }
+
+          setVaultId(topics.args.vaultId.toString())
           dispatch({
             type: 'TRANSACTION_COMPLETE',
             txHash,
@@ -777,9 +792,7 @@ export function IdentityForm({
                     className="mt-auto w-40"
                     onClick={() => {
                       if (successAction === TransactionSuccessAction.VIEW) {
-                        navigate(
-                          `${PATHS.IDENTITY}/${transactionResponseData.vault_id}`,
-                        )
+                        navigate(`${PATHS.IDENTITY}/${vaultId}`)
                       }
                       handleClose()
                     }}


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Fixed an issue where vault_id was being passed as null into the completion screen when creating an identity which was causing the 'View Identity' button to navigate to a bad route.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
