### PR TITLE
ENG-4704 fix(portal,1ui): refine gradients in claim and identity row

### DIFF
--- a/apps/portal/app/components/list/activity.tsx
+++ b/apps/portal/app/components/list/activity.tsx
@@ -25,7 +25,6 @@ import {
 } from '@0xintuition/api'
 
 import RemixLink from '@components/remix-link'
-import { stakeModalAtom } from '@lib/state/store'
 import {
   formatBalance,
   getAtomDescription,
@@ -39,7 +38,6 @@ import { Link } from '@remix-run/react'
 import { BLOCK_EXPLORER_URL, PATHS } from 'app/consts'
 import { PaginationType } from 'app/types/pagination'
 import { formatDistance } from 'date-fns'
-import { useSetAtom } from 'jotai'
 
 import { List } from './list'
 
@@ -73,11 +71,13 @@ export function ActivityList({
       enableSearch={false}
       enableSort={false}
     >
-      {activities.map((activity) => (
+      {activities.map((activity, index) => (
         <ActivityItem
           key={activity.id}
           activity={activity}
           eventMessages={eventMessages}
+          index={index}
+          totalItems={activities.length}
         />
       ))}
     </List>
@@ -96,9 +96,13 @@ type EventMessages = {
 function ActivityItem({
   activity,
   eventMessages,
+  index,
+  totalItems,
 }: {
   activity: ActivityPresenter
   eventMessages: EventMessages
+  index: number
+  totalItems: number
 }) {
   const eventMessage = eventMessages[activity.event_type as keyof EventMessages]
   const isRedeemEvent = activity.event_type.startsWith('redeem')
@@ -112,14 +116,12 @@ function ActivityItem({
       : eventMessage.toString()
     : ''
 
-  const setStakeModalActive = useSetAtom(stakeModalAtom)
-
   return (
     <div
       key={activity.id}
-      className={`bg-background rounded-xl mb-6 last:mb-0 flex flex-col w-full max-sm:p-3`}
+      className="grow shrink basis-0 self-stretch bg-background first:border-t-px first:rounded-t-xl last:rounded-b-xl theme-border border-t-0 flex-col justify-start inline-flex"
     >
-      <div className="flex flex-row items-center py-3 justify-between min-w-full max-md:flex-col max-md:gap-3">
+      <div className="flex flex-row items-center px-4 py-3 justify-between min-w-full max-md:flex-col max-md:gap-3">
         <div className="flex flex-row items-center gap-2 max-md:flex-col">
           <HoverCard openDelay={150} closeDelay={150}>
             <HoverCardTrigger asChild>
@@ -221,17 +223,9 @@ function ActivityItem({
                 value: tag.num_tagged_identities,
               })) ?? undefined
             }
-            onStakeClick={() =>
-              setStakeModalActive((prevState) => ({
-                ...prevState,
-                mode: 'deposit',
-                modalType: 'identity',
-                isOpen: true,
-                identity: activity.identity ?? undefined,
-                vaultId: activity.identity?.vault_id ?? null,
-              }))
-            }
-            className="w-full hover:bg-transparent"
+            isFirst={index === 0}
+            isLast={index === totalItems - 1}
+            className="border-none rounded-none"
           />
         )}
         {activity.claim && (
@@ -249,29 +243,9 @@ function ActivityItem({
                   ? ClaimPosition.claimAgainst
                   : undefined
             }
-            onStakeForClick={() =>
-              setStakeModalActive((prevState) => ({
-                ...prevState,
-                mode: 'deposit',
-                modalType: 'claim',
-                direction: ClaimPosition.claimFor,
-                isOpen: true,
-                claim: activity.claim ?? undefined,
-                vaultId: activity.claim?.vault_id ?? null,
-              }))
-            }
-            onStakeAgainstClick={() =>
-              setStakeModalActive((prevState) => ({
-                ...prevState,
-                mode: 'deposit',
-                modalType: 'claim',
-                direction: ClaimPosition.claimAgainst,
-                isOpen: true,
-                claim: activity.claim ?? undefined,
-                vaultId: activity.claim?.counter_vault_id ?? null,
-              }))
-            }
-            className="w-full hover:bg-transparent"
+            isFirst={index === 0}
+            isLast={index === totalItems - 1}
+            className="border-none rounded-none"
           >
             <Link to={getClaimUrl(activity.claim.vault_id)} prefetch="intent">
               <Claim

--- a/apps/portal/app/components/stake/stake-form.tsx
+++ b/apps/portal/app/components/stake/stake-form.tsx
@@ -152,14 +152,14 @@ export default function StakeForm({
             </div>
             <div className="w-96 mx-auto">
               <Tabs defaultValue={mode}>
-                <TabsList className="relative overflow-hidden">
+                <TabsList className="relative overflow-visible">
                   <div
-                    className={`absolute mx-auto inset-0 bg-[radial-gradient(ellipse_at_bottom_center,_var(--tw-gradient-stops))] ${
+                    className={`absolute mx-auto overflow-visible inset-0 bg-[radial-gradient(70%_150%_at_50%_100%,_var(--tw-gradient-stops))] ${
                       direction === 'for'
-                        ? 'from-for/50 via-for/10'
+                        ? 'from-for/50 via-for/20 via-for/10 via-for/5'
                         : direction === 'against'
-                          ? 'from-against/50 via-against/10'
-                          : 'from-primary/20 via-primary/5'
+                          ? 'from-against/50 via-against/20 via-against/10 via-against/5'
+                          : 'from-primary/20 via-primary/10 via-primary/5 via-primary/2'
                     } to-transparent`}
                   />
                   <TabsTrigger

--- a/packages/1ui/src/components/ClaimRow/ClaimRow.spec.tsx
+++ b/packages/1ui/src/components/ClaimRow/ClaimRow.spec.tsx
@@ -26,10 +26,11 @@ describe('ClaimRow', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
       <DocumentFragment>
         <div
-          class="w-full flex flex-col items-center bg-primary/5 border border-border/10 rounded-t-xl rounded-b-xl"
+          class="w-full flex flex-col items-center bg-primary/5 border border-border/10 overflow-hidden rounded-t-xl rounded-b-xl"
         >
           <div
             class="w-full flex justify-between items-center p-4 rounded-t-xl"
+            style="background-image: none;"
           >
             <div
               class="flex items-center gap-1"
@@ -252,10 +253,10 @@ describe('ClaimRow', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
       <DocumentFragment>
         <div
-          class="w-full flex flex-col items-center bg-primary/5 border border-border/10 rounded-t-xl rounded-b-xl"
+          class="w-full flex flex-col items-center bg-primary/5 border border-border/10 overflow-hidden rounded-t-xl rounded-b-xl"
         >
           <div
-            class="w-full flex justify-between items-center p-4 rounded-t-xl bg-gradient-to-r from-transparent to-for"
+            class="w-full flex justify-between items-center p-4 rounded-t-xl"
           >
             <div
               class="flex items-center gap-1"
@@ -451,7 +452,7 @@ describe('ClaimRow', () => {
             </div>
           </div>
           <div
-            class="flex flex-row justify-end px-4 py-0.5 w-full items-center gap-1.5 h-9 bg-for/10 text-for"
+            class="flex flex-row justify-end px-4 py-0.5 w-full items-center gap-1.5 h-9 rounded-b-xl"
           >
             <svg
               class="h-4 w-4"

--- a/packages/1ui/src/components/ClaimRow/ClaimRow.tsx
+++ b/packages/1ui/src/components/ClaimRow/ClaimRow.tsx
@@ -23,8 +23,8 @@ export interface ClaimRowProps extends React.HTMLAttributes<HTMLDivElement> {
   currency?: CurrencyType
   userPosition?: string
   positionDirection?: ClaimPositionType
-  onStakeForClick: () => void
-  onStakeAgainstClick: () => void
+  onStakeForClick?: () => void
+  onStakeAgainstClick?: () => void
   isFirst?: boolean
   isLast?: boolean
 }
@@ -79,22 +79,26 @@ const ClaimRow = ({
             numPositionsFor={numPositionsFor}
             numPositionsAgainst={numPositionsAgainst}
           />
-          <StakeButton
-            variant={StakeButtonVariant.claimFor}
-            numPositions={numPositionsFor}
-            direction={ClaimPosition.claimFor}
-            positionDirection={positionDirection}
-            disabled={positionDirection === ClaimPosition.claimAgainst}
-            onClick={onStakeForClick}
-          />
-          <StakeButton
-            variant={StakeButtonVariant.claimAgainst}
-            numPositions={numPositionsAgainst}
-            direction={ClaimPosition.claimAgainst}
-            positionDirection={positionDirection}
-            disabled={positionDirection === ClaimPosition.claimFor}
-            onClick={onStakeAgainstClick}
-          />
+          {!!onStakeForClick && !!onStakeAgainstClick && (
+            <>
+              <StakeButton
+                variant={StakeButtonVariant.claimFor}
+                numPositions={numPositionsFor}
+                direction={ClaimPosition.claimFor}
+                positionDirection={positionDirection}
+                disabled={positionDirection === ClaimPosition.claimAgainst}
+                onClick={onStakeForClick}
+              />
+              <StakeButton
+                variant={StakeButtonVariant.claimAgainst}
+                numPositions={numPositionsAgainst}
+                direction={ClaimPosition.claimAgainst}
+                positionDirection={positionDirection}
+                disabled={positionDirection === ClaimPosition.claimFor}
+                onClick={onStakeAgainstClick}
+              />
+            </>
+          )}
           <ContextMenu>
             <ContextMenuTrigger disabled>
               <Button

--- a/packages/1ui/src/components/ClaimRow/ClaimRow.tsx
+++ b/packages/1ui/src/components/ClaimRow/ClaimRow.tsx
@@ -48,21 +48,24 @@ const ClaimRow = ({
   return (
     <div
       className={cn(
-        `w-full flex flex-col items-center bg-primary/5 border border-border/10`,
+        `w-full flex flex-col items-center bg-primary/5 border border-border/10 overflow-hidden`,
         isFirst && 'rounded-t-xl',
         isLast && 'rounded-b-xl',
         className,
       )}
     >
       <div
+        style={{
+          backgroundImage:
+            userPosition && userPosition !== '0'
+              ? positionDirection === ClaimPosition.claimFor
+                ? 'linear-gradient(to right, transparent, rgba(0, 111, 232, 0.5))'
+                : 'linear-gradient(to right, transparent, rgba(255, 149, 0, 0.5))'
+              : 'none',
+        }}
         className={cn(
           `w-full flex justify-between items-center p-4`,
           isFirst && 'rounded-t-xl',
-          userPosition &&
-            userPosition !== '0' &&
-            (positionDirection === ClaimPosition.claimFor
-              ? 'bg-gradient-to-r from-transparent to-for'
-              : 'bg-gradient-to-r from-transparent to-against'),
         )}
       >
         <div className="flex items-center gap-1">{children}</div>
@@ -115,11 +118,15 @@ const ClaimRow = ({
       </div>
       {userPosition && userPosition !== '0' && (
         <div
+          style={{
+            backgroundImage:
+              positionDirection === ClaimPosition.claimFor
+                ? 'linear-gradient(to right, transparent, rgba(0, 111, 232, 0.2))'
+                : 'linear-gradient(to right, transparent, rgba(255, 149, 0, 0.2))',
+          }}
           className={cn(
             `flex flex-row justify-end px-4 py-0.5 w-full items-center gap-1.5 h-9`,
-            positionDirection === ClaimPosition.claimFor
-              ? 'bg-for/10 text-for'
-              : 'bg-against/10 text-against',
+            isLast && 'rounded-b-xl',
           )}
         >
           <Icon name={IconName.arrowUp} className="h-4 w-4" />

--- a/packages/1ui/src/components/IdentityRow/IdentityRow.spec.tsx
+++ b/packages/1ui/src/components/IdentityRow/IdentityRow.spec.tsx
@@ -202,7 +202,7 @@ describe('IdentityRow', () => {
                 </div>
               </div>
               <button
-                class="flex justify-center items-center text-sm font-medium border aria-disabled:text-muted-foreground aria-disabled:border-muted aria-disabled:pointer-events-none bg-gradient-to-b from-transparent to-transparent hover:text-primary aria-disabled:bg-transparent aria-selected:primary-gradient-subtle aria-selected:border-primary/10 shadow-md-subtle max-sm:py-2 max-sm:text-base py-0.5 px-2.5 gap-1.5 h-9 w-16 rounded-xl disabled:bg-primary/5 disabled:border-primary/20 disabled:text-primary/20 bg-primary/10 border-primary/30 hover:bg-primary/20 hover:border-primary/60 text-secondary"
+                class="flex justify-center items-center text-sm font-medium border aria-disabled:text-muted-foreground aria-disabled:border-muted aria-disabled:pointer-events-none bg-gradient-to-b from-transparent to-transparent hover:text-primary aria-disabled:bg-transparent aria-selected:primary-gradient-subtle aria-selected:border-primary/10 shadow-md-subtle max-sm:py-2 max-sm:text-base py-0.5 px-2.5 gap-1.5 h-9 w-16 rounded-xl disabled:bg-primary/5 disabled:border-primary/20 disabled:text-primary/20 hover:bg-primary/20 text-secondary bg-primary/20 border-primary/60 hover:border-primary/60"
               >
                 <svg
                   class="h-4 w-4"

--- a/packages/1ui/src/components/IdentityRow/IdentityRow.tsx
+++ b/packages/1ui/src/components/IdentityRow/IdentityRow.tsx
@@ -37,7 +37,7 @@ export interface IdentityRowProps extends React.HTMLAttributes<HTMLDivElement> {
   numPositions: number
   tags?: TagWithValueProps[]
   userPosition?: string
-  onStakeClick: () => void
+  onStakeClick?: () => void
   isFirst?: boolean
   isLast?: boolean
 }
@@ -111,11 +111,13 @@ const IdentityRow = ({
 
         <div className="flex items-center gap-3">
           <StakeTVL totalTVL={+totalTVL} currency={currency} />
-          <StakeButton
-            numPositions={numPositions}
-            userPosition={!!userPosition && userPosition !== '0'}
-            onClick={onStakeClick}
-          />
+          {!!onStakeClick && (
+            <StakeButton
+              numPositions={numPositions}
+              userPosition={!!userPosition && userPosition !== '0'}
+              onClick={onStakeClick}
+            />
+          )}
           <ContextMenu>
             <ContextMenuTrigger disabled>
               <Button

--- a/packages/1ui/src/components/IdentityRow/IdentityRow.tsx
+++ b/packages/1ui/src/components/IdentityRow/IdentityRow.tsx
@@ -111,7 +111,11 @@ const IdentityRow = ({
 
         <div className="flex items-center gap-3">
           <StakeTVL totalTVL={+totalTVL} currency={currency} />
-          <StakeButton numPositions={numPositions} onClick={onStakeClick} />
+          <StakeButton
+            numPositions={numPositions}
+            userPosition={!!userPosition && userPosition !== '0'}
+            onClick={onStakeClick}
+          />
           <ContextMenu>
             <ContextMenuTrigger disabled>
               <Button

--- a/packages/1ui/src/components/StakeButton/StakeButton.tsx
+++ b/packages/1ui/src/components/StakeButton/StakeButton.tsx
@@ -25,6 +25,9 @@ const stakeButtonVariants = cva(
         [StakeButtonVariant.claimAgainst]:
           'bg-against/10 border-against/30 hover:bg-against hover:border-against/50 text-against',
       },
+      userPosition: {
+        true: 'bg-primary/20 border-primary/60 hover:border-primary/60',
+      },
       positionDirection: {
         [ClaimPosition.claimFor]:
           'text-primary bg-for border-border/30 hover:border-border/30',
@@ -43,6 +46,7 @@ export interface StakeButtonProps
     VariantProps<typeof stakeButtonVariants> {
   numPositions: number
   direction?: ClaimPositionType
+  userPosition?: boolean
   positionDirection?: ClaimPositionType
   className?: string
   onClick: () => void
@@ -54,6 +58,7 @@ const StakeButton = React.forwardRef<HTMLButtonElement, StakeButtonProps>(
       className,
       variant,
       numPositions,
+      userPosition,
       direction,
       positionDirection,
       onClick,
@@ -67,6 +72,7 @@ const StakeButton = React.forwardRef<HTMLButtonElement, StakeButtonProps>(
         className={cn(
           stakeButtonVariants({
             variant,
+            userPosition,
             positionDirection,
             className,
           }),


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [x] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Improved the gradient and color on ClaimRow and IdentityRow for better visibility
- Improved visibility of StakeButton on IdentityRow when a user has a position
- Improved the gradient on the TabList in StakeForm

## Screen Captures

![image](https://github.com/user-attachments/assets/a32f52d0-7360-4991-bd08-d0b43334a0c8)
![image](https://github.com/user-attachments/assets/0e683b08-58b7-447b-8c2a-0dbb0ab1b6b0)
![image](https://github.com/user-attachments/assets/66eb6ab5-8753-41d7-9839-b3a4d7616a19)


## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
