### PR TITLE
ENG-4803 fix(portal): increase retries to 10 in get claim resource route

### DIFF
--- a/apps/portal/app/routes/resources+/get-claim.tsx
+++ b/apps/portal/app/routes/resources+/get-claim.tsx
@@ -12,7 +12,7 @@ export interface GetClaimLoaderData {
   error?: string
 }
 
-const MAX_RETRIES = 1
+const MAX_RETRIES = 10
 const RETRY_DELAY = 2000 // 2 seconds
 
 export async function loader({ request }: LoaderFunctionArgs) {


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Increases max retries from 1 to 10 in the get claim resource route.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
