### PR TITLE
ENG-4769 feat(portal,graphql): user profile metadata left panel

### DIFF
--- a/apps/portal/app/components/edit-profile/modal.tsx
+++ b/apps/portal/app/components/edit-profile/modal.tsx
@@ -4,7 +4,8 @@ import { UserPresenter } from '@0xintuition/api'
 import { EditProfileForm } from './form'
 
 export interface EditProfileModalProps {
-  userObject: UserPresenter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userObject: any //TODO: (ENG-4782) Fix once we have the correct types
   open?: boolean
   setUserObject?: (userObject: UserPresenter) => void
   onClose: () => void

--- a/apps/portal/app/components/tags/add-tags.tsx
+++ b/apps/portal/app/components/tags/add-tags.tsx
@@ -23,9 +23,11 @@ import { useAtom } from 'jotai'
 import { TagsListInputPortal } from './tags-list-input-portal'
 
 interface AddTagsProps {
-  selectedTags: IdentityPresenter[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  selectedTags: any // TODO: (ENG-4782) temporary type fix until we lock in final types
   existingTagIds: string[]
-  identity: IdentityPresenter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  identity: any // TODO: (ENG-4782) temporary type fix until we lock in final types
   userWallet: string
   onAddTag: (newTag: IdentityPresenter) => void
   onRemoveTag: (id: string) => void
@@ -47,7 +49,8 @@ export function AddTags({
   invalidTags,
   setInvalidTags,
 }: AddTagsProps) {
-  const formattedTags = selectedTags?.map((tag) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const formattedTags = selectedTags?.map((tag: any) => ({
     name: tag.display_name,
     id: tag.vault_id,
     tagCount: tag.tag_count,

--- a/apps/portal/app/components/tags/tags-form.tsx
+++ b/apps/portal/app/components/tags/tags-form.tsx
@@ -37,7 +37,7 @@ import { TagSearchCombobox } from './tags-search-combo-box'
 interface TagsFormProps {
   identity: IdentityPresenter | undefined // TODO: (ENG-4782) temporary type fix until we lock in final types
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tags: any[] // TODO: (ENG-4782) temporary type fix until we lock in final types
+  tagClaims: any[] // TODO: (ENG-4782) temporary type fix until we lock in final types
   userWallet: string
   mode: 'view' | 'add'
   readOnly?: boolean
@@ -47,7 +47,7 @@ interface TagsFormProps {
 
 export function TagsForm({
   identity,
-  tags,
+  tagClaims,
   userWallet,
   mode,
   readOnly = false,
@@ -57,9 +57,9 @@ export function TagsForm({
   const navigate = useNavigate()
   const [currentTab, setCurrentTab] = useState(mode)
 
-  logger('tags in tag form', tags)
+  logger('tags in tag form', tagClaims)
   logger('identity in tags-form', identity)
-  const existingTagIds = tags ? tags.map((tag) => tag.id) : []
+  const existingTagIds = tagClaims ? tagClaims.map((tag) => tag.id) : []
 
   const { state, dispatch } = useTransactionState<
     TransactionStateType,
@@ -175,7 +175,7 @@ export function TagsForm({
                   )}
                   <TabsContent value="view" className="h-full">
                     <TagSearchCombobox
-                      tagClaims={tags || []}
+                      tagClaims={tagClaims || []}
                       shouldFilter={true}
                       onTagClick={handleTagClick}
                     />

--- a/apps/portal/app/components/tags/tags-form.tsx
+++ b/apps/portal/app/components/tags/tags-form.tsx
@@ -12,7 +12,7 @@ import {
   TabsTrigger,
   Trunctacular,
 } from '@0xintuition/1ui'
-import { ClaimPresenter, IdentityPresenter } from '@0xintuition/api'
+import { IdentityPresenter } from '@0xintuition/api'
 
 import { TransactionState } from '@components/transaction-state'
 import {
@@ -35,8 +35,9 @@ import TagsReview from './tags-review'
 import { TagSearchCombobox } from './tags-search-combo-box'
 
 interface TagsFormProps {
-  identity: IdentityPresenter
-  tagClaims: ClaimPresenter[]
+  identity: IdentityPresenter | undefined // TODO: (ENG-4782) temporary type fix until we lock in final types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tags: any[] // TODO: (ENG-4782) temporary type fix until we lock in final types
   userWallet: string
   mode: 'view' | 'add'
   readOnly?: boolean
@@ -46,7 +47,7 @@ interface TagsFormProps {
 
 export function TagsForm({
   identity,
-  tagClaims,
+  tags,
   userWallet,
   mode,
   readOnly = false,
@@ -56,9 +57,9 @@ export function TagsForm({
   const navigate = useNavigate()
   const [currentTab, setCurrentTab] = useState(mode)
 
-  const existingTagIds = tagClaims
-    ? tagClaims.map((tagClaim) => tagClaim.vault_id)
-    : []
+  logger('tags in tag form', tags)
+  logger('identity in tags-form', identity)
+  const existingTagIds = tags ? tags.map((tag) => tag.id) : []
 
   const { state, dispatch } = useTransactionState<
     TransactionStateType,
@@ -94,11 +95,13 @@ export function TagsForm({
 
   const setSaveListModalActive = useSetAtom(saveListModalAtom)
 
-  const handleTagClick = (tagClaim: ClaimPresenter) => {
+  // TODO: (ENG-4782) temporary type fix until we lock in final types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleTagClick = (tag: any) => {
     setSaveListModalActive({
       isOpen: true,
-      id: tagClaim.vault_id,
-      tag: tagClaim.object,
+      id: tag.id,
+      tag: tag.object,
     })
   }
 
@@ -164,7 +167,7 @@ export function TagsForm({
                         dispatch={dispatch}
                         onRemoveTag={handleRemoveTag}
                         onRemoveInvalidTag={handleRemoveInvalidTag}
-                        subjectVaultId={identity.vault_id}
+                        subjectVaultId={identity?.id ?? ''}
                         invalidTags={invalidTags}
                         setInvalidTags={setInvalidTags}
                       />
@@ -172,7 +175,7 @@ export function TagsForm({
                   )}
                   <TabsContent value="view" className="h-full">
                     <TagSearchCombobox
-                      tagClaims={tagClaims || []}
+                      tagClaims={tags || []}
                       shouldFilter={true}
                       onTagClick={handleTagClick}
                     />
@@ -201,7 +204,7 @@ export function TagsForm({
             <div className="h-full flex flex-col">
               <TagsReview
                 dispatch={dispatch}
-                subjectVaultId={identity.vault_id}
+                subjectVaultId={identity?.id ?? ''}
                 tags={selectedTags}
               />
             </div>
@@ -222,15 +225,15 @@ export function TagsForm({
                   className="w-40"
                   onClick={() => {
                     navigate(
-                      identity.is_user
-                        ? `${PATHS.PROFILE}/${identity.identity_id}`
-                        : `${PATHS.IDENTITY}/${identity.vault_id}`,
+                      identity?.is_user
+                        ? `${PATHS.PROFILE}/${identity?.id}`
+                        : `${PATHS.IDENTITY}/${identity?.id}`,
                     )
 
                     onClose()
                   }}
                 >
-                  View {identity.is_user ? 'profile' : 'identity'}
+                  View {identity?.is_user ? 'profile' : 'identity'}
                 </Button>
               )
             }

--- a/apps/portal/app/components/tags/tags-modal.tsx
+++ b/apps/portal/app/components/tags/tags-modal.tsx
@@ -1,11 +1,12 @@
 import { Dialog, DialogContent } from '@0xintuition/1ui'
-import { ClaimPresenter, IdentityPresenter } from '@0xintuition/api'
+import { IdentityPresenter } from '@0xintuition/api'
 
 import { TagsForm } from './tags-form'
 
 export interface TagsModalProps {
-  identity: IdentityPresenter
-  tagClaims: ClaimPresenter[]
+  identity: IdentityPresenter | undefined // TODO: (ENG-4782) temporary type fix until we lock in final types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tags: any[] // TODO: (ENG-4782) temporary type fix until we lock in final types
   userWallet: string
   open?: boolean
   mode: 'view' | 'add'
@@ -16,7 +17,7 @@ export interface TagsModalProps {
 
 export default function TagsModal({
   identity,
-  tagClaims,
+  tags,
   userWallet,
   open,
   mode,
@@ -35,7 +36,7 @@ export default function TagsModal({
         <DialogContent className="h-[550px]">
           <TagsForm
             identity={identity}
-            tagClaims={tagClaims}
+            tags={tags}
             userWallet={userWallet}
             mode={mode}
             readOnly={readOnly}

--- a/apps/portal/app/components/tags/tags-modal.tsx
+++ b/apps/portal/app/components/tags/tags-modal.tsx
@@ -1,12 +1,12 @@
 import { Dialog, DialogContent } from '@0xintuition/1ui'
-import { IdentityPresenter } from '@0xintuition/api'
 
 import { TagsForm } from './tags-form'
 
 export interface TagsModalProps {
-  identity: IdentityPresenter | undefined // TODO: (ENG-4782) temporary type fix until we lock in final types
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tags: any[] // TODO: (ENG-4782) temporary type fix until we lock in final types
+  identity: any // TODO: (ENG-4782) temporary type fix until we lock in final types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tagClaims: any[] // TODO: (ENG-4782) temporary type fix until we lock in final types
   userWallet: string
   open?: boolean
   mode: 'view' | 'add'
@@ -17,7 +17,7 @@ export interface TagsModalProps {
 
 export default function TagsModal({
   identity,
-  tags,
+  tagClaims,
   userWallet,
   open,
   mode,
@@ -36,7 +36,7 @@ export default function TagsModal({
         <DialogContent className="h-[550px]">
           <TagsForm
             identity={identity}
-            tags={tags}
+            tagClaims={tagClaims}
             userWallet={userWallet}
             mode={mode}
             readOnly={readOnly}

--- a/apps/portal/app/components/tags/tags-search-combo-box.tsx
+++ b/apps/portal/app/components/tags/tags-search-combo-box.tsx
@@ -16,6 +16,7 @@ import {
 import { ClaimPresenter } from '@0xintuition/api'
 
 import { IdentitySearchComboboxItem } from '@components/identity/identity-search-combo-box-item'
+import logger from '@lib/utils/logger'
 import { formatBalance, getAtomIpfsLink, truncateString } from '@lib/utils/misc'
 
 export interface TagSearchComboboxProps
@@ -32,6 +33,7 @@ const TagSearchCombobox = ({
   onTagClick = () => {},
   ...props
 }: TagSearchComboboxProps) => {
+  logger('tagClaims in tags-search-combo-box', tagClaims)
   return (
     <div className="min-w-96" {...props}>
       <Command className="border-none">

--- a/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
@@ -495,7 +495,7 @@ export default function Profile() {
                 className="w-fit border-dashed"
                 onClick={() => {
                   setTagsModalActive({ isOpen: true, mode: 'add' })
-                }}
+                }} // TODO: The View All Tags modal is currently not working -- there are issues that we will fix in another ticket
               >
                 <Icon name="plus-small" className="w-5 h-5" />
                 Add tags
@@ -751,7 +751,7 @@ export default function Profile() {
                   } as unknown as IdentityPresenter)
                 : undefined
             } // TODO: (ENG-4782) temporary type fix until we lock in final types
-            tags={accountTagsResult?.triples ?? []} // TODO: (ENG-4782) temporary type fix until we lock in final types
+            tagClaims={accountTagsResult?.triples ?? []} // TODO: (ENG-4782) temporary type fix until we lock in final types
             userWallet={userWallet}
             open={tagsModalActive.isOpen}
             mode={tagsModalActive.mode}

--- a/packages/1ui/src/components/ProfileCard/ProfileCard.tsx
+++ b/packages/1ui/src/components/ProfileCard/ProfileCard.tsx
@@ -94,7 +94,7 @@ const ProfileCard = ({
             <ProfileCardStatItem
               value={stats.points}
               label="IQ Points"
-              valueClassName="text-success"
+              valueClassName="text-warning"
             />
           )}
         </div>

--- a/packages/1ui/src/components/ProfileCard/components/ProfileCardStatItem.tsx
+++ b/packages/1ui/src/components/ProfileCard/components/ProfileCardStatItem.tsx
@@ -20,7 +20,12 @@ const ProfileCardStatItem = ({
       <Text variant="body" weight="medium" className={valueClassName}>
         {formattedValue}
       </Text>
-      <Text variant="body" className="text-muted-foreground">
+      <Text
+        variant="body"
+        className={
+          label === 'IQ Points' ? 'text-warning' : 'text-muted-foreground'
+        }
+      >
         {label}
       </Text>
     </div>

--- a/packages/graphql/src/fragments/account.graphql
+++ b/packages/graphql/src/fragments/account.graphql
@@ -4,9 +4,6 @@ fragment AccountMetadata on accounts {
   id
   atomId
   type
-  atom {
-    ...AtomValue
-  }
 }
 
 fragment AccountClaimsAggregate on accounts {

--- a/packages/graphql/src/fragments/atom.graphql
+++ b/packages/graphql/src/fragments/atom.graphql
@@ -45,7 +45,22 @@ fragment AtomVaultDetails on atoms {
   vault {
     positionCount
     totalShares
-    currentSharePrice
+    positions_aggregate {
+      aggregate {
+        count
+        sum {
+          shares
+        }
+      }
+    }
+    positions {
+      id
+      account {
+        label
+        id
+      }
+      shares
+    }
   }
 }
 

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -7537,7 +7537,23 @@ export type AtomVaultDetailsFragment = {
     __typename?: 'vaults'
     positionCount: number
     totalShares: any
-    currentSharePrice: any
+    positions_aggregate: {
+      __typename?: 'positions_aggregate'
+      aggregate?: {
+        __typename?: 'positions_aggregate_fields'
+        count: number
+        sum?: {
+          __typename?: 'positions_sum_fields'
+          shares?: any | null
+        } | null
+      } | null
+    }
+    positions: Array<{
+      __typename?: 'positions'
+      id: string
+      shares: any
+      account?: { __typename?: 'accounts'; label: string; id: string } | null
+    }>
   } | null
 }
 
@@ -9431,7 +9447,23 @@ export type GetAtomsQuery = {
       __typename?: 'vaults'
       positionCount: number
       totalShares: any
-      currentSharePrice: any
+      positions_aggregate: {
+        __typename?: 'positions_aggregate'
+        aggregate?: {
+          __typename?: 'positions_aggregate_fields'
+          count: number
+          sum?: {
+            __typename?: 'positions_sum_fields'
+            shares?: any | null
+          } | null
+        } | null
+      }
+      positions: Array<{
+        __typename?: 'positions'
+        id: string
+        shares: any
+        account?: { __typename?: 'accounts'; label: string; id: string } | null
+      }>
     } | null
     value?: {
       __typename?: 'atomValues'
@@ -9525,7 +9557,27 @@ export type GetAtomsWithAggregatesQuery = {
         __typename?: 'vaults'
         positionCount: number
         totalShares: any
-        currentSharePrice: any
+        positions_aggregate: {
+          __typename?: 'positions_aggregate'
+          aggregate?: {
+            __typename?: 'positions_aggregate_fields'
+            count: number
+            sum?: {
+              __typename?: 'positions_sum_fields'
+              shares?: any | null
+            } | null
+          } | null
+        }
+        positions: Array<{
+          __typename?: 'positions'
+          id: string
+          shares: any
+          account?: {
+            __typename?: 'accounts'
+            label: string
+            id: string
+          } | null
+        }>
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -9626,7 +9678,23 @@ export type GetAtomQuery = {
       __typename?: 'vaults'
       positionCount: number
       totalShares: any
-      currentSharePrice: any
+      positions_aggregate: {
+        __typename?: 'positions_aggregate'
+        aggregate?: {
+          __typename?: 'positions_aggregate_fields'
+          count: number
+          sum?: {
+            __typename?: 'positions_sum_fields'
+            shares?: any | null
+          } | null
+        } | null
+      }
+      positions: Array<{
+        __typename?: 'positions'
+        id: string
+        shares: any
+        account?: { __typename?: 'accounts'; label: string; id: string } | null
+      }>
     } | null
     asSubject: Array<{
       __typename?: 'triples'
@@ -13423,7 +13491,22 @@ export const AtomVaultDetailsFragmentDoc = `
   vault {
     positionCount
     totalShares
-    currentSharePrice
+    positions_aggregate {
+      aggregate {
+        count
+        sum {
+          shares
+        }
+      }
+    }
+    positions {
+      id
+      account {
+        label
+        id
+      }
+      shares
+    }
   }
 }
     `
@@ -18297,7 +18380,69 @@ export const AtomVaultDetails = {
                 { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
                 {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'currentSharePrice' },
+                  name: { kind: 'Name', value: 'positions_aggregate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'count' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'sum' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'shares' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                    ],
+                  },
                 },
               ],
             },
@@ -25229,7 +25374,69 @@ export const GetAtoms = {
                 { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
                 {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'currentSharePrice' },
+                  name: { kind: 'Name', value: 'positions_aggregate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'count' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'sum' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'shares' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                    ],
+                  },
                 },
               ],
             },
@@ -25552,7 +25759,69 @@ export const GetAtomsWithAggregates = {
                 { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
                 {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'currentSharePrice' },
+                  name: { kind: 'Name', value: 'positions_aggregate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'count' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'sum' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'shares' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                    ],
+                  },
                 },
               ],
             },
@@ -25860,7 +26129,69 @@ export const GetAtom = {
                 { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
                 {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'currentSharePrice' },
+                  name: { kind: 'Name', value: 'positions_aggregate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'count' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'sum' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'shares' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                    ],
+                  },
                 },
               ],
             },

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -11281,6 +11281,41 @@ export type GetConnectionsQuery = {
   }>
 }
 
+export type GetConnectionsCountQueryVariables = Exact<{
+  subjectId: Scalars['numeric']['input']
+  predicateId: Scalars['numeric']['input']
+  objectId: Scalars['numeric']['input']
+  address: Scalars['String']['input']
+}>
+
+export type GetConnectionsCountQuery = {
+  __typename?: 'query_root'
+  following_count: {
+    __typename?: 'triples_aggregate'
+    aggregate?: {
+      __typename?: 'triples_aggregate_fields'
+      count: number
+    } | null
+  }
+  followers_count: Array<{
+    __typename?: 'triples'
+    vault?: {
+      __typename?: 'vaults'
+      positions_aggregate: {
+        __typename?: 'positions_aggregate'
+        aggregate?: {
+          __typename?: 'positions_aggregate_fields'
+          count: number
+          sum?: {
+            __typename?: 'positions_sum_fields'
+            shares?: any | null
+          } | null
+        } | null
+      }
+    } | null
+  }>
+}
+
 export type GetListItemsQueryVariables = Exact<{
   predicateId?: InputMaybe<Scalars['numeric']['input']>
   objectId?: InputMaybe<Scalars['numeric']['input']>
@@ -15764,6 +15799,113 @@ useGetConnectionsQuery.fetcher = (
 ) =>
   fetcher<GetConnectionsQuery, GetConnectionsQueryVariables>(
     GetConnectionsDocument,
+    variables,
+    options,
+  )
+
+export const GetConnectionsCountDocument = `
+    query GetConnectionsCount($subjectId: numeric!, $predicateId: numeric!, $objectId: numeric!, $address: String!) {
+  following_count: triples_aggregate(
+    where: {_and: [{subjectId: {_eq: $subjectId}}, {predicateId: {_eq: $predicateId}}, {vault: {positions: {accountId: {_eq: $address}}}}]}
+  ) {
+    aggregate {
+      count
+    }
+  }
+  followers_count: triples(
+    where: {_and: [{subjectId: {_eq: $subjectId}}, {predicateId: {_eq: $predicateId}}, {objectId: {_eq: $objectId}}]}
+  ) {
+    vault {
+      positions_aggregate {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetConnectionsCountQuery = <
+  TData = GetConnectionsCountQuery,
+  TError = unknown,
+>(
+  variables: GetConnectionsCountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetConnectionsCountQuery, TError, TData>,
+    'queryKey'
+  > & {
+    queryKey?: UseQueryOptions<
+      GetConnectionsCountQuery,
+      TError,
+      TData
+    >['queryKey']
+  },
+) => {
+  return useQuery<GetConnectionsCountQuery, TError, TData>({
+    queryKey: ['GetConnectionsCount', variables],
+    queryFn: fetcher<
+      GetConnectionsCountQuery,
+      GetConnectionsCountQueryVariables
+    >(GetConnectionsCountDocument, variables),
+    ...options,
+  })
+}
+
+useGetConnectionsCountQuery.document = GetConnectionsCountDocument
+
+useGetConnectionsCountQuery.getKey = (
+  variables: GetConnectionsCountQueryVariables,
+) => ['GetConnectionsCount', variables]
+
+export const useInfiniteGetConnectionsCountQuery = <
+  TData = InfiniteData<GetConnectionsCountQuery>,
+  TError = unknown,
+>(
+  variables: GetConnectionsCountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetConnectionsCountQuery, TError, TData>,
+    'queryKey'
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetConnectionsCountQuery,
+      TError,
+      TData
+    >['queryKey']
+  },
+) => {
+  return useInfiniteQuery<GetConnectionsCountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          'GetConnectionsCount.infinite',
+          variables,
+        ],
+        queryFn: (metaData) =>
+          fetcher<GetConnectionsCountQuery, GetConnectionsCountQueryVariables>(
+            GetConnectionsCountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) },
+          )(),
+        ...restOptions,
+      }
+    })(),
+  )
+}
+
+useInfiniteGetConnectionsCountQuery.getKey = (
+  variables: GetConnectionsCountQueryVariables,
+) => ['GetConnectionsCount.infinite', variables]
+
+useGetConnectionsCountQuery.fetcher = (
+  variables: GetConnectionsCountQueryVariables,
+  options?: RequestInit['headers'],
+) =>
+  fetcher<GetConnectionsCountQuery, GetConnectionsCountQueryVariables>(
+    GetConnectionsCountDocument,
     variables,
     options,
   )
@@ -30203,6 +30345,373 @@ export const GetConnections = {
                       {
                         kind: 'Field',
                         name: { kind: 'Name', value: 'shares' },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode
+export const GetConnectionsCount = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'GetConnectionsCount' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'subjectId' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'numeric' },
+            },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'predicateId' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'numeric' },
+            },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'objectId' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'numeric' },
+            },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'address' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'String' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            alias: { kind: 'Name', value: 'following_count' },
+            name: { kind: 'Name', value: 'triples_aggregate' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'where' },
+                value: {
+                  kind: 'ObjectValue',
+                  fields: [
+                    {
+                      kind: 'ObjectField',
+                      name: { kind: 'Name', value: '_and' },
+                      value: {
+                        kind: 'ListValue',
+                        values: [
+                          {
+                            kind: 'ObjectValue',
+                            fields: [
+                              {
+                                kind: 'ObjectField',
+                                name: { kind: 'Name', value: 'subjectId' },
+                                value: {
+                                  kind: 'ObjectValue',
+                                  fields: [
+                                    {
+                                      kind: 'ObjectField',
+                                      name: { kind: 'Name', value: '_eq' },
+                                      value: {
+                                        kind: 'Variable',
+                                        name: {
+                                          kind: 'Name',
+                                          value: 'subjectId',
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                          {
+                            kind: 'ObjectValue',
+                            fields: [
+                              {
+                                kind: 'ObjectField',
+                                name: { kind: 'Name', value: 'predicateId' },
+                                value: {
+                                  kind: 'ObjectValue',
+                                  fields: [
+                                    {
+                                      kind: 'ObjectField',
+                                      name: { kind: 'Name', value: '_eq' },
+                                      value: {
+                                        kind: 'Variable',
+                                        name: {
+                                          kind: 'Name',
+                                          value: 'predicateId',
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                          {
+                            kind: 'ObjectValue',
+                            fields: [
+                              {
+                                kind: 'ObjectField',
+                                name: { kind: 'Name', value: 'vault' },
+                                value: {
+                                  kind: 'ObjectValue',
+                                  fields: [
+                                    {
+                                      kind: 'ObjectField',
+                                      name: {
+                                        kind: 'Name',
+                                        value: 'positions',
+                                      },
+                                      value: {
+                                        kind: 'ObjectValue',
+                                        fields: [
+                                          {
+                                            kind: 'ObjectField',
+                                            name: {
+                                              kind: 'Name',
+                                              value: 'accountId',
+                                            },
+                                            value: {
+                                              kind: 'ObjectValue',
+                                              fields: [
+                                                {
+                                                  kind: 'ObjectField',
+                                                  name: {
+                                                    kind: 'Name',
+                                                    value: '_eq',
+                                                  },
+                                                  value: {
+                                                    kind: 'Variable',
+                                                    name: {
+                                                      kind: 'Name',
+                                                      value: 'address',
+                                                    },
+                                                  },
+                                                },
+                                              ],
+                                            },
+                                          },
+                                        ],
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'aggregate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'count' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: 'Field',
+            alias: { kind: 'Name', value: 'followers_count' },
+            name: { kind: 'Name', value: 'triples' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'where' },
+                value: {
+                  kind: 'ObjectValue',
+                  fields: [
+                    {
+                      kind: 'ObjectField',
+                      name: { kind: 'Name', value: '_and' },
+                      value: {
+                        kind: 'ListValue',
+                        values: [
+                          {
+                            kind: 'ObjectValue',
+                            fields: [
+                              {
+                                kind: 'ObjectField',
+                                name: { kind: 'Name', value: 'subjectId' },
+                                value: {
+                                  kind: 'ObjectValue',
+                                  fields: [
+                                    {
+                                      kind: 'ObjectField',
+                                      name: { kind: 'Name', value: '_eq' },
+                                      value: {
+                                        kind: 'Variable',
+                                        name: {
+                                          kind: 'Name',
+                                          value: 'subjectId',
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                          {
+                            kind: 'ObjectValue',
+                            fields: [
+                              {
+                                kind: 'ObjectField',
+                                name: { kind: 'Name', value: 'predicateId' },
+                                value: {
+                                  kind: 'ObjectValue',
+                                  fields: [
+                                    {
+                                      kind: 'ObjectField',
+                                      name: { kind: 'Name', value: '_eq' },
+                                      value: {
+                                        kind: 'Variable',
+                                        name: {
+                                          kind: 'Name',
+                                          value: 'predicateId',
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                          {
+                            kind: 'ObjectValue',
+                            fields: [
+                              {
+                                kind: 'ObjectField',
+                                name: { kind: 'Name', value: 'objectId' },
+                                value: {
+                                  kind: 'ObjectValue',
+                                  fields: [
+                                    {
+                                      kind: 'ObjectField',
+                                      name: { kind: 'Name', value: '_eq' },
+                                      value: {
+                                        kind: 'Variable',
+                                        name: {
+                                          kind: 'Name',
+                                          value: 'objectId',
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'vault' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'positions_aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'aggregate' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'count' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'sum' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'shares',
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
                       },
                     ],
                   },

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -7265,33 +7265,6 @@ export type AccountMetadataFragment = {
   id: string
   atomId?: any | null
   type: string
-  atom?: {
-    __typename?: 'atoms'
-    value?: {
-      __typename?: 'atomValues'
-      person?: {
-        __typename?: 'persons'
-        name?: string | null
-        image?: string | null
-        description?: string | null
-        url?: string | null
-      } | null
-      thing?: {
-        __typename?: 'things'
-        name?: string | null
-        image?: string | null
-        description?: string | null
-        url?: string | null
-      } | null
-      organization?: {
-        __typename?: 'organizations'
-        name?: string | null
-        image?: string | null
-        description?: string | null
-        url?: string | null
-      } | null
-    } | null
-  } | null
 }
 
 export type AccountClaimsAggregateFragment = {
@@ -7578,33 +7551,6 @@ export type AtomTripleFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
     } | null
     predicate?: {
@@ -7622,33 +7568,6 @@ export type AtomTripleFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
     } | null
   }>
@@ -7671,33 +7590,6 @@ export type AtomTripleFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
     } | null
     object?: {
@@ -7715,33 +7607,6 @@ export type AtomTripleFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
     } | null
   }>
@@ -7764,33 +7629,6 @@ export type AtomTripleFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
     } | null
     predicate?: {
@@ -7808,33 +7646,6 @@ export type AtomTripleFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
     } | null
   }>
@@ -7963,33 +7774,6 @@ export type EventDetailsFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -8031,33 +7815,6 @@ export type EventDetailsFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -8099,33 +7856,6 @@ export type EventDetailsFragment = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -8401,33 +8131,6 @@ export type TripleMetadataFragment = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
     } | null
     value?: {
       __typename?: 'atomValues'
@@ -8469,33 +8172,6 @@ export type TripleMetadataFragment = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
     } | null
     value?: {
       __typename?: 'atomValues'
@@ -8537,33 +8213,6 @@ export type TripleMetadataFragment = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
     } | null
     value?: {
       __typename?: 'atomValues'
@@ -8841,29 +8490,33 @@ export type GetAccountsQuery = {
     type: string
     atom?: {
       __typename?: 'atoms'
-      value?: {
-        __typename?: 'atomValues'
-        person?: {
-          __typename?: 'persons'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        thing?: {
-          __typename?: 'things'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        organization?: {
-          __typename?: 'organizations'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
+      vaultId: any
+      walletId: string
+      vault?: {
+        __typename?: 'vaults'
+        positionCount: number
+        totalShares: any
+        positions_aggregate: {
+          __typename?: 'positions_aggregate'
+          aggregate?: {
+            __typename?: 'positions_aggregate_fields'
+            count: number
+            sum?: {
+              __typename?: 'positions_sum_fields'
+              shares?: any | null
+            } | null
+          } | null
+        }
+        positions: Array<{
+          __typename?: 'positions'
+          id: string
+          shares: any
+          account?: {
+            __typename?: 'accounts'
+            label: string
+            id: string
+          } | null
+        }>
       } | null
     } | null
     claims: Array<{
@@ -8924,33 +8577,6 @@ export type GetAccountsWithAggregatesQuery = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
       claims: Array<{
         __typename?: 'claims'
         shares: any
@@ -9026,29 +8652,33 @@ export type GetAccountQuery = {
     type: string
     atom?: {
       __typename?: 'atoms'
-      value?: {
-        __typename?: 'atomValues'
-        person?: {
-          __typename?: 'persons'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        thing?: {
-          __typename?: 'things'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        organization?: {
-          __typename?: 'organizations'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
+      vaultId: any
+      walletId: string
+      vault?: {
+        __typename?: 'vaults'
+        positionCount: number
+        totalShares: any
+        positions_aggregate: {
+          __typename?: 'positions_aggregate'
+          aggregate?: {
+            __typename?: 'positions_aggregate_fields'
+            count: number
+            sum?: {
+              __typename?: 'positions_sum_fields'
+              shares?: any | null
+            } | null
+          } | null
+        }
+        positions: Array<{
+          __typename?: 'positions'
+          id: string
+          shares: any
+          account?: {
+            __typename?: 'accounts'
+            label: string
+            id: string
+          } | null
+        }>
       } | null
     } | null
     claims: Array<{
@@ -9143,33 +8773,6 @@ export type GetAccountWithPaginatedRelationsQuery = {
     id: string
     atomId?: any | null
     type: string
-    atom?: {
-      __typename?: 'atoms'
-      value?: {
-        __typename?: 'atomValues'
-        person?: {
-          __typename?: 'persons'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        thing?: {
-          __typename?: 'things'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        organization?: {
-          __typename?: 'organizations'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-      } | null
-    } | null
     claims: Array<{
       __typename?: 'claims'
       shares: any
@@ -9261,33 +8864,6 @@ export type GetAccountWithAggregatesQuery = {
     id: string
     atomId?: any | null
     type: string
-    atom?: {
-      __typename?: 'atoms'
-      value?: {
-        __typename?: 'atomValues'
-        person?: {
-          __typename?: 'persons'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        thing?: {
-          __typename?: 'things'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-        organization?: {
-          __typename?: 'organizations'
-          name?: string | null
-          image?: string | null
-          description?: string | null
-          url?: string | null
-        } | null
-      } | null
-    } | null
     claims_aggregate: {
       __typename?: 'claims_aggregate'
       aggregate?: {
@@ -9415,33 +8991,6 @@ export type GetAtomsQuery = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
     } | null
     vault?: {
       __typename?: 'vaults'
@@ -9525,33 +9074,6 @@ export type GetAtomsWithAggregatesQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       vault?: {
         __typename?: 'vaults'
@@ -9646,33 +9168,6 @@ export type GetAtomQuery = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
     } | null
     vault?: {
       __typename?: 'vaults'
@@ -9715,33 +9210,6 @@ export type GetAtomQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
       } | null
       predicate?: {
@@ -9759,33 +9227,6 @@ export type GetAtomQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
       } | null
     }>
@@ -9808,33 +9249,6 @@ export type GetAtomQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
       } | null
       object?: {
@@ -9852,33 +9266,6 @@ export type GetAtomQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
       } | null
     }>
@@ -9901,33 +9288,6 @@ export type GetAtomQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
       } | null
       predicate?: {
@@ -9945,33 +9305,6 @@ export type GetAtomQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
       } | null
     }>
@@ -10132,33 +9465,6 @@ export type GetEventsQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
         value?: {
           __typename?: 'atomValues'
@@ -10200,33 +9506,6 @@ export type GetEventsQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
         value?: {
           __typename?: 'atomValues'
@@ -10268,33 +9547,6 @@ export type GetEventsQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
         value?: {
           __typename?: 'atomValues'
@@ -10585,33 +9837,6 @@ export type GetEventsWithAggregatesQuery = {
             id: string
             atomId?: any | null
             type: string
-            atom?: {
-              __typename?: 'atoms'
-              value?: {
-                __typename?: 'atomValues'
-                person?: {
-                  __typename?: 'persons'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-                thing?: {
-                  __typename?: 'things'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-                organization?: {
-                  __typename?: 'organizations'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-              } | null
-            } | null
           } | null
           value?: {
             __typename?: 'atomValues'
@@ -10653,33 +9878,6 @@ export type GetEventsWithAggregatesQuery = {
             id: string
             atomId?: any | null
             type: string
-            atom?: {
-              __typename?: 'atoms'
-              value?: {
-                __typename?: 'atomValues'
-                person?: {
-                  __typename?: 'persons'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-                thing?: {
-                  __typename?: 'things'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-                organization?: {
-                  __typename?: 'organizations'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-              } | null
-            } | null
           } | null
           value?: {
             __typename?: 'atomValues'
@@ -10721,33 +9919,6 @@ export type GetEventsWithAggregatesQuery = {
             id: string
             atomId?: any | null
             type: string
-            atom?: {
-              __typename?: 'atoms'
-              value?: {
-                __typename?: 'atomValues'
-                person?: {
-                  __typename?: 'persons'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-                thing?: {
-                  __typename?: 'things'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-                organization?: {
-                  __typename?: 'organizations'
-                  name?: string | null
-                  image?: string | null
-                  description?: string | null
-                  url?: string | null
-                } | null
-              } | null
-            } | null
           } | null
           value?: {
             __typename?: 'atomValues'
@@ -11645,33 +10816,6 @@ export type GetTagsQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -11713,33 +10857,6 @@ export type GetTagsQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -11781,33 +10898,6 @@ export type GetTagsQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -11906,33 +10996,6 @@ export type GetTagsCustomQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -11974,33 +11037,6 @@ export type GetTagsCustomQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -12042,33 +11078,6 @@ export type GetTagsCustomQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -12175,33 +11184,6 @@ export type GetTriplesQuery = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
     } | null
     subject?: {
       __typename?: 'atoms'
@@ -12218,33 +11200,6 @@ export type GetTriplesQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -12286,33 +11241,6 @@ export type GetTriplesQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -12354,33 +11282,6 @@ export type GetTriplesQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -12520,33 +11421,6 @@ export type GetTriplesWithAggregatesQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       subject?: {
         __typename?: 'atoms'
@@ -12563,33 +11437,6 @@ export type GetTriplesWithAggregatesQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
         value?: {
           __typename?: 'atomValues'
@@ -12631,33 +11478,6 @@ export type GetTriplesWithAggregatesQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
         value?: {
           __typename?: 'atomValues'
@@ -12699,33 +11519,6 @@ export type GetTriplesWithAggregatesQuery = {
           id: string
           atomId?: any | null
           type: string
-          atom?: {
-            __typename?: 'atoms'
-            value?: {
-              __typename?: 'atomValues'
-              person?: {
-                __typename?: 'persons'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              thing?: {
-                __typename?: 'things'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-              organization?: {
-                __typename?: 'organizations'
-                name?: string | null
-                image?: string | null
-                description?: string | null
-                url?: string | null
-              } | null
-            } | null
-          } | null
         } | null
         value?: {
           __typename?: 'atomValues'
@@ -12888,33 +11681,6 @@ export type GetTripleQuery = {
       id: string
       atomId?: any | null
       type: string
-      atom?: {
-        __typename?: 'atoms'
-        value?: {
-          __typename?: 'atomValues'
-          person?: {
-            __typename?: 'persons'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          thing?: {
-            __typename?: 'things'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-          organization?: {
-            __typename?: 'organizations'
-            name?: string | null
-            image?: string | null
-            description?: string | null
-            url?: string | null
-          } | null
-        } | null
-      } | null
     } | null
     subject?: {
       __typename?: 'atoms'
@@ -12931,33 +11697,6 @@ export type GetTripleQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -12999,33 +11738,6 @@ export type GetTripleQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -13067,33 +11779,6 @@ export type GetTripleQuery = {
         id: string
         atomId?: any | null
         type: string
-        atom?: {
-          __typename?: 'atoms'
-          value?: {
-            __typename?: 'atomValues'
-            person?: {
-              __typename?: 'persons'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            thing?: {
-              __typename?: 'things'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-            organization?: {
-              __typename?: 'organizations'
-              name?: string | null
-              image?: string | null
-              description?: string | null
-              url?: string | null
-            } | null
-          } | null
-        } | null
       } | null
       value?: {
         __typename?: 'atomValues'
@@ -13510,30 +12195,6 @@ export const AtomVaultDetailsFragmentDoc = `
   }
 }
     `
-export const AtomValueFragmentDoc = `
-    fragment AtomValue on atoms {
-  value {
-    person {
-      name
-      image
-      description
-      url
-    }
-    thing {
-      name
-      image
-      description
-      url
-    }
-    organization {
-      name
-      image
-      description
-      url
-    }
-  }
-}
-    `
 export const AccountMetadataFragmentDoc = `
     fragment AccountMetadata on accounts {
   label
@@ -13541,9 +12202,6 @@ export const AccountMetadataFragmentDoc = `
   id
   atomId
   type
-  atom {
-    ...AtomValue
-  }
 }
     `
 export const AtomTripleFragmentDoc = `
@@ -13650,6 +12308,30 @@ export const RedemptionEventFragmentFragmentDoc = `
     receiverId
     sharesRedeemedBySender
     assetsForReceiver
+  }
+}
+    `
+export const AtomValueFragmentDoc = `
+    fragment AtomValue on atoms {
+  value {
+    person {
+      name
+      image
+      description
+      url
+    }
+    thing {
+      name
+      image
+      description
+      url
+    }
+    organization {
+      name
+      image
+      description
+      url
+    }
   }
 }
     `
@@ -14000,10 +12682,33 @@ export const GetAccountsDocument = `
     ...AccountMetadata
     ...AccountClaims
     ...AccountPositions
+    atom {
+      vaultId
+      walletId
+      vault {
+        positionCount
+        totalShares
+        positions_aggregate {
+          aggregate {
+            count
+            sum {
+              shares
+            }
+          }
+        }
+        positions {
+          id
+          account {
+            label
+            id
+          }
+          shares
+        }
+      }
+    }
   }
 }
     ${AccountMetadataFragmentDoc}
-${AtomValueFragmentDoc}
 ${AccountClaimsFragmentDoc}
 ${AccountPositionsFragmentDoc}`
 
@@ -14101,7 +12806,6 @@ export const GetAccountsWithAggregatesDocument = `
   }
 }
     ${AccountMetadataFragmentDoc}
-${AtomValueFragmentDoc}
 ${AccountClaimsFragmentDoc}
 ${AccountPositionsFragmentDoc}`
 
@@ -14297,6 +13001,9 @@ export const GetAccountDocument = `
     query GetAccount($address: String!, $claimsLimit: Int, $claimsOffset: Int, $claimsWhere: claims_bool_exp, $positionsLimit: Int, $positionsOffset: Int, $positionsWhere: positions_bool_exp, $atomsWhere: atoms_bool_exp, $atomsOrderBy: [atoms_order_by!], $atomsLimit: Int, $atomsOffset: Int, $triplesWhere: triples_bool_exp, $triplesOrderBy: [triples_order_by!], $triplesLimit: Int, $triplesOffset: Int) {
   account(id: $address) {
     ...AccountMetadata
+    atom {
+      ...AtomVaultDetails
+    }
     ...AccountClaims
     ...AccountPositions
     ...AccountCreatedAtoms
@@ -14307,7 +13014,7 @@ export const GetAccountDocument = `
   }
 }
     ${AccountMetadataFragmentDoc}
-${AtomValueFragmentDoc}
+${AtomVaultDetailsFragmentDoc}
 ${AccountClaimsFragmentDoc}
 ${AccountPositionsFragmentDoc}
 ${AccountCreatedAtomsFragmentDoc}
@@ -14397,7 +13104,6 @@ export const GetAccountWithPaginatedRelationsDocument = `
   }
 }
     ${AccountMetadataFragmentDoc}
-${AtomValueFragmentDoc}
 ${AccountClaimsFragmentDoc}
 ${AccountPositionsFragmentDoc}
 ${AccountCreatedAtomsFragmentDoc}
@@ -14502,7 +13208,6 @@ export const GetAccountWithAggregatesDocument = `
   }
 }
     ${AccountMetadataFragmentDoc}
-${AtomValueFragmentDoc}
 ${AccountClaimsAggregateFragmentDoc}
 ${AccountPositionsAggregateFragmentDoc}
 ${AccountCreatedAtomsAggregateFragmentDoc}
@@ -18452,81 +17157,6 @@ export const AtomVaultDetails = {
     },
   ],
 } as unknown as DocumentNode
-export const AtomValue = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'atoms' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode
 export const AccountMetadata = {
   kind: 'Document',
   definitions: [
@@ -18545,89 +17175,6 @@ export const AccountMetadata = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'atoms' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -18865,89 +17412,6 @@ export const AtomTriple = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'atoms' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -19037,6 +17501,81 @@ export const RedemptionEventFragment = {
                 {
                   kind: 'Field',
                   name: { kind: 'Name', value: 'assetsForReceiver' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode
+export const AtomValue = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'AtomValue' },
+      typeCondition: {
+        kind: 'NamedType',
+        name: { kind: 'Name', value: 'atoms' },
+      },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'value' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'person' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'description' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'thing' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'description' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'organization' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'description' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+                    ],
+                  },
                 },
               ],
             },
@@ -19552,19 +18091,6 @@ export const TripleMetadata = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -20166,19 +18692,6 @@ export const EventDetails = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -21769,6 +20282,121 @@ export const GetAccounts = {
                   kind: 'FragmentSpread',
                   name: { kind: 'Name', value: 'AccountPositions' },
                 },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'atom' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'walletId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vault' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'positionCount' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'totalShares' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: {
+                                kind: 'Name',
+                                value: 'positions_aggregate',
+                              },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'aggregate' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'count',
+                                          },
+                                        },
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'sum' },
+                                          selectionSet: {
+                                            kind: 'SelectionSet',
+                                            selections: [
+                                              {
+                                                kind: 'Field',
+                                                name: {
+                                                  kind: 'Name',
+                                                  value: 'shares',
+                                                },
+                                              },
+                                            ],
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'positions' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'id' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'account' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'label',
+                                          },
+                                        },
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'id' },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'shares' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
               ],
             },
           },
@@ -21790,19 +20418,6 @@ export const GetAccounts = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -21991,76 +20606,6 @@ export const GetAccounts = {
                           ],
                         },
                       },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'atoms' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
                     ],
                   },
                 },
@@ -22318,19 +20863,6 @@ export const GetAccountsWithAggregates = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -22519,76 +21051,6 @@ export const GetAccountsWithAggregates = {
                           ],
                         },
                       },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'atoms' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
                     ],
                   },
                 },
@@ -22846,6 +21308,19 @@ export const GetAccount = {
                   name: { kind: 'Name', value: 'AccountMetadata' },
                 },
                 {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'atom' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'FragmentSpread',
+                        name: { kind: 'Name', value: 'AtomVaultDetails' },
+                      },
+                    ],
+                  },
+                },
+                {
                   kind: 'FragmentSpread',
                   name: { kind: 'Name', value: 'AccountClaims' },
                 },
@@ -22913,19 +21388,6 @@ export const GetAccount = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -23382,7 +21844,7 @@ export const GetAccount = {
     },
     {
       kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
+      name: { kind: 'Name', value: 'AtomVaultDetails' },
       typeCondition: {
         kind: 'NamedType',
         name: { kind: 'Name', value: 'atoms' },
@@ -23390,57 +21852,82 @@ export const GetAccount = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          { kind: 'Field', name: { kind: 'Name', value: 'vaultId' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'walletId' } },
           {
             kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
+            name: { kind: 'Name', value: 'vault' },
             selectionSet: {
               kind: 'SelectionSet',
               selections: [
                 {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
+                  name: { kind: 'Name', value: 'positionCount' },
+                },
+                { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions_aggregate' },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
                       {
                         kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
+                        name: { kind: 'Name', value: 'aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'count' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'sum' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'shares' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
                       },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
                     ],
                   },
                 },
                 {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
+                  name: { kind: 'Name', value: 'positions' },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                       {
                         kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
                       },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
                       {
                         kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
+                        name: { kind: 'Name', value: 'shares' },
                       },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
                     ],
                   },
                 },
@@ -23677,19 +22164,6 @@ export const GetAccountWithPaginatedRelations = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -24135,76 +22609,6 @@ export const GetAccountWithPaginatedRelations = {
                           ],
                         },
                       },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'atoms' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
                     ],
                   },
                 },
@@ -24444,19 +22848,6 @@ export const GetAccountWithAggregates = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -24978,76 +23369,6 @@ export const GetAccountWithAggregates = {
         ],
       },
     },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'AtomValue' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'atoms' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'value' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'person' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'thing' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'organization' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'description' },
-                      },
-                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
   ],
 } as unknown as DocumentNode
 export const GetAtoms = {
@@ -25222,19 +23543,6 @@ export const GetAtoms = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -25607,19 +23915,6 @@ export const GetAtomsWithAggregates = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -25977,19 +24272,6 @@ export const GetAtom = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -26742,19 +25024,6 @@ export const GetEvents = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -27780,19 +26049,6 @@ export const GetEventsWithAggregates = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -32207,19 +30463,6 @@ export const GetTags = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -32621,19 +30864,6 @@ export const GetTagsCustom = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -33143,19 +31373,6 @@ export const GetTriples = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -33782,19 +31999,6 @@ export const GetTriplesWithAggregates = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },
@@ -34405,19 +32609,6 @@ export const GetTriple = {
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'atomId' } },
           { kind: 'Field', name: { kind: 'Name', value: 'type' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'AtomValue' },
-                },
-              ],
-            },
-          },
         ],
       },
     },

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -8652,8 +8652,14 @@ export type GetAccountQuery = {
     type: string
     atom?: {
       __typename?: 'atoms'
-      vaultId: any
+      id: any
+      data: string
+      image?: string | null
+      label?: string | null
+      emoji?: string | null
+      type: string
       walletId: string
+      vaultId: any
       vault?: {
         __typename?: 'vaults'
         positionCount: number
@@ -8679,6 +8685,30 @@ export type GetAccountQuery = {
             id: string
           } | null
         }>
+      } | null
+      value?: {
+        __typename?: 'atomValues'
+        person?: {
+          __typename?: 'persons'
+          name?: string | null
+          image?: string | null
+          description?: string | null
+          url?: string | null
+        } | null
+        thing?: {
+          __typename?: 'things'
+          name?: string | null
+          image?: string | null
+          description?: string | null
+          url?: string | null
+        } | null
+        organization?: {
+          __typename?: 'organizations'
+          name?: string | null
+          image?: string | null
+          description?: string | null
+          url?: string | null
+        } | null
       } | null
     } | null
     claims: Array<{
@@ -13002,6 +13032,7 @@ export const GetAccountDocument = `
   account(id: $address) {
     ...AccountMetadata
     atom {
+      ...AtomMetadata
       ...AtomVaultDetails
     }
     ...AccountClaims
@@ -13014,6 +13045,8 @@ export const GetAccountDocument = `
   }
 }
     ${AccountMetadataFragmentDoc}
+${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
 ${AtomVaultDetailsFragmentDoc}
 ${AccountClaimsFragmentDoc}
 ${AccountPositionsFragmentDoc}
@@ -21315,6 +21348,10 @@ export const GetAccount = {
                     selections: [
                       {
                         kind: 'FragmentSpread',
+                        name: { kind: 'Name', value: 'AtomMetadata' },
+                      },
+                      {
+                        kind: 'FragmentSpread',
                         name: { kind: 'Name', value: 'AtomVaultDetails' },
                       },
                     ],
@@ -21838,6 +21875,100 @@ export const GetAccount = {
                 },
               ],
             },
+          },
+        ],
+      },
+    },
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'AtomValue' },
+      typeCondition: {
+        kind: 'NamedType',
+        name: { kind: 'Name', value: 'atoms' },
+      },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'value' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'person' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'description' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'thing' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'description' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'organization' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'description' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'AtomMetadata' },
+      typeCondition: {
+        kind: 'NamedType',
+        name: { kind: 'Name', value: 'atoms' },
+      },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'data' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'emoji' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'type' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'walletId' } },
+          {
+            kind: 'FragmentSpread',
+            name: { kind: 'Name', value: 'AtomValue' },
           },
         ],
       },

--- a/packages/graphql/src/queries/accounts.graphql
+++ b/packages/graphql/src/queries/accounts.graphql
@@ -15,6 +15,30 @@ query GetAccounts(
     ...AccountMetadata
     ...AccountClaims
     ...AccountPositions
+    atom {
+      vaultId
+      walletId
+      vault {
+        positionCount
+        totalShares
+        positions_aggregate {
+          aggregate {
+            count
+            sum {
+              shares
+            }
+          }
+        }
+        positions {
+          id
+          account {
+            label
+            id
+          }
+          shares
+        }
+      }
+    }
   }
 }
 
@@ -83,6 +107,9 @@ query GetAccount(
 ) {
   account(id: $address) {
     ...AccountMetadata
+    atom {
+      ...AtomVaultDetails
+    }
     ...AccountClaims
     ...AccountPositions
     ...AccountCreatedAtoms

--- a/packages/graphql/src/queries/accounts.graphql
+++ b/packages/graphql/src/queries/accounts.graphql
@@ -108,6 +108,7 @@ query GetAccount(
   account(id: $address) {
     ...AccountMetadata
     atom {
+      ...AtomMetadata
       ...AtomVaultDetails
     }
     ...AccountClaims

--- a/packages/graphql/src/queries/follows.graphql
+++ b/packages/graphql/src/queries/follows.graphql
@@ -186,3 +186,47 @@ query GetConnections(
     ...FollowMetadata
   }
 }
+
+query GetConnectionsCount(
+  $subjectId: numeric!
+  $predicateId: numeric!
+  $objectId: numeric!
+  $address: String!
+) {
+  # Following count
+  following_count: triples_aggregate(
+    where: {
+      _and: [
+        { subjectId: { _eq: $subjectId } }
+        { predicateId: { _eq: $predicateId } }
+        { vault: { positions: { accountId: { _eq: $address } } } }
+      ]
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+
+  # Followers count
+  followers_count: triples(
+    where: {
+      _and: [
+        { subjectId: { _eq: $subjectId } }
+        { predicateId: { _eq: $predicateId } }
+        { objectId: { _eq: $objectId } }
+      ]
+    }
+  ) {
+    vault {
+      positions_aggregate {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Updates queries and fragments to support what we need for the user metadata. Runs codegen
- Uses the `useGetVaultDetails` hook and GraphQL hooks for all user data (excluding Points)
- This includes several TODO comments flagging our need to fix/update the type safety once we lock it all in
- This breaks the  _View All Tags_ modal but there are a lot of other pieces we need to fix to get this to work and we'll need to revisit it

## Screen Captures

![graphql-user-profile-metadata](https://github.com/user-attachments/assets/3bb523a4-2d1b-41a4-82af-e167a1d7b975)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
