### PR TITLE
ENG-4471 feat(portal,graphql): query consumer identity details

### DIFF
--- a/apps/portal/app/components/list/claims.tsx
+++ b/apps/portal/app/components/list/claims.tsx
@@ -4,15 +4,29 @@ import {
   ClaimRow,
   IconName,
   Identity,
+  useSidebarLayoutContext,
 } from '@0xintuition/1ui'
-import { ClaimSortColumn } from '@0xintuition/api'
+import {
+  ClaimPresenter,
+  ClaimSortColumn,
+  IdentityPresenter,
+} from '@0xintuition/api'
 import { GetTriplesWithPositionsQuery } from '@0xintuition/graphql'
 
 import { ListHeader } from '@components/list/list-header'
 import RemixLink from '@components/remix-link'
 import { stakeModalAtom } from '@lib/state/store'
-import { getClaimUrl } from '@lib/utils/misc'
+import {
+  formatBalance,
+  getAtomDescription,
+  getAtomImage,
+  getAtomIpfsLink,
+  getAtomLabel,
+  getAtomLink,
+  getClaimUrl,
+} from '@lib/utils/misc'
 import { Link } from '@remix-run/react'
+import { PaginationType } from 'app/types'
 import { useSetAtom } from 'jotai'
 
 import { SortOption } from '../sort-select'
@@ -23,7 +37,7 @@ type Triple = NonNullable<
 >
 
 // TODO: (ENG-4830) Add ReadOnly support back in and update our util functions that use it
