### PR TITLE
ENG-0000 fix(portal): changes httpOnly logic to false and wraps verifyPrivyAccessToken

### DIFF
--- a/apps/portal/app/.server/privy.ts
+++ b/apps/portal/app/.server/privy.ts
@@ -15,14 +15,19 @@ export const verifyPrivyAccessToken = async (
   const privy = getPrivyClient()
   const authToken = getPrivyAccessToken(req)
   if (!authToken) {
-    logger('No privy access token found')
+    logger('No Privy access token found')
     return null
   }
-  const verifiedClaims = await privy.verifyAuthToken(
-    authToken,
-    process.env.PRIVY_VERIFICATION_KEY,
-  )
-  return verifiedClaims
+  try {
+    const verifiedClaims = await privy.verifyAuthToken(
+      authToken,
+      process.env.PRIVY_VERIFICATION_KEY,
+    )
+    return verifiedClaims
+  } catch (error) {
+    logger('Error verifying Privy access token', error)
+    return null
+  }
 }
 
 // takes user privy DID (e.g. authCheck().userId)

--- a/apps/portal/app/routes/app.tsx
+++ b/apps/portal/app/routes/app.tsx
@@ -24,7 +24,7 @@ import { Address } from 'viem'
 
 // Create a cookie instance to handle the test cookie
 const privySessionCookie = createCookie('privy-session', {
-  httpOnly: true,
+  httpOnly: false,
   secure: true,
   sameSite: 'strict',
   path: '/',

--- a/apps/portal/app/routes/app.tsx
+++ b/apps/portal/app/routes/app.tsx
@@ -28,7 +28,7 @@ const privySessionCookie = createCookie('privy-session', {
   secure: true,
   sameSite: 'strict',
   path: '/',
-  domain: 'portal.intuition.systems',
+  domain: '.portal.intuition.systems',
 })
 
 export async function loader({ request }: LoaderFunctionArgs) {


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Updates the cookie check logic to `httpOnly` to `false`
- Wraps the `verifyPrivyAccessToken` in a try/catch block

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
