### PR TITLE
ENG-0000 fix(portal): hide duplicate built on base on desktop login route

### DIFF
--- a/apps/portal/app/routes/login.tsx
+++ b/apps/portal/app/routes/login.tsx
@@ -119,7 +119,7 @@ export default function Login() {
           <PrivyLoginButton handleLogin={handleLogin} />
         </div>
         <div className="flex items-center justify-center max-sm:flex-col max-sm:gap-2 max-sm:items-center max-sm:text-center gap-1">
-          <div className="justify-center">
+          <div className="justify-center md:hidden">
             <BuiltOnBase />
           </div>
           <Text variant="body" className="text-secondary-foreground/60">


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

When making the responsive changes in a recent update, we added the "Built on Base" link to the footer on mobile and hid the one in the header. There was no class added to hide the one in the footer on desktop, which this adds.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