-interface ClaimsListProps {
+interface ClaimsListNewProps {
   claims: Triple[]
   pagination: { aggregate?: { count: number } } | number
   paramPrefix?: string
@@ -33,7 +47,7 @@ interface ClaimsListProps {
   // readOnly?: boolean
 }
 
-export function ClaimsList({
+export function ClaimsListNew({
   claims,
   pagination,
   paramPrefix,
@@ -41,7 +55,7 @@ export function ClaimsList({
   enableSearch = true,
   enableSort = true,
   // readOnly = false,
-}: ClaimsListProps) {
+}: ClaimsListNewProps) {
   const setStakeModalActive = useSetAtom(stakeModalAtom)
 
   const paginationCount =
@@ -88,14 +102,33 @@ export function ClaimsList({
           className="grow shrink basis-0 self-stretch bg-background first:border-t-px first:rounded-t-xl last:rounded-b-xl theme-border border-t-0 flex-col justify-start gap-5 inline-flex"
         >
           <ClaimRow
-            numPositionsFor={0}
-            numPositionsAgainst={0}
-            tvlFor="0"
-            tvlAgainst="0"
-            totalTVL="0"
-            userPosition="0"
-            positionDirection={undefined}
+            numPositionsFor={triple.vault?.positionCount ?? 0}
+            numPositionsAgainst={triple.counterVault?.positionCount ?? 0}
+            tvlFor={formatBalance(triple.vault?.totalShares ?? '0', 18)}
+            tvlAgainst={formatBalance(
+              triple.counterVault?.totalShares ?? '0',
+              18,
+            )}
+            totalTVL={formatBalance(
+              BigInt(triple.vault?.totalShares ?? '0') +
+                BigInt(triple.counterVault?.totalShares ?? '0'),
+              18,
+            )}
+            userPosition={formatBalance(
+              triple.vault?.positions?.[0]?.shares ??
+                triple.counterVault?.positions?.[0]?.shares ??
+                '0',
+              18,
+            )}
+            positionDirection={
+              triple.vault?.positions?.[0]?.shares
+                ? ClaimPosition.claimFor
+                : triple.counterVault?.positions?.[0]?.shares
+                  ? ClaimPosition.claimAgainst
+                  : undefined
+            }
             onStakeForClick={() =>
+              // @ts-ignore // TODO: Fix the staking actions to use correct types
               setStakeModalActive((prevState) => ({
                 ...prevState,
                 mode: 'deposit',
@@ -103,10 +136,11 @@ export function ClaimsList({
                 direction: ClaimPosition.claimFor,
                 isOpen: true,
                 claim: triple,
-                vaultId: triple.vault?.id,
+                vaultId: triple?.id,
               }))
             }
             onStakeAgainstClick={() =>
+              // @ts-ignore // TODO: Fix the staking actions to use correct types
               setStakeModalActive((prevState) => ({
                 ...prevState,
                 mode: 'deposit',
@@ -114,14 +148,14 @@ export function ClaimsList({
                 direction: ClaimPosition.claimAgainst,
                 isOpen: true,
                 claim: triple,
-                vaultId: triple.vault?.id,
+                vaultId: triple?.id,
               }))
             }
             isFirst={!enableHeader && index === 0}
             isLast={index === claims.length - 1}
             className="border-none rounded-none"
           >
-            <Link to={getClaimUrl(triple.vault?.id ?? '')} prefetch="intent">
+            <Link to={getClaimUrl(triple?.id ?? '')} prefetch="intent">
               <Claim
                 size="md"
                 subject={{
@@ -154,6 +188,167 @@ export function ClaimsList({
                   link: '',
                   linkComponent: RemixLink,
                 }}
+                isClickable={true}
+              />
+            </Link>
+          </ClaimRow>
+        </div>
+      ))}
+    </List>
+  )
+}
+
+// LEGACY IMPLEMENTATION -- CAN REMOVE ONCE ALL CLAIMS ARE CONVERTED TO NEW IMPLEMENTATION
+export function ClaimsList({
+  claims,
+  pagination,
+  paramPrefix,
+  enableHeader = true,
+  enableSearch = true,
+  enableSort = true,
+  readOnly = false,
+}: {
+  claims: ClaimPresenter[]
+  pagination?: PaginationType
+  paramPrefix?: string
+  enableHeader?: boolean
+  enableSearch?: boolean
+  enableSort?: boolean
+  readOnly?: boolean
+}) {
+  const setStakeModalActive = useSetAtom(stakeModalAtom)
+  const { isMobileView } = useSidebarLayoutContext()
+
+  const options: SortOption<ClaimSortColumn>[] = [
+    { value: 'Total ETH', sortBy: 'AssetsSum' },
+    { value: 'ETH For', sortBy: 'ForAssetsSum' },
+    { value: 'ETH Against', sortBy: 'AgainstAssetsSum' },
+    { value: 'Total Positions', sortBy: 'NumPositions' },
+    { value: 'Positions For', sortBy: 'ForNumPositions' },
+    { value: 'Positions Against', sortBy: 'AgainstNumPositions' },
+    { value: 'Updated At', sortBy: 'UpdatedAt' },
+    { value: 'Created At', sortBy: 'CreatedAt' },
+  ]
+
+  return (
+    <List<ClaimSortColumn>
+      pagination={pagination}
+      paginationLabel="claims"
+      options={options}
+      paramPrefix={paramPrefix}
+      enableSearch={enableSearch}
+      enableSort={enableSort}
+    >
+      {enableHeader && (
+        <ListHeader
+          items={[
+            { label: 'Claim', icon: IconName.claim },
+            { label: 'TVL', icon: IconName.ethereum },
+          ]}
+        />
+      )}
+      {claims.map((claim, index) => (
+        <div
+          key={claim.claim_id}
+          className="grow shrink basis-0 self-stretch first:border-t-px first:rounded-t-xl last:rounded-b-xl theme-border border-t-0 flex-col justify-start gap-5 inline-flex"
+        >
+          <ClaimRow
+            numPositionsFor={claim.for_num_positions}
+            numPositionsAgainst={claim.against_num_positions}
+            tvlFor={formatBalance(claim.for_assets_sum, 18)}
+            tvlAgainst={formatBalance(claim.against_assets_sum, 18)}
+            totalTVL={formatBalance(claim.assets_sum, 18)}
+            userPosition={formatBalance(claim.user_assets, 18)}
+            positionDirection={
+              +claim.user_assets_for > 0
+                ? ClaimPosition.claimFor
+                : +claim.user_assets_against > 0
+                  ? ClaimPosition.claimAgainst
+                  : undefined
+            }
+            onStakeForClick={() =>
+              setStakeModalActive((prevState) => ({
+                ...prevState,
+                mode: 'deposit',
+                modalType: 'claim',
+                direction: ClaimPosition.claimFor,
+                isOpen: true,
+                claim,
+                vaultId: claim.vault_id,
+              }))
+            }
+            onStakeAgainstClick={() =>
+              setStakeModalActive((prevState) => ({
+                ...prevState,
+                mode: 'deposit',
+                modalType: 'claim',
+                direction: ClaimPosition.claimAgainst,
+                isOpen: true,
+                claim,
+                vaultId: claim.counter_vault_id,
+              }))
+            }
+            isFirst={!enableHeader && index === 0}
+            isLast={index === claims.length - 1}
+            className="border-none rounded-none"
+          >
+            <Link to={getClaimUrl(claim.vault_id)} prefetch="intent">
+              <Claim
+                size="md"
+                subject={{
+                  variant: claim.subject?.is_user
+                    ? Identity.user
+                    : Identity.nonUser,
+                  label: getAtomLabel(claim.subject as IdentityPresenter),
+                  imgSrc: getAtomImage(claim.subject as IdentityPresenter),
+                  id: claim.subject?.identity_id,
+                  description: getAtomDescription(
+                    claim.subject as IdentityPresenter,
+                  ),
+                  ipfsLink: getAtomIpfsLink(claim.subject as IdentityPresenter),
+                  link: getAtomLink(
+                    claim.subject as IdentityPresenter,
+                    readOnly,
+                  ),
+                  linkComponent: RemixLink,
+                }}
+                predicate={{
+                  variant: claim.predicate?.is_user
+                    ? Identity.user
+                    : Identity.nonUser,
+                  label: getAtomLabel(claim.predicate as IdentityPresenter),
+                  imgSrc: getAtomImage(claim.predicate as IdentityPresenter),
+                  id: claim.predicate?.identity_id,
+                  description: getAtomDescription(
+                    claim.predicate as IdentityPresenter,
+                  ),
+                  ipfsLink: getAtomIpfsLink(
+                    claim.predicate as IdentityPresenter,
+                  ),
+                  link: getAtomLink(
+                    claim.predicate as IdentityPresenter,
+                    readOnly,
+                  ),
+                  linkComponent: RemixLink,
+                }}
+                object={{
+                  variant: claim.object?.is_user
+                    ? Identity.user
+                    : Identity.nonUser,
+                  label: getAtomLabel(claim.object as IdentityPresenter),
+                  imgSrc: getAtomImage(claim.object as IdentityPresenter),
+                  id: claim.object?.identity_id,
+                  description: getAtomDescription(
+                    claim.object as IdentityPresenter,
+                  ),
+                  ipfsLink: getAtomIpfsLink(claim.object as IdentityPresenter),
+                  link: getAtomLink(
+                    claim.object as IdentityPresenter,
+                    readOnly,
+                  ),
+                  linkComponent: RemixLink,
+                }}
+                orientation={isMobileView ? 'vertical' : 'horizontal'}
                 isClickable={true}
               />
             </Link>

--- a/apps/portal/app/components/list/positions-on-identity.tsx
+++ b/apps/portal/app/components/list/positions-on-identity.tsx
@@ -1,11 +1,12 @@
 import { IconName, Identity } from '@0xintuition/1ui'
-import { PositionSortColumn } from '@0xintuition/api'
+import { PositionPresenter, PositionSortColumn } from '@0xintuition/api'
 import { GetPositionsQuery } from '@0xintuition/graphql'
 
 import { IdentityPositionRow } from '@components/identity/identity-position-row'
 import { ListHeader } from '@components/list/list-header'
 import { formatBalance, getProfileUrl } from '@lib/utils/misc'
 import { BLOCK_EXPLORER_URL } from 'app/consts'
+import { PaginationType } from 'app/types'
 import { formatUnits } from 'viem'
 
 import { SortOption } from '../sort-select'
@@ -13,7 +14,7 @@ import { List } from './list'
 
 type Position = NonNullable<GetPositionsQuery['positions']>[number]
 
-export function PositionsOnIdentity({
+export function PositionsOnIdentityNew({
   positions,
   pagination,
   readOnly = false,
@@ -73,6 +74,60 @@ export function PositionsOnIdentity({
             // updatedAt={position.updated_at} // TODO: Fix this when we have the updated_at
             link={getProfileUrl(position.account?.id, readOnly)}
             ipfsLink={`${BLOCK_EXPLORER_URL}/address/${position.account?.id}`}
+          />
+        </div>
+      ))}
+    </List>
+  )
+}
+
+// LEGACY IMPLEMENTATION -- CAN REMOVE ONCE ALL POSITIONS ARE CONVERTED TO NEW IMPLEMENTATION
+export function PositionsOnIdentity({
+  positions,
+  pagination,
+  readOnly = false,
+}: {
+  positions: PositionPresenter[]
+  pagination: PaginationType
+  readOnly?: boolean
+}) {
+  const options: SortOption<PositionSortColumn>[] = [
+    { value: 'Total ETH', sortBy: 'Assets' },
+    { value: 'Updated At', sortBy: 'UpdatedAt' },
+    { value: 'Created At', sortBy: 'CreatedAt' },
+  ]
+
+  return (
+    <List<PositionSortColumn>
+      pagination={pagination}
+      paginationLabel="positions"
+      options={options}
+      paramPrefix="positions"
+    >
+      <ListHeader
+        items={[
+          { label: 'User', icon: IconName.cryptoPunk },
+          { label: 'Position Amount', icon: IconName.ethereum },
+        ]}
+      />
+      {positions.map((position) => (
+        <div
+          key={position.id}
+          className={`grow shrink basis-0 self-stretch bg-black first:rounded-t-xl last:rounded-b-xl theme-border flex-col justify-start items-start gap-5 inline-flex`}
+        >
+          <IdentityPositionRow
+            variant={Identity.user}
+            avatarSrc={position.user?.image ?? ''}
+            name={position.user?.display_name ?? ''}
+            description={position.user?.description ?? ''}
+            id={position.user?.wallet ?? ''}
+            amount={+formatBalance(BigInt(position.assets), 18)}
+            feesAccrued={Number(
+              formatUnits(BigInt(+position.assets - +position.value), 18),
+            )}
+            updatedAt={position.updated_at}
+            link={getProfileUrl(position.user?.wallet, readOnly)}
+            ipfsLink={`${BLOCK_EXPLORER_URL}/address/${position.user?.wallet}`}
           />
         </div>
       ))}

--- a/apps/portal/app/components/list/positions-on-identity.tsx
+++ b/apps/portal/app/components/list/positions-on-identity.tsx
@@ -1,23 +1,25 @@
 import { IconName, Identity } from '@0xintuition/1ui'
-import { PositionPresenter, PositionSortColumn } from '@0xintuition/api'
+import { PositionSortColumn } from '@0xintuition/api'
+import { GetPositionsQuery } from '@0xintuition/graphql'
 
 import { IdentityPositionRow } from '@components/identity/identity-position-row'
 import { ListHeader } from '@components/list/list-header'
 import { formatBalance, getProfileUrl } from '@lib/utils/misc'
 import { BLOCK_EXPLORER_URL } from 'app/consts'
-import { PaginationType } from 'app/types/pagination'
 import { formatUnits } from 'viem'
 
 import { SortOption } from '../sort-select'
 import { List } from './list'
+
+type Position = NonNullable<GetPositionsQuery['positions']>[number]
 
 export function PositionsOnIdentity({
   positions,
   pagination,
   readOnly = false,
 }: {
-  positions: PositionPresenter[]
-  pagination: PaginationType
+  positions: Position[]
+  pagination: { aggregate?: { count: number } } | number
   readOnly?: boolean
 }) {
   const options: SortOption<PositionSortColumn>[] = [
@@ -26,9 +28,19 @@ export function PositionsOnIdentity({
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
 
+  const paginationCount =
+    typeof pagination === 'number'
+      ? pagination
+      : pagination?.aggregate?.count ?? 0
+
   return (
     <List<PositionSortColumn>
-      pagination={pagination}
+      pagination={{
+        currentPage: 1,
+        limit: 10,
+        totalEntries: paginationCount,
+        totalPages: Math.ceil(paginationCount / 10),
+      }}
       paginationLabel="positions"
       options={options}
       paramPrefix="positions"
@@ -39,24 +51,28 @@ export function PositionsOnIdentity({
           { label: 'Position Amount', icon: IconName.ethereum },
         ]}
       />
-      {positions.map((position) => (
+      {positions?.map((position) => (
         <div
           key={position.id}
           className={`grow shrink basis-0 self-stretch bg-black first:rounded-t-xl last:rounded-b-xl theme-border flex-col justify-start items-start gap-5 inline-flex`}
         >
           <IdentityPositionRow
             variant={Identity.user}
-            avatarSrc={position.user?.image ?? ''}
-            name={position.user?.display_name ?? ''}
-            description={position.user?.description ?? ''}
-            id={position.user?.wallet ?? ''}
-            amount={+formatBalance(BigInt(position.assets), 18)}
+            avatarSrc={position.account?.image ?? ''}
+            name={position.account?.label ?? ''}
+            description={position.account?.label ?? ''} // TODO: Fix this when we have the description
+            id={position.account?.id ?? ''}
+            amount={+formatBalance(BigInt(position.shares || '0'), 18)}
             feesAccrued={Number(
-              formatUnits(BigInt(+position.assets - +position.value), 18),
+              formatUnits(
+                // @ts-ignore // TODO: Fix this when we determine what the value should be
+                BigInt(+position.shares - +(position.value ?? position.shares)),
+                18,
+              ),
             )}
-            updatedAt={position.updated_at}
-            link={getProfileUrl(position.user?.wallet, readOnly)}
-            ipfsLink={`${BLOCK_EXPLORER_URL}/address/${position.user?.wallet}`}
+            // updatedAt={position.updated_at} // TODO: Fix this when we have the updated_at
+            link={getProfileUrl(position.account?.id, readOnly)}
+            ipfsLink={`${BLOCK_EXPLORER_URL}/address/${position.account?.id}`}
           />
         </div>
       ))}

--- a/apps/portal/app/components/profile/data-about-header.tsx
+++ b/apps/portal/app/components/profile/data-about-header.tsx
@@ -8,6 +8,7 @@ import {
   TextWeight,
   Trunctacular,
 } from '@0xintuition/1ui'
+import { IdentityPresenter } from '@0xintuition/api'
 
 export const DataAboutHeaderVariants = {
   positions: 'positions',
@@ -18,10 +19,11 @@ export type DataAboutHeaderVariantType =
   (typeof DataAboutHeaderVariants)[keyof typeof DataAboutHeaderVariants]
 
 interface DataAboutHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  userIdentity?: IdentityPresenter
   variant: DataAboutHeaderVariantType
-  atomImage: string
-  atomLabel: string
-  atomVariant: 'user' | 'non-user'
+  atomImage?: string
+  atomLabel?: string
+  atomVariant?: 'user' | 'non-user'
   totalClaims?: number
   totalPositions?: number
   totalStake: number
@@ -51,7 +53,7 @@ const DataAboutHeader: React.FC<DataAboutHeaderProps> = ({
           {variant === 'claims' ? 'Claims about' : 'Conviction in'}
         </Text>
         <IdentityTag imgSrc={atomImage} variant={atomVariant}>
-          <Trunctacular value={atomLabel} maxStringLength={40} />
+          <Trunctacular value={atomLabel ?? ''} maxStringLength={40} />
         </IdentityTag>
       </div>
       <div className="flex justify-between w-full">

--- a/apps/portal/app/components/profile/data-about-header.tsx
+++ b/apps/portal/app/components/profile/data-about-header.tsx
@@ -8,9 +8,6 @@ import {
   TextWeight,
   Trunctacular,
 } from '@0xintuition/1ui'
-import { IdentityPresenter } from '@0xintuition/api'
-
-import { getAtomLabel } from '@lib/utils/misc'
 
 export const DataAboutHeaderVariants = {
   positions: 'positions',
@@ -22,7 +19,9 @@ export type DataAboutHeaderVariantType =
 
 interface DataAboutHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   variant: DataAboutHeaderVariantType
-  userIdentity: IdentityPresenter
+  atomImage: string
+  atomLabel: string
+  atomVariant: 'user' | 'non-user'
   totalClaims?: number
   totalPositions?: number
   totalStake: number
@@ -30,7 +29,9 @@ interface DataAboutHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const DataAboutHeader: React.FC<DataAboutHeaderProps> = ({
   variant,
-  userIdentity,
+  atomImage,
+  atomLabel,
+  atomVariant,
   totalClaims,
   totalPositions,
   totalStake,
@@ -49,14 +50,8 @@ const DataAboutHeader: React.FC<DataAboutHeaderProps> = ({
         >
           {variant === 'claims' ? 'Claims about' : 'Conviction in'}
         </Text>
-        <IdentityTag
-          imgSrc={userIdentity?.user?.image ?? userIdentity?.image}
-          variant={userIdentity?.user ? 'user' : 'non-user'}
-        >
-          <Trunctacular
-            value={getAtomLabel(userIdentity)}
-            maxStringLength={40}
-          />
+        <IdentityTag imgSrc={atomImage} variant={atomVariant}>
+          <Trunctacular value={atomLabel} maxStringLength={40} />
         </IdentityTag>
       </div>
       <div className="flex justify-between w-full">

--- a/apps/portal/app/routes/app+/identity+/$id+/index.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id+/index.tsx
@@ -19,8 +19,8 @@ import {
 
 import CreateClaimModal from '@components/create-claim/create-claim-modal'
 import { ErrorPage } from '@components/error-page'
-import { ClaimsList as ClaimsAboutIdentity } from '@components/list/claims'
-import { PositionsOnIdentity } from '@components/list/positions-on-identity'
+import { ClaimsListNew as ClaimsAboutIdentity } from '@components/list/claims'
+import { PositionsOnIdentityNew } from '@components/list/positions-on-identity'
 import DataAboutHeader from '@components/profile/data-about-header'
 import { RevalidateButton } from '@components/revalidate-button'
 import { DataHeaderSkeleton, PaginatedListSkeleton } from '@components/skeleton'
@@ -347,7 +347,7 @@ export default function ProfileDataAbout() {
                 <RevalidateButton />
               </ErrorStateCard>
             ) : (
-              <PositionsOnIdentity
+              <PositionsOnIdentityNew
                 positions={positionsResult?.positions ?? []}
                 pagination={positionsResult?.total?.aggregate?.count ?? {}}
               />

--- a/apps/portal/app/routes/app+/identity+/$id.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id.tsx
@@ -59,11 +59,6 @@ import logger from '@lib/utils/logger'
 import {
   calculatePercentageOfTvl,
   formatBalance,
-  getAtomDescription,
-  getAtomId,
-  getAtomImage,
-  getAtomIpfsLink,
-  getAtomLabel,
   invariant,
 } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs } from '@remix-run/node'
@@ -198,7 +193,7 @@ export interface IdentityLoaderData {
 }
 
 export default function IdentityDetails() {
-  const { identity, list, userWallet, tagClaims, initialParams } =
+  const { identity, userWallet, tagClaims, initialParams } =
     useLiveLoader<IdentityLoaderData>(['attest', 'create'])
   const navigate = useNavigate()
 

--- a/apps/portal/app/routes/app+/identity+/$id.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id.tsx
@@ -22,6 +22,17 @@ import {
   ClaimsService,
   IdentityPresenter,
 } from '@0xintuition/api'
+import {
+  fetcher,
+  GetAtomDocument,
+  GetAtomQuery,
+  GetAtomQueryVariables,
+  GetTagsDocument,
+  GetTagsQuery,
+  GetTagsQueryVariables,
+  useGetAtomQuery,
+  useGetTagsQuery,
+} from '@0xintuition/graphql'
 
 import { DetailInfoCard } from '@components/detail-info-card'
 import { ErrorPage } from '@components/error-page'
@@ -32,6 +43,7 @@ import ShareCta from '@components/share-cta'
 import ShareModal from '@components/share-modal'
 import StakeModal from '@components/stake/stake-modal'
 import TagsModal from '@components/tags/tags-modal'
+import { useGetVaultDetails } from '@lib/hooks/useGetVaultDetails'
 import { useLiveLoader } from '@lib/hooks/useLiveLoader'
 import { getIdentityOrPending } from '@lib/services/identities'
 import { getTags } from '@lib/services/tags'
@@ -57,7 +69,7 @@ import {
 import { json, LoaderFunctionArgs } from '@remix-run/node'
 import { Outlet, useNavigate } from '@remix-run/react'
 import { requireUser, requireUserWallet } from '@server/auth'
-import { getVaultDetails } from '@server/multivault'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
 import {
   BLOCK_EXPLORER_URL,
   CURRENT_ENV,
@@ -66,11 +78,7 @@ import {
   PATHS,
 } from 'app/consts'
 import TwoPanelLayout from 'app/layouts/two-panel-layout'
-import { VaultDetailsType } from 'app/types/vault'
 import { useAtom } from 'jotai'
-import { GetAccountQuery, fetcher, GetAccountQueryVariables, GetAccountDocument, GetTagsQuery, GetTagsQueryVariables, GetTagsDocument, GetAtomDocument, GetAtomQuery, GetAtomQueryVariables, GetAtomQuery, useGetAtomQuery, useGetTagsQuery } from '@0xintuition/graphql'
-import { dehydrate, QueryClient } from '@tanstack/react-query'
-import { string } from 'zod'
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const user = await requireUser(request)
@@ -107,21 +115,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     logger('Failed to fetch list:', error)
   }
 
-  let vaultDetails: VaultDetailsType | null = null
-
-  if (!!identity && identity.vault_id) {
-    try {
-      vaultDetails = await getVaultDetails(
-        identity.contract,
-        identity.vault_id,
-        userWallet as `0x${string}`,
-      )
-    } catch (error) {
-      logger('Failed to fetch vaultDetails:', error)
-      vaultDetails = null
-    }
-  }
-
   const url = new URL(request.url)
   const searchParams = new URLSearchParams(url.search)
 
@@ -130,8 +123,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     subjectId: identity.id,
     searchParams,
   })
-
-
 
   let atomResult: GetAtomQuery | null = null
 
@@ -153,14 +144,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       queryFn: () => atomResult,
     })
 
-
-    const atomTagsResult = await fetcher<
-      GetTagsQuery,
-      GetTagsQueryVariables
-    >(GetTagsDocument, {
-      subjectId: params.id,
-      predicateId: getSpecialPredicate(CURRENT_ENV).tagPredicate.vaultId,
-    })()
+    const atomTagsResult = await fetcher<GetTagsQuery, GetTagsQueryVariables>(
+      GetTagsDocument,
+      {
+        subjectId: params.id,
+        predicateId: getSpecialPredicate(CURRENT_ENV).tagPredicate.vaultId,
+      },
+    )()
 
     logger('Atom Tags Result:', atomTagsResult)
 
@@ -185,26 +175,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   logger('[$ID] -- END')
   return json({
-
     identity,
     list,
     isPending,
-    vaultDetails,
     userWallet,
     tagClaims,
     dehydratedState: dehydrate(queryClient),
     initialParams: {
-      atomId: params.id
-    }
+      atomId: params.id,
+    },
   })
 }
 
 export interface IdentityLoaderData {
   identity: IdentityPresenter
   list: ClaimPresenter
-  vaultDetails: VaultDetailsType
   userWallet: string
-  isPending: boolean
   tagClaims: ClaimPresenter[]
   initialParams: {
     atomId: string
@@ -212,11 +198,13 @@ export interface IdentityLoaderData {
 }
 
 export default function IdentityDetails() {
-  const { identity, list, vaultDetails, userWallet, isPending, tagClaims, initialParams } =
+  const { identity, list, userWallet, tagClaims, initialParams } =
     useLiveLoader<IdentityLoaderData>(['attest', 'create'])
   const navigate = useNavigate()
 
-  const { user_assets, assets_sum } = vaultDetails ? vaultDetails : identity
+  // TODO: Remove this once the `status is added to atoms -- that will be what we check if something is pending. For now setting this to false and removing the legacy isPending check
+  const isPending = false
+
   const [stakeModalActive, setStakeModalActive] = useAtom(stakeModalAtom)
   const [tagsModalActive, setTagsModalActive] = useAtom(tagsModalAtom)
   const [saveListModalActive, setSaveListModalActive] =
@@ -235,7 +223,7 @@ export default function IdentityDetails() {
 
   const { data: atomResult } = useGetAtomQuery(
     {
-      id: initialParams.atomId
+      id: initialParams.atomId,
     },
     {
       queryKey: ['get-atom', { id: initialParams.atomId }],
@@ -263,17 +251,34 @@ export default function IdentityDetails() {
 
   logger('Atom Tags Result (Client):', atomTagsResult)
 
+  const { data: vaultDetails } = useGetVaultDetails(
+    MULTIVAULT_CONTRACT_ADDRESS,
+    initialParams.atomId,
+    undefined, // no counterVaultId
+    {
+      queryKey: [
+        'get-vault-details',
+        MULTIVAULT_CONTRACT_ADDRESS,
+        initialParams.atomId,
+      ],
+    },
+  )
+
+  logger('Vault Details:', vaultDetails)
+  const { user_assets, assets_sum } = vaultDetails ? vaultDetails : identity
+
   const leftPanel = (
     <div className="flex-col justify-start items-start inline-flex gap-6 max-lg:w-full">
       <ProfileCard
         variant={Identity.nonUser}
-        avatarSrc={getAtomImage(identity)}
-        name={getAtomLabel(identity)}
-        id={getAtomId(identity)}
-        vaultId={identity?.vault_id}
-        bio={getAtomDescription(identity)}
-        ipfsLink={getAtomIpfsLink(identity)}
-        externalLink={identity.external_reference ?? ''}
+        // avatarSrc={getAtomImage(identity)} // TODO: Bring back our utils once we're ready!
+        avatarSrc={atomResult?.atom?.value?.thing?.image ?? ''}
+        name={atomResult?.atom?.value?.thing?.name ?? ''}
+        id={atomResult?.atom?.id ?? ''}
+        vaultId={atomResult?.atom?.id ?? 0}
+        bio={atomResult?.atom?.value?.thing?.description ?? ''}
+        ipfsLink={atomResult?.atom?.data ?? ''}
+        externalLink={atomResult?.atom?.value?.thing?.url ?? ''}
         onAvatarClick={() => {
           setImageModalActive({
             isOpen: true,
@@ -286,19 +291,21 @@ export default function IdentityDetails() {
         <>
           <Tags>
             <div className="flex flex-row gap-2 md:flex-col">
-              {Array.isArray(tagClaims) && tagClaims.length > 0 ? (
-                <TagsContent numberOfTags={tagClaims?.length ?? 0}>
-                  {tagClaims.slice(0, 5).map((tagClaim) => (
+              {atomTagsResult && atomTagsResult.triples.length > 0 ? (
+                <TagsContent numberOfTags={atomTagsResult.triples?.length ?? 0}>
+                  {atomTagsResult.triples.slice(0, 5).map((tag) => (
                     <TagWithValue
-                      key={tagClaim.claim_id}
-                      label={tagClaim.object?.display_name}
-                      value={tagClaim.num_positions}
+                      key={tag.id}
+                      label={tag.object?.label ?? ''}
+                      value={tag.vault?.allPositions?.aggregate?.count ?? 0}
                       onStake={() => {
-                        setSelectedTag(tagClaim.object)
+                        setSelectedTag(
+                          tag?.object as unknown as IdentityPresenter,
+                        ) // TODO: (ENG-4782) temporary type fix until we lock in final types
                         setSaveListModalActive({
                           isOpen: true,
-                          id: tagClaim.vault_id,
-                          tag: tagClaim.object,
+                          id: tag.id,
+                          tag: tag.object as unknown as IdentityPresenter, // TODO: (ENG-4782) temporary type fix until we lock in final types
                         })
                       }}
                     />
@@ -329,7 +336,40 @@ export default function IdentityDetails() {
                   ...prevState,
                   mode: 'redeem',
                   modalType: 'identity',
-                  identity,
+                  identity: {
+                    // TODO: (ENG-4782) temporary type fix until we lock in final types
+                    id: atomResult?.atom?.id ?? '',
+                    label: atomResult?.atom?.value?.thing?.name ?? '',
+                    image: atomResult?.atom?.value?.thing?.image ?? '',
+                    vault_id: atomResult?.atom?.id,
+                    assets_sum: '0',
+                    user_assets: '0',
+                    contract: MULTIVAULT_CONTRACT_ADDRESS,
+                    asset_delta: '0',
+                    conviction_price: '0',
+                    conviction_price_delta: '0',
+                    conviction_sum: '0',
+                    num_positions: 0,
+                    price: '0',
+                    price_delta: '0',
+                    status: 'active',
+                    total_conviction: '0',
+                    type: 'user',
+                    updated_at: new Date().toISOString(),
+                    created_at: new Date().toISOString(),
+                    creator_address: '',
+                    display_name: atomResult?.atom?.value?.thing?.name ?? '',
+                    follow_vault_id: '',
+                    user: null,
+                    creator: null,
+                    identity_hash: '',
+                    identity_id: '',
+                    is_contract: false,
+                    is_user: true,
+                    pending: false,
+                    pending_type: null,
+                    pending_vault_id: null,
+                  } as unknown as IdentityPresenter,
                   isOpen: true,
                 }))
               }
@@ -350,16 +390,51 @@ export default function IdentityDetails() {
           ) : null}
           <IdentityStakeCard
             tvl={+formatBalance(assets_sum, 18)}
-            holders={identity?.num_positions}
-            variant={identity.is_user ? Identity.user : Identity.nonUser}
-            identityImgSrc={getAtomImage(identity)}
-            identityDisplayName={getAtomLabel(identity)}
+            holders={atomResult?.atom?.vault?.positionCount ?? 0}
+            variant={Identity.nonUser} // TODO: Use the atom type to determine this once we have these
+            // identityImgSrc={getAtomImage(identity)}
+            // identityDisplayName={getAtomLabel(identity)}
+            identityImgSrc={atomResult?.atom?.value?.thing?.image ?? ''}
+            identityDisplayName={atomResult?.atom?.value?.thing?.name ?? ''}
             onBuyClick={() =>
               setStakeModalActive((prevState) => ({
                 ...prevState,
                 mode: 'deposit',
                 modalType: 'identity',
-                identity,
+                identity: {
+                  // TODO: (ENG-4782) temporary type fix until we lock in final types
+                  id: atomResult?.atom?.id ?? '',
+                  label: atomResult?.atom?.value?.thing?.name ?? '',
+                  image: atomResult?.atom?.value?.thing?.image ?? '',
+                  vault_id: atomResult?.atom?.id,
+                  assets_sum: '0',
+                  user_assets: '0',
+                  contract: MULTIVAULT_CONTRACT_ADDRESS,
+                  asset_delta: '0',
+                  conviction_price: '0',
+                  conviction_price_delta: '0',
+                  conviction_sum: '0',
+                  num_positions: 0,
+                  price: '0',
+                  price_delta: '0',
+                  status: 'active',
+                  total_conviction: '0',
+                  type: 'user',
+                  updated_at: new Date().toISOString(),
+                  created_at: new Date().toISOString(),
+                  creator_address: '',
+                  display_name: atomResult?.atom?.value?.thing?.name ?? '',
+                  follow_vault_id: '',
+                  user: null,
+                  creator: null,
+                  identity_hash: '',
+                  identity_id: '',
+                  is_contract: false,
+                  is_user: true,
+                  pending: false,
+                  pending_type: null,
+                  pending_vault_id: null,
+                } as unknown as IdentityPresenter,
                 isOpen: true,
               }))
             }
@@ -371,18 +446,18 @@ export default function IdentityDetails() {
       )}
       <DetailInfoCard
         variant={Identity.user}
-        list={list}
-        username={identity.creator?.display_name ?? '?'}
-        avatarImgSrc={identity.creator?.image ?? ''}
-        id={identity.creator?.wallet ?? ''}
+        username={atomResult?.atom?.creator?.label ?? '?'}
+        avatarImgSrc={atomResult?.atom?.creator?.image ?? ''}
+        id={atomResult?.atom?.creator?.id ?? ''}
         description={identity.creator?.description ?? ''}
         link={
-          identity.creator?.id
-            ? `${PATHS.PROFILE}/${identity.creator?.wallet}`
+          atomResult?.atom?.creator?.id
+            ? `${PATHS.PROFILE}/${atomResult?.atom?.creator?.id}`
             : ''
         }
-        ipfsLink={`${BLOCK_EXPLORER_URL}/address/${identity.creator?.wallet}`}
-        timestamp={identity.created_at}
+        ipfsLink={`${BLOCK_EXPLORER_URL}/address/${atomResult?.atom?.creator?.id}`}
+        // timestamp={atomResult?.atom?.blockTimestamp ?? new Date().toISOString()} // TODO: Add this once we have it on the atom
+        timestamp={new Date().toISOString()}
         className="w-full"
       />
       <ShareCta

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "portal:dev": "nx dev @0xintuition/portal",
     "portal:start": "nx start @0xintuition/portal",
     "portal:build": "nx build @0xintuition/portal",
+    "portal:typecheck": "nx typecheck @0xintuition/portal",
     "portal:lint": "nx lint @0xintuition/portal",
     "portal:test": "nx test @0xintuition/portal --reporter=verbose",
     "template:dev": "nx dev @0xintuition/template",

--- a/packages/graphql/src/fragments/position.graphql
+++ b/packages/graphql/src/fragments/position.graphql
@@ -3,6 +3,7 @@ fragment PositionDetails on positions {
   account {
     id
     label
+    image
   }
   vault {
     id

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -11935,6 +11935,75 @@ export type GetTripleQuery = {
   } | null
 }
 
+export type GetAtomTriplesWithPositionsQueryVariables = Exact<{
+  where?: InputMaybe<Triples_Bool_Exp>
+}>
+
+export type GetAtomTriplesWithPositionsQuery = {
+  __typename?: 'query_root'
+  triples_aggregate: {
+    __typename?: 'triples_aggregate'
+    aggregate?: {
+      __typename?: 'triples_aggregate_fields'
+      count: number
+    } | null
+  }
+}
+
+export type GetTriplesWithPositionsQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  orderBy?: InputMaybe<Array<Triples_Order_By> | Triples_Order_By>
+  where?: InputMaybe<Triples_Bool_Exp>
+  address?: InputMaybe<Scalars['String']['input']>
+}>
+
+export type GetTriplesWithPositionsQuery = {
+  __typename?: 'query_root'
+  total: {
+    __typename?: 'triples_aggregate'
+    aggregate?: {
+      __typename?: 'triples_aggregate_fields'
+      count: number
+    } | null
+  }
+  triples: Array<{
+    __typename?: 'triples'
+    id: any
+    subject?: {
+      __typename?: 'atoms'
+      id: any
+      label?: string | null
+      image?: string | null
+    } | null
+    predicate?: {
+      __typename?: 'atoms'
+      id: any
+      label?: string | null
+      image?: string | null
+    } | null
+    object?: {
+      __typename?: 'atoms'
+      id: any
+      label?: string | null
+      image?: string | null
+    } | null
+    vault?: {
+      __typename?: 'vaults'
+      positions: Array<{
+        __typename?: 'positions'
+        shares: any
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
+      }>
+    } | null
+  }>
+}
+
 export type GetVaultsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>
   offset?: InputMaybe<Scalars['Int']['input']>
@@ -15886,6 +15955,240 @@ useGetTripleQuery.fetcher = (
 ) =>
   fetcher<GetTripleQuery, GetTripleQueryVariables>(
     GetTripleDocument,
+    variables,
+    options,
+  )
+
+export const GetAtomTriplesWithPositionsDocument = `
+    query GetAtomTriplesWithPositions($where: triples_bool_exp) {
+  triples_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}
+    `
+
+export const useGetAtomTriplesWithPositionsQuery = <
+  TData = GetAtomTriplesWithPositionsQuery,
+  TError = unknown,
+>(
+  variables?: GetAtomTriplesWithPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomTriplesWithPositionsQuery, TError, TData>,
+    'queryKey'
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAtomTriplesWithPositionsQuery,
+      TError,
+      TData
+    >['queryKey']
+  },
+) => {
+  return useQuery<GetAtomTriplesWithPositionsQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ['GetAtomTriplesWithPositions']
+        : ['GetAtomTriplesWithPositions', variables],
+    queryFn: fetcher<
+      GetAtomTriplesWithPositionsQuery,
+      GetAtomTriplesWithPositionsQueryVariables
+    >(GetAtomTriplesWithPositionsDocument, variables),
+    ...options,
+  })
+}
+
+useGetAtomTriplesWithPositionsQuery.document =
+  GetAtomTriplesWithPositionsDocument
+
+useGetAtomTriplesWithPositionsQuery.getKey = (
+  variables?: GetAtomTriplesWithPositionsQueryVariables,
+) =>
+  variables === undefined
+    ? ['GetAtomTriplesWithPositions']
+    : ['GetAtomTriplesWithPositions', variables]
+
+export const useInfiniteGetAtomTriplesWithPositionsQuery = <
+  TData = InfiniteData<GetAtomTriplesWithPositionsQuery>,
+  TError = unknown,
+>(
+  variables: GetAtomTriplesWithPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomTriplesWithPositionsQuery, TError, TData>,
+    'queryKey'
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomTriplesWithPositionsQuery,
+      TError,
+      TData
+    >['queryKey']
+  },
+) => {
+  return useInfiniteQuery<GetAtomTriplesWithPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ['GetAtomTriplesWithPositions.infinite']
+            : ['GetAtomTriplesWithPositions.infinite', variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetAtomTriplesWithPositionsQuery,
+            GetAtomTriplesWithPositionsQueryVariables
+          >(GetAtomTriplesWithPositionsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {}),
+          })(),
+        ...restOptions,
+      }
+    })(),
+  )
+}
+
+useInfiniteGetAtomTriplesWithPositionsQuery.getKey = (
+  variables?: GetAtomTriplesWithPositionsQueryVariables,
+) =>
+  variables === undefined
+    ? ['GetAtomTriplesWithPositions.infinite']
+    : ['GetAtomTriplesWithPositions.infinite', variables]
+
+useGetAtomTriplesWithPositionsQuery.fetcher = (
+  variables?: GetAtomTriplesWithPositionsQueryVariables,
+  options?: RequestInit['headers'],
+) =>
+  fetcher<
+    GetAtomTriplesWithPositionsQuery,
+    GetAtomTriplesWithPositionsQueryVariables
+  >(GetAtomTriplesWithPositionsDocument, variables, options)
+
+export const GetTriplesWithPositionsDocument = `
+    query GetTriplesWithPositions($limit: Int, $offset: Int, $orderBy: [triples_order_by!], $where: triples_bool_exp, $address: String) {
+  total: triples_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  triples(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    id
+    subject {
+      id
+      label
+      image
+    }
+    predicate {
+      id
+      label
+      image
+    }
+    object {
+      id
+      label
+      image
+    }
+    vault {
+      positions(where: {accountId: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+  }
+}
+    `
+
+export const useGetTriplesWithPositionsQuery = <
+  TData = GetTriplesWithPositionsQuery,
+  TError = unknown,
+>(
+  variables?: GetTriplesWithPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTriplesWithPositionsQuery, TError, TData>,
+    'queryKey'
+  > & {
+    queryKey?: UseQueryOptions<
+      GetTriplesWithPositionsQuery,
+      TError,
+      TData
+    >['queryKey']
+  },
+) => {
+  return useQuery<GetTriplesWithPositionsQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ['GetTriplesWithPositions']
+        : ['GetTriplesWithPositions', variables],
+    queryFn: fetcher<
+      GetTriplesWithPositionsQuery,
+      GetTriplesWithPositionsQueryVariables
+    >(GetTriplesWithPositionsDocument, variables),
+    ...options,
+  })
+}
+
+useGetTriplesWithPositionsQuery.document = GetTriplesWithPositionsDocument
+
+useGetTriplesWithPositionsQuery.getKey = (
+  variables?: GetTriplesWithPositionsQueryVariables,
+) =>
+  variables === undefined
+    ? ['GetTriplesWithPositions']
+    : ['GetTriplesWithPositions', variables]
+
+export const useInfiniteGetTriplesWithPositionsQuery = <
+  TData = InfiniteData<GetTriplesWithPositionsQuery>,
+  TError = unknown,
+>(
+  variables: GetTriplesWithPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTriplesWithPositionsQuery, TError, TData>,
+    'queryKey'
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTriplesWithPositionsQuery,
+      TError,
+      TData
+    >['queryKey']
+  },
+) => {
+  return useInfiniteQuery<GetTriplesWithPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ['GetTriplesWithPositions.infinite']
+            : ['GetTriplesWithPositions.infinite', variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetTriplesWithPositionsQuery,
+            GetTriplesWithPositionsQueryVariables
+          >(GetTriplesWithPositionsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {}),
+          })(),
+        ...restOptions,
+      }
+    })(),
+  )
+}
+
+useInfiniteGetTriplesWithPositionsQuery.getKey = (
+  variables?: GetTriplesWithPositionsQueryVariables,
+) =>
+  variables === undefined
+    ? ['GetTriplesWithPositions.infinite']
+    : ['GetTriplesWithPositions.infinite', variables]
+
+useGetTriplesWithPositionsQuery.fetcher = (
+  variables?: GetTriplesWithPositionsQueryVariables,
+  options?: RequestInit['headers'],
+) =>
+  fetcher<GetTriplesWithPositionsQuery, GetTriplesWithPositionsQueryVariables>(
+    GetTriplesWithPositionsDocument,
     variables,
     options,
   )
@@ -33242,6 +33545,316 @@ export const GetTriple = {
           },
           { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
           { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode
+export const GetAtomTriplesWithPositions = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'GetAtomTriplesWithPositions' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'where' },
+          },
+          type: {
+            kind: 'NamedType',
+            name: { kind: 'Name', value: 'triples_bool_exp' },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'triples_aggregate' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'where' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'where' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'aggregate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'count' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode
+export const GetTriplesWithPositions = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'GetTriplesWithPositions' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'limit' },
+          },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'offset' },
+          },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'orderBy' },
+          },
+          type: {
+            kind: 'ListType',
+            type: {
+              kind: 'NonNullType',
+              type: {
+                kind: 'NamedType',
+                name: { kind: 'Name', value: 'triples_order_by' },
+              },
+            },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'where' },
+          },
+          type: {
+            kind: 'NamedType',
+            name: { kind: 'Name', value: 'triples_bool_exp' },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'address' },
+          },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            alias: { kind: 'Name', value: 'total' },
+            name: { kind: 'Name', value: 'triples_aggregate' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'where' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'where' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'aggregate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'count' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'triples' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'limit' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'limit' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'offset' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'offset' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'order_by' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'orderBy' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'where' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'where' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'subject' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'predicate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'object' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'image' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'vault' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'positions' },
+                        arguments: [
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'where' },
+                            value: {
+                              kind: 'ObjectValue',
+                              fields: [
+                                {
+                                  kind: 'ObjectField',
+                                  name: { kind: 'Name', value: 'accountId' },
+                                  value: {
+                                    kind: 'ObjectValue',
+                                    fields: [
+                                      {
+                                        kind: 'ObjectField',
+                                        name: { kind: 'Name', value: '_eq' },
+                                        value: {
+                                          kind: 'Variable',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'address',
+                                          },
+                                        },
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'account' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'id' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'label' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'image' },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'shares' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
         ],
       },
     },

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -11990,6 +11990,23 @@ export type GetTriplesWithPositionsQuery = {
     } | null
     vault?: {
       __typename?: 'vaults'
+      totalShares: any
+      positionCount: number
+      positions: Array<{
+        __typename?: 'positions'
+        shares: any
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
+      }>
+    } | null
+    counterVault?: {
+      __typename?: 'vaults'
+      totalShares: any
+      positionCount: number
       positions: Array<{
         __typename?: 'positions'
         shares: any
@@ -16087,6 +16104,20 @@ export const GetTriplesWithPositionsDocument = `
       image
     }
     vault {
+      totalShares
+      positionCount
+      positions(where: {accountId: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+    counterVault {
+      totalShares
+      positionCount
       positions(where: {accountId: {_eq: $address}}) {
         account {
           id
@@ -33784,6 +33815,96 @@ export const GetTriplesWithPositions = {
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'totalShares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'positionCount' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'positions' },
+                        arguments: [
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'where' },
+                            value: {
+                              kind: 'ObjectValue',
+                              fields: [
+                                {
+                                  kind: 'ObjectField',
+                                  name: { kind: 'Name', value: 'accountId' },
+                                  value: {
+                                    kind: 'ObjectValue',
+                                    fields: [
+                                      {
+                                        kind: 'ObjectField',
+                                        name: { kind: 'Name', value: '_eq' },
+                                        value: {
+                                          kind: 'Variable',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'address',
+                                          },
+                                        },
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'account' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'id' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'label' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'image' },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'shares' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'counterVault' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'totalShares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'positionCount' },
+                      },
                       {
                         kind: 'Field',
                         name: { kind: 'Name', value: 'positions' },

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -10672,6 +10672,7 @@ export type GetPositionsQuery = {
     aggregate?: {
       __typename?: 'positions_aggregate_fields'
       count: number
+      sum?: { __typename?: 'positions_sum_fields'; shares?: any | null } | null
     } | null
   }
   positions: Array<{
@@ -14833,6 +14834,9 @@ export const GetPositionsDocument = `
   total: positions_aggregate(where: $where) {
     aggregate {
       count
+      sum {
+        shares
+      }
     }
   }
   positions(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
@@ -29782,6 +29786,19 @@ export const GetPositions = {
                     kind: 'SelectionSet',
                     selections: [
                       { kind: 'Field', name: { kind: 'Name', value: 'count' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'sum' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'shares' },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -8054,7 +8054,12 @@ export type PositionDetailsFragment = {
   id: string
   shares: any
   vaultId: any
-  account?: { __typename?: 'accounts'; id: string; label: string } | null
+  account?: {
+    __typename?: 'accounts'
+    id: string
+    label: string
+    image?: string | null
+  } | null
   vault?: {
     __typename?: 'vaults'
     id: any
@@ -10680,7 +10685,12 @@ export type GetPositionsQuery = {
     id: string
     shares: any
     vaultId: any
-    account?: { __typename?: 'accounts'; id: string; label: string } | null
+    account?: {
+      __typename?: 'accounts'
+      id: string
+      label: string
+      image?: string | null
+    } | null
     vault?: {
       __typename?: 'vaults'
       id: any
@@ -10724,7 +10734,12 @@ export type GetPositionsWithAggregatesQuery = {
       id: string
       shares: any
       vaultId: any
-      account?: { __typename?: 'accounts'; id: string; label: string } | null
+      account?: {
+        __typename?: 'accounts'
+        id: string
+        label: string
+        image?: string | null
+      } | null
       vault?: {
         __typename?: 'vaults'
         id: any
@@ -10779,7 +10794,12 @@ export type GetPositionQuery = {
     id: string
     shares: any
     vaultId: any
-    account?: { __typename?: 'accounts'; id: string; label: string } | null
+    account?: {
+      __typename?: 'accounts'
+      id: string
+      label: string
+      image?: string | null
+    } | null
     vault?: {
       __typename?: 'vaults'
       id: any
@@ -12611,6 +12631,7 @@ export const PositionDetailsFragmentDoc = `
   account {
     id
     label
+    image
   }
   vault {
     id
@@ -19720,6 +19741,7 @@ export const PositionDetails = {
               selections: [
                 { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'image' } },
               ],
             },
           },
@@ -29874,6 +29896,7 @@ export const GetPositions = {
               selections: [
                 { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'image' } },
               ],
             },
           },
@@ -30110,6 +30133,7 @@ export const GetPositionsWithAggregates = {
               selections: [
                 { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'image' } },
               ],
             },
           },
@@ -30330,6 +30354,7 @@ export const GetPosition = {
               selections: [
                 { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'image' } },
               ],
             },
           },

--- a/packages/graphql/src/queries/positions.graphql
+++ b/packages/graphql/src/queries/positions.graphql
@@ -8,6 +8,9 @@ query GetPositions(
   total: positions_aggregate(where: $where) {
     aggregate {
       count
+      sum {
+        shares
+      }
     }
   }
   positions(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {

--- a/packages/graphql/src/queries/triples.graphql
+++ b/packages/graphql/src/queries/triples.graphql
@@ -65,3 +65,53 @@ query GetTriple($tripleId: numeric!) {
     }
   }
 }
+
+query GetAtomTriplesWithPositions($where: triples_bool_exp) {
+  triples_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}
+
+query GetTriplesWithPositions(
+  $limit: Int
+  $offset: Int
+  $orderBy: [triples_order_by!]
+  $where: triples_bool_exp
+  $address: String
+) {
+  total: triples_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  triples(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    id
+    subject {
+      id
+      label
+      image
+    }
+    predicate {
+      id
+      label
+      image
+    }
+    object {
+      id
+      label
+      image
+    }
+    vault {
+      positions(where: { accountId: { _eq: $address } }) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+  }
+}

--- a/packages/graphql/src/queries/triples.graphql
+++ b/packages/graphql/src/queries/triples.graphql
@@ -104,6 +104,20 @@ query GetTriplesWithPositions(
       image
     }
     vault {
+      totalShares
+      positionCount
+      positions(where: { accountId: { _eq: $address } }) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+    counterVault {
+      totalShares
+      positionCount
       positions(where: { accountId: { _eq: $address } }) {
         account {
           id


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Converts all of Identity Details to use GraphQL API
- Updates several components to work with this, including pagination, but keeps the previous version until we fully migrate to keep the typechecks building
- Note: Still need pagination/sort/search adjustments but those are in another ticket. We also need to tweak the staking actions, but we're going to do that in a separate PR.

## Screen Captures

![identity-details-graphql](https://github.com/user-attachments/assets/c750b7bb-c2fe-4ad0-b249-59b93433b3e9)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
