### PR TITLE
ENG-4730 fix(1ui): format large numbers in StakeButton

### DIFF
--- a/packages/1ui/src/components/StakeButton/StakeButton.tsx
+++ b/packages/1ui/src/components/StakeButton/StakeButton.tsx
@@ -6,6 +6,7 @@ import { Icon, IconName } from 'components/Icon'
 import { Text, TextVariant } from 'components/Text'
 import { cn } from 'styles'
 import { ClaimPosition, ClaimPositionType } from 'types'
+import { formatNumber } from 'utils'
 
 export const StakeButtonVariant = {
   identity: 'identity',
@@ -90,7 +91,7 @@ const StakeButton = React.forwardRef<HTMLButtonElement, StakeButtonProps>(
           className="h-4 w-4"
         />
         <Text variant={TextVariant.caption} className="text-inherit">
-          {numPositions}
+          {formatNumber(numPositions)}
         </Text>
       </Button>
     )

--- a/packages/1ui/src/utils/number.spec.ts
+++ b/packages/1ui/src/utils/number.spec.ts
@@ -5,14 +5,14 @@ import { formatNumber } from './number'
 describe('formatNumber', () => {
   it('should format numbers greater than or equal to 1,000,000 as M', () => {
     expect(formatNumber(1000000)).toBe('1M')
-    expect(formatNumber(2500000)).toBe('3M')
+    expect(formatNumber(2500000)).toBe('2.5M')
     expect(formatNumber(1999999)).toBe('2M')
   })
 
-  it('should format numbers greater than or equal to 1,000 and less than 1,000,000 as k', () => {
-    expect(formatNumber(1000)).toBe('1k')
-    expect(formatNumber(1500)).toBe('2k')
-    expect(formatNumber(999999)).toBe('1000k')
+  it('should format numbers greater than or equal to 1,000 and less than 1,000,000 as K', () => {
+    expect(formatNumber(1000)).toBe('1K')
+    expect(formatNumber(1500)).toBe('1.5K')
+    expect(formatNumber(999999)).toBe('1000K')
   })
 
   it('should return the number as a string if it is less than 1,000', () => {
@@ -22,7 +22,7 @@ describe('formatNumber', () => {
   })
 
   it('should handle edge cases correctly', () => {
-    expect(formatNumber(999999)).toBe('1000k')
+    expect(formatNumber(999999)).toBe('1000K')
     expect(formatNumber(1000000)).toBe('1M')
   })
 })

--- a/packages/1ui/src/utils/number.ts
+++ b/packages/1ui/src/utils/number.ts
@@ -8,7 +8,7 @@ export const formatNumber = (value: number): string => {
   } else if (value >= 1000) {
     const thousands = value / 1000
     return thousands >= 100
-      ? `${Math.round(thousands)}k`
+      ? `${Math.round(thousands)}K`
       : `${thousands.toFixed(1).replace(/\.?0+$/, '')}K`
   }
   return value.toString()

--- a/packages/1ui/src/utils/number.ts
+++ b/packages/1ui/src/utils/number.ts
@@ -1,9 +1,15 @@
 // Utility function to format large numbers
 export const formatNumber = (value: number): string => {
   if (value >= 1000000) {
-    return `${Math.round(value / 1000000)}M`
+    const millions = value / 1000000
+    return millions >= 100
+      ? `${Math.round(millions)}M`
+      : `${millions.toFixed(1).replace(/\.?0+$/, '')}M`
   } else if (value >= 1000) {
-    return `${Math.round(value / 1000)}k`
+    const thousands = value / 1000
+    return thousands >= 100
+      ? `${Math.round(thousands)}k`
+      : `${thousands.toFixed(1).replace(/\.?0+$/, '')}K`
   }
   return value.toString()
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [x] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Formats large numbers down to prevent issues with icon shrinking/overflow in StakeButtons. i.e. 2,330 -> 2.3k 

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
