### PR TITLE
ENG-4713 fix(portal,1ui): remove staking from identity rows on list detail

### DIFF
--- a/apps/portal/app/components/list/tags.tsx
+++ b/apps/portal/app/components/list/tags.tsx
@@ -10,7 +10,7 @@ import {
 import { ClaimPresenter, SortColumn } from '@0xintuition/api'
 
 import { ListHeader } from '@components/list/list-header'
-import { saveListModalAtom, stakeModalAtom } from '@lib/state/store'
+import { saveListModalAtom } from '@lib/state/store'
 import {
   formatBalance,
   getAtomDescription,
@@ -51,7 +51,6 @@ export function TagsList({
   ]
 
   const setSaveListModalActive = useSetAtom(saveListModalAtom)
-  const setStakeModalActive = useSetAtom(stakeModalAtom)
 
   return (
     <>
@@ -71,7 +70,7 @@ export function TagsList({
             ]}
           />
         )}
-        {claims.map((claim) => {
+        {claims.map((claim, index) => {
           const identity = claim.subject
           // TODO: ENG-0000: Show filled save if user has a position on claim
           // TODO: ENG-0000: Show only user position if user is on filtering by you.
@@ -79,9 +78,9 @@ export function TagsList({
           return (
             <div
               key={claim.claim_id}
-              className={`grow shrink basis-0 self-stretch bg-background first:border-t-px first:rounded-t-xl last:rounded-b-xl theme-border border-t-0 flex-col justify-start hover:bg-secondary/10 transition-colors duration-200 items-start gap-5 inline-flex`}
+              className={`grow shrink basis-0 self-stretch bg-primary/5 first:border-t-px first:rounded-t-xl last:rounded-b-xl theme-border border-t-0 flex-col justify-start items-start inline-flex gap-8`}
             >
-              <div className="flex flex-row gap-2 w-full">
+              <div className="flex flex-row gap-2 w-full pr-4">
                 <IdentityRow
                   variant={
                     claim.subject?.is_user ? Identity.user : Identity.nonUser
@@ -105,17 +104,10 @@ export function TagsList({
                   numPositions={claim?.num_positions || 0}
                   link={getAtomLink(identity, readOnly)}
                   ipfsLink={getAtomIpfsLink(identity)}
-                  onStakeClick={() =>
-                    setStakeModalActive((prevState) => ({
-                      ...prevState,
-                      mode: 'deposit',
-                      modalType: 'identity',
-                      isOpen: true,
-                      identity: identity ?? undefined,
-                      vaultId: identity?.vault_id ?? null,
-                    }))
-                  }
-                  className={`w-full hover:bg-transparent ${readOnly ? '' : 'pr-0'}`}
+                  className={`w-full border-none rounded-none bg-transparent ${readOnly ? '' : 'pr-0'}`}
+                  isFirst={!enableHeader && index === 0}
+                  isLast={index === claims.length - 1}
+                  hideContextMenu={true}
                 />
                 {readOnly === false && (
                   <Button

--- a/apps/portal/app/components/lists/featured-lists-carousel.tsx
+++ b/apps/portal/app/components/lists/featured-lists-carousel.tsx
@@ -114,7 +114,7 @@ export function FeaturedListCarousel({ lists }: FeaturedListCarouselProps) {
               <Link
                 to={getListUrl(list.vault_id, '')}
                 prefetch="intent"
-                className="block"
+                className="block md:w-auto mx-auto max-w-[400px] md:max-w-none"
                 onClick={(e) => e.stopPropagation()}
               >
                 <FeaturedListCard

--- a/apps/portal/app/components/lists/featured-lists-carousel.tsx
+++ b/apps/portal/app/components/lists/featured-lists-carousel.tsx
@@ -106,7 +106,7 @@ export function FeaturedListCarousel({ lists }: FeaturedListCarouselProps) {
   }, [emblaApi])
 
   return (
-    <div className="relative max-w-[400px] md:max-w-none">
+    <div className="relative w-full">
       <div className="overflow-hidden" ref={emblaRef}>
         <div className="flex gap-6">
           {lists.map((list) => (
@@ -114,7 +114,7 @@ export function FeaturedListCarousel({ lists }: FeaturedListCarouselProps) {
               <Link
                 to={getListUrl(list.vault_id, '')}
                 prefetch="intent"
-                className="block md:w-auto mx-auto max-w-[400px] md:max-w-none"
+                className="block"
                 onClick={(e) => e.stopPropagation()}
               >
                 <FeaturedListCard

--- a/apps/portal/app/components/lists/featured-lists-carousel.tsx
+++ b/apps/portal/app/components/lists/featured-lists-carousel.tsx
@@ -106,7 +106,7 @@ export function FeaturedListCarousel({ lists }: FeaturedListCarouselProps) {
   }, [emblaApi])
 
   return (
-    <div className="relative w-full">
+    <div className="relative max-w-[400px] md:max-w-none">
       <div className="overflow-hidden" ref={emblaRef}>
         <div className="flex gap-6">
           {lists.map((list) => (

--- a/packages/1ui/src/components/IdentityRow/IdentityRow.tsx
+++ b/packages/1ui/src/components/IdentityRow/IdentityRow.tsx
@@ -43,6 +43,7 @@ export interface IdentityRowProps extends React.HTMLAttributes<HTMLDivElement> {
   onStakeClick?: () => void
   isFirst?: boolean
   isLast?: boolean
+  hideContextMenu?: boolean
 }
 
 const IdentityRow = ({
@@ -61,6 +62,7 @@ const IdentityRow = ({
   onStakeClick,
   isFirst = true,
   isLast = true,
+  hideContextMenu = false,
 }: IdentityRowProps) => {
   const { isMobileView } = useSidebarLayoutContext()
 
@@ -115,21 +117,23 @@ const IdentityRow = ({
               </div>
             </HoverCardContent>
           </HoverCard>
-          <ContextMenu>
-            <ContextMenuTrigger className="sm:hidden ml-auto">
-              <Button variant={ButtonVariant.text} size={ButtonSize.icon}>
-                <Icon
-                  name={IconName.context}
-                  className="text-secondary/70 h-4 w-4"
-                />
-              </Button>
-            </ContextMenuTrigger>
-            <ContextMenuContent>
-              <ContextMenuItem>Profile</ContextMenuItem>
-              <ContextMenuItem>Settings</ContextMenuItem>
-              <ContextMenuItem>Logout</ContextMenuItem>
-            </ContextMenuContent>
-          </ContextMenu>
+          {!hideContextMenu && (
+            <ContextMenu>
+              <ContextMenuTrigger className="sm:hidden ml-auto">
+                <Button variant={ButtonVariant.text} size={ButtonSize.icon}>
+                  <Icon
+                    name={IconName.context}
+                    className="text-secondary/70 h-4 w-4"
+                  />
+                </Button>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem>Profile</ContextMenuItem>
+                <ContextMenuItem>Settings</ContextMenuItem>
+                <ContextMenuItem>Logout</ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
+          )}
         </div>
         <Separator className="md:hidden" />
         <div className="flex items-center gap-3 max-sm:justify-between max-sm:w-full">
@@ -142,25 +146,27 @@ const IdentityRow = ({
               className="w-full"
             />
           )}
-          <ContextMenu>
-            <ContextMenuTrigger disabled className="max-sm:hidden">
-              <Button
-                variant={ButtonVariant.text}
-                size={ButtonSize.icon}
-                disabled
-              >
-                <Icon
-                  name={IconName.context}
-                  className="text-secondary/70 h-4 w-4"
-                />
-              </Button>
-            </ContextMenuTrigger>
-            <ContextMenuContent>
-              <ContextMenuItem>Profile</ContextMenuItem>
-              <ContextMenuItem>Settings</ContextMenuItem>
-              <ContextMenuItem>Logout</ContextMenuItem>
-            </ContextMenuContent>
-          </ContextMenu>
+          {!hideContextMenu && (
+            <ContextMenu>
+              <ContextMenuTrigger disabled className="max-sm:hidden">
+                <Button
+                  variant={ButtonVariant.text}
+                  size={ButtonSize.icon}
+                  disabled
+                >
+                  <Icon
+                    name={IconName.context}
+                    className="text-secondary/70 h-4 w-4"
+                  />
+                </Button>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem>Profile</ContextMenuItem>
+                <ContextMenuItem>Settings</ContextMenuItem>
+                <ContextMenuItem>Logout</ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
+          )}
         </div>
       </div>
       {userPosition && userPosition !== '0' && (


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [x] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

** This was branched off of `vital/eng-4712-responsiveness-fixes`. Make sure that gets merged in first, and rebase this off main before merging** 

Removes the staking buttons and context menu from IdentityRow on List Detail route. Staking was removed because it doesn't make sense in this context, you'd be staking on the subject identity of the has tag claim, and we already have the save list functionality baked into this. Removed the context button because it lives inside of IdentityRow and clashes with the save list button. Should revisit when we get to the list and detail page rework and create a specific row component for list details.

## Screen Captures

![image](https://github.com/user-attachments/assets/f5b5567c-af59-4248-88b0-1688cac59bc4)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
