### PR TITLE
ENG-4780 fix(portal): make scrollarea height more responsive in review staking screens

### DIFF
--- a/apps/portal/app/components/stake/stake-review.tsx
+++ b/apps/portal/app/components/stake/stake-review.tsx
@@ -170,7 +170,7 @@ export default function StakeReview({
       : calculateRedeemFees(val, vaultDetails)
 
   return (
-    <ScrollArea className="h-[600px] w-full">
+    <ScrollArea className="h-[calc(100vh-240px)] min-h-[360px] max-h-[600px] w-full">
       <div className="flex flex-col px-10">
         <div className="flex flex-col gap-10">
           <div className="flex flex-col gap-5 items-center justify-center">


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

ScrollArea on staking review screens was overflowing on wider screens < 800px in height. This is a temporary fix for that. We can revisit this when we get back to working on modal standardization.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
