### PR TITLE
ENG-0000 fix(portal): adds logic to app.tsx to clear old domain privy-session

### DIFF
--- a/apps/portal/app/routes/app.tsx
+++ b/apps/portal/app/routes/app.tsx
@@ -7,7 +7,12 @@ import { getIdentityOrPending } from '@lib/services/identities'
 import logger from '@lib/utils/logger'
 import { getMaintenanceMode } from '@lib/utils/maintenance'
 import { invariant } from '@lib/utils/misc'
-import { json, LoaderFunctionArgs, redirect } from '@remix-run/node'
+import {
+  createCookie,
+  json,
+  LoaderFunctionArgs,
+  redirect,
+} from '@remix-run/node'
 import { Outlet, useLoaderData, useLocation } from '@remix-run/react'
 import { fetchWrapper } from '@server/api'
 import { requireUserWallet } from '@server/auth'
@@ -17,8 +22,38 @@ import { PATHS } from 'app/consts'
 import RootLayout from 'app/layouts/root-layout'
 import { Address } from 'viem'
 
+// Create a cookie instance to handle the test cookie
+const privySessionCookie = createCookie('privy-session', {
+  httpOnly: true,
+  secure: true,
+  sameSite: 'strict',
+  path: '/',
+  domain: 'portal.intuition.systems',
+})
+
 export async function loader({ request }: LoaderFunctionArgs) {
   getMaintenanceMode()
+  logger('checking access token in app.tsx')
+
+  // Check if the cookie exists
+  const cookieHeader = request.headers.get('Cookie')
+  logger(`cookieHeader: ${cookieHeader}`)
+  const hasCookie = await privySessionCookie.parse(cookieHeader)
+  logger(`hasCookie: ${hasCookie === true ? 'true' : 'false'}`)
+
+  // Create response headers
+  const headers = new Headers()
+
+  if (hasCookie) {
+    // Set cookie to be deleted if it exists
+    logger('deleting privy-session cookie')
+    headers.append(
+      'Set-Cookie',
+      await privySessionCookie.serialize('', {
+        expires: new Date(0), // Set expiration to past date to delete
+      }),
+    )
+  }
 
   const wallet = await requireUserWallet(request)
   invariant(wallet, 'Unauthorized')
@@ -68,11 +103,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
   // TODO: Figure out why SiteWideBanner has no access to window.ENV values [ENG-3367]
   const featureFlags = getFeatureFlags()
 
-  return json({
-    wallet,
-    userObject,
-    featureFlags,
-  })
+  return json(
+    {
+      wallet,
+      userObject,
+      featureFlags,
+    },
+    {
+      headers, // Include our cookie headers in the response
+    },
+  )
 }
 
 export default function App() {


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds logic to app.tsx to clear old domain `privy-session` cookie

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
