### PR TITLE
ENG-4696 fix(portal): increase maxLength on Trunctacular in ProfileCard

### DIFF
--- a/packages/1ui/src/components/ProfileCard/ProfileCard.tsx
+++ b/packages/1ui/src/components/ProfileCard/ProfileCard.tsx
@@ -107,7 +107,7 @@ const ProfileCard = ({
               weight="medium"
               className="text-primary-300 pt-2.5 whitespace-pre-wrap"
             >
-              <Trunctacular value={bio} maxStringLength={266} />
+              <Trunctacular value={bio} maxStringLength={512} />
             </Text>
           </div>
         )}


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Increased the maxLength in the ProfileCard component to match the max chars now allowed in an identities description. When it was < the max chars, it was creating some weird styling issues.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
