### PR TITLE
ENG-4797 fix(portal): prevent vault details fetch before stake modal is opened

### DIFF
--- a/apps/portal/app/components/stake/stake-modal.tsx
+++ b/apps/portal/app/components/stake/stake-modal.tsx
@@ -81,8 +81,6 @@ export default function StakeModal({
   direction,
   onSuccess,
 }: StakeModalProps) {
-  console.log('claim', claim)
-  console.log('direction', direction)
   const fetchReval = useFetcher()
   const [stakeModalState] = useAtom(stakeModalAtom)
   const { mode, modalType } = stakeModalState
@@ -110,7 +108,7 @@ export default function StakeModal({
   useEffect(() => {
     let isCancelled = false
 
-    if (vaultId !== null) {
+    if (open && vaultId !== null) {
       const finalUrl = `${GET_VAULT_DETAILS_RESOURCE_ROUTE}?contract=${contract}&vaultId=${vaultId}&fetchId=${fetchId}`
       if (!isCancelled) {
         vaultDetailsFetcher.load(finalUrl)


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Overview of the changes in the PR.

## Screen Captures

- Fixes an issue where StakeModal was trying to fetch vault details before it was opened which was causing a 500 because vault_id was undefined.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
