### PR TITLE
ENG-4732 fix(portal): format numbers on profile overview cards

### DIFF
--- a/apps/portal/app/components/profile/overview-about-header.tsx
+++ b/apps/portal/app/components/profile/overview-about-header.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {
   Button,
   ButtonVariant,
+  formatNumber,
   Icon,
   IconName,
   IdentityTag,
@@ -77,7 +78,9 @@ export function OverviewAboutHeader({
               {variant === 'claims' ? 'Claims' : 'Positions'}
             </Text>
             <Text variant="bodyLarge" weight="medium" className="items-center">
-              {variant === 'claims' ? totalClaims ?? 0 : totalPositions ?? 0}
+              {formatNumber(
+                variant === 'claims' ? totalClaims ?? 0 : totalPositions ?? 0,
+              )}
             </Text>
           </div>
           <div className="flex flex-col max-md:items-center">
@@ -88,7 +91,7 @@ export function OverviewAboutHeader({
             >
               TVL
             </Text>
-            <MonetaryValue value={totalStake} currency="ETH" />
+            <MonetaryValue value={+totalStake.toFixed(2)} currency="ETH" />
           </div>
         </div>
         <div className="flex flex-col items-end justify-end ml-auto max-sm:w-full max-sm:items-center">

--- a/apps/portal/app/components/profile/overview-created-header.tsx
+++ b/apps/portal/app/components/profile/overview-created-header.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {
   Button,
   ButtonVariant,
+  formatNumber,
   Icon,
   IconName,
   Text,
@@ -51,7 +52,7 @@ export function OverviewCreatedHeader({
             weight="medium"
             className="items-center max-sm:items-start"
           >
-            {totalCreated ?? 0}
+            {formatNumber(totalCreated ?? 0)}
           </Text>
         </div>
         <div className="flex flex-col items-end justify-end ml-auto">

--- a/apps/portal/app/components/profile/overview-staking-header.tsx
+++ b/apps/portal/app/components/profile/overview-staking-header.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {
   Button,
   ButtonVariant,
+  formatNumber,
   Icon,
   IconName,
   MonetaryValue,
@@ -54,7 +55,7 @@ export function OverviewStakingHeader({
                 Identities
               </Text>
               <Text variant="bodyLarge" weight="medium">
-                {totalIdentities}
+                {formatNumber(totalIdentities)}
               </Text>
             </div>
             <div className="flex flex-col max-sm:items-center">
@@ -66,7 +67,7 @@ export function OverviewStakingHeader({
                 Claims
               </Text>
               <Text variant="bodyLarge" weight="medium">
-                {totalClaims}
+                {formatNumber(totalClaims)}
               </Text>
             </div>
           </div>
@@ -78,7 +79,7 @@ export function OverviewStakingHeader({
             >
               TVL
             </Text>
-            <MonetaryValue value={totalStake} currency="ETH" />
+            <MonetaryValue value={+totalStake.toFixed(2)} currency="ETH" />
           </div>
         </div>
         <div className="flex">


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Formats long numbers in Profile Overview cards as well as reduces the number of decimals shown for TVL in those cards to 2 to prevent overflow issues.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
