### PR TITLE
ENG-4765 feat(portal): user profile data about change to use graphql

### DIFF
--- a/apps/portal/app/routes/app+/identity+/$id+/index.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id+/index.tsx
@@ -52,6 +52,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const url = new URL(request.url)
   // const searchParams = new URLSearchParams(url.search)
+  const queryClient = new QueryClient()
 
   // TODO: once we fully fix sort/pagination, we'll want to update these to use triples instead of claims, and orderBy instead of sortBy in the actual query params
   const triplesLimit = parseInt(url.searchParams.get('claimsLimit') || '10')
@@ -87,8 +88,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     url.searchParams.get('positionsOffset') || '0',
   )
   const positionsOrderBy = url.searchParams.get('positionsSortBy')
-
-  const queryClient = new QueryClient()
 
   const positionsWhere = {
     vaultId: { _eq: id },

--- a/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/_layout.tsx
@@ -196,8 +196,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
       predicateId: getSpecialPredicate(CURRENT_ENV).tagPredicate.vaultId,
     })()
 
-    logger('Account Tags Result:', accountTagsResult)
-
     await queryClient.prefetchQuery({
       queryKey: [
         'get-tags',
@@ -219,8 +217,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
       objectId: accountResult.account.atomId,
       address: queryAddress,
     })()
-
-    logger('Account Connections Count Result:', accountConnectionsCountResult)
 
     await queryClient.prefetchQuery({
       queryKey: [
@@ -351,12 +347,6 @@ export default function Profile() {
       ],
     },
   )
-
-  logger('Account Result:', accountResult)
-  logger('Account Tags Result:', accountTagsResult)
-  logger('Account Connections Count Result:', accountConnectionsCountResult)
-  logger('tags', accountTagsResult && accountTagsResult?.triples)
-  logger('Vault Details:', vaultDetails)
 
   const { user_assets, assets_sum } = vaultDetails ? vaultDetails : userIdentity
 

--- a/apps/portal/app/routes/app+/profile+/_index+/data-about.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/data-about.tsx
@@ -1,78 +1,255 @@
 import { Suspense } from 'react'
 
 import { Button, ErrorStateCard, Icon, IconName, Text } from '@0xintuition/1ui'
-import { ClaimsService, IdentitiesService } from '@0xintuition/api'
+import {
+  fetcher,
+  GetAccountDocument,
+  GetAccountQuery,
+  GetAccountQueryVariables,
+  GetAtomDocument,
+  GetAtomQuery,
+  GetAtomQueryVariables,
+  GetPositionsDocument,
+  GetPositionsQuery,
+  GetPositionsQueryVariables,
+  GetTriplesWithPositionsDocument,
+  GetTriplesWithPositionsQuery,
+  GetTriplesWithPositionsQueryVariables,
+  useGetAtomQuery,
+  useGetPositionsQuery,
+  useGetTriplesWithPositionsQuery,
+} from '@0xintuition/graphql'
 
 import CreateClaimModal from '@components/create-claim/create-claim-modal'
 import { ErrorPage } from '@components/error-page'
-import { ClaimsList as ClaimsAboutIdentity } from '@components/list/claims'
-import { PositionsOnIdentity } from '@components/list/positions-on-identity'
+import { ClaimsListNew as ClaimsAboutIdentity } from '@components/list/claims'
+import { PositionsOnIdentityNew as PositionsOnIdentity } from '@components/list/positions-on-identity'
 import DataAboutHeader from '@components/profile/data-about-header'
 import { RevalidateButton } from '@components/revalidate-button'
 import { DataHeaderSkeleton, PaginatedListSkeleton } from '@components/skeleton'
 import { useLiveLoader } from '@lib/hooks/useLiveLoader'
-import { getClaimsAboutIdentity } from '@lib/services/claims'
-import { getPositionsOnIdentity } from '@lib/services/positions'
 import { detailCreateClaimModalAtom } from '@lib/state/store'
+import logger from '@lib/utils/logger'
 import { formatBalance, invariant } from '@lib/utils/misc'
-import { defer, LoaderFunctionArgs } from '@remix-run/node'
-import { Await, useRouteLoaderData } from '@remix-run/react'
-import { fetchWrapper } from '@server/api'
+import { json, LoaderFunctionArgs } from '@remix-run/node'
 import { requireUserWallet } from '@server/auth'
-import { NO_USER_IDENTITY_ERROR, NO_WALLET_ERROR } from 'app/consts'
+import { QueryClient } from '@tanstack/react-query'
+import { NO_WALLET_ERROR } from 'app/consts'
 import { useAtom } from 'jotai'
-
-import { ProfileLoaderData } from './_layout'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const userWallet = await requireUserWallet(request)
   invariant(userWallet, NO_WALLET_ERROR)
-
-  const userIdentity = await fetchWrapper(request, {
-    method: IdentitiesService.getIdentityById,
-    args: { id: userWallet },
-  })
-
-  invariant(userIdentity, 'No user identity')
+  const queryAddress = userWallet.toLowerCase()
 
   const url = new URL(request.url)
-  const searchParams = new URLSearchParams(url.search)
+  // const searchParams = new URLSearchParams(url.search)
 
-  return defer({
-    positions: getPositionsOnIdentity({
-      request,
-      identityId: userIdentity.id,
-      searchParams,
-    }),
-    claims: getClaimsAboutIdentity({
-      request,
-      identityId: userIdentity.id,
-      searchParams,
-    }),
-    claimsSummary: fetchWrapper(request, {
-      method: ClaimsService.claimSummary,
-      args: {
-        identity: userIdentity.id,
+  const queryClient = new QueryClient()
+
+  logger('Fetching Account Data...')
+  const accountResult = await fetcher<
+    GetAccountQuery,
+    GetAccountQueryVariables
+  >(GetAccountDocument, { address: queryAddress })()
+
+  if (!accountResult) {
+    throw new Error('No account data found for address')
+  }
+
+  if (!accountResult.account?.atomId) {
+    throw new Error('No atom ID found for account')
+  }
+
+  await queryClient.prefetchQuery({
+    queryKey: ['get-account', { address: queryAddress }],
+    queryFn: () => accountResult,
+  })
+
+  // TODO: once we fully fix sort/pagination, we'll want to update these to use triples instead of claims, and orderBy instead of sortBy in the actual query params
+  const triplesLimit = parseInt(url.searchParams.get('claimsLimit') || '10')
+
+  const triplesOffset = parseInt(url.searchParams.get('claimsOffset') || '0')
+  const triplesOrderBy = url.searchParams.get('claimsSortBy')
+
+  const atomId = accountResult.account.atomId
+  logger('atomId', atomId)
+
+  const triplesWhere = {
+    _or: [
+      {
+        subjectId: {
+          _eq: atomId,
+        },
       },
-    }),
+      {
+        objectId: {
+          _eq: atomId,
+        },
+      },
+      {
+        predicateId: {
+          _eq: atomId,
+        },
+      },
+    ],
+  }
+
+  const positionsLimit = parseInt(
+    url.searchParams.get('positionsLimit') || '10',
+  )
+
+  const positionsOffset = parseInt(
+    url.searchParams.get('positionsOffset') || '0',
+  )
+  const positionsOrderBy = url.searchParams.get('positionsSortBy')
+
+  const positionsWhere = {
+    vaultId: { _eq: atomId },
+  }
+
+  await queryClient.prefetchQuery({
+    queryKey: ['get-atom', { id: atomId }],
+    queryFn: () =>
+      fetcher<GetAtomQuery, GetAtomQueryVariables>(GetAtomDocument, {
+        id: atomId,
+      })(),
+  })
+
+  await queryClient.prefetchQuery({
+    queryKey: [
+      'get-triples-with-positions',
+      { triplesWhere, triplesLimit, triplesOffset, triplesOrderBy },
+    ],
+    queryFn: () =>
+      fetcher<
+        GetTriplesWithPositionsQuery,
+        GetTriplesWithPositionsQueryVariables
+      >(GetTriplesWithPositionsDocument, {
+        where: triplesWhere,
+        limit: triplesLimit,
+        offset: triplesOffset,
+        orderBy: triplesOrderBy ? [{ [triplesOrderBy]: 'desc' }] : undefined,
+        address: queryAddress,
+      }),
+  })
+
+  await queryClient.prefetchQuery({
+    queryKey: [
+      'get-atom-positions',
+      { positionsWhere, positionsLimit, positionsOffset, positionsOrderBy },
+    ],
+    queryFn: () =>
+      fetcher<GetPositionsQuery, GetPositionsQueryVariables>(
+        GetPositionsDocument,
+        {
+          where: positionsWhere,
+          limit: positionsLimit,
+          offset: positionsOffset,
+          orderBy: positionsOrderBy
+            ? [{ [positionsOrderBy]: 'desc' }]
+            : undefined,
+        },
+      )(),
+  })
+
+  return json({
     userWallet,
+    queryAddress,
+    initialParams: {
+      triplesLimit,
+      triplesOffset,
+      triplesOrderBy,
+      triplesWhere,
+      positionsLimit,
+      positionsOffset,
+      positionsOrderBy,
+      positionsWhere,
+      atomId,
+    },
   })
 }
 
 export default function ProfileDataAbout() {
-  const { positions, claims, claimsSummary, userWallet } = useLiveLoader<
+  const { userWallet, queryAddress, initialParams } = useLiveLoader<
     typeof loader
   >(['attest'])
-
-  const { userIdentity } =
-    useRouteLoaderData<ProfileLoaderData>(
-      'routes/app+/profile+/_index+/_layout',
-    ) ?? {}
-  invariant(userIdentity, NO_USER_IDENTITY_ERROR)
 
   const [createClaimModalActive, setCreateClaimModalActive] = useAtom(
     detailCreateClaimModalAtom,
   )
+
+  logger('initialParams', initialParams)
+  const { data: atomResult, isLoading: isLoadingAtom } = useGetAtomQuery(
+    {
+      id: initialParams.atomId,
+    },
+    {
+      queryKey: ['get-atom', { id: initialParams.atomId }],
+    },
+  )
+
+  logger('Atom Result (Client):', atomResult)
+
+  const {
+    data: triplesResult,
+    isLoading: isLoadingTriples,
+    isError: isErrorTriples,
+    error: errorTriples,
+  } = useGetTriplesWithPositionsQuery(
+    {
+      where: initialParams.triplesWhere,
+      limit: initialParams.triplesLimit,
+      offset: initialParams.triplesOffset,
+      orderBy: initialParams.triplesOrderBy
+        ? [{ [initialParams.triplesOrderBy]: 'desc' }]
+        : undefined,
+      address: queryAddress,
+    },
+    {
+      queryKey: [
+        'get-triples-with-positions',
+        {
+          where: initialParams.triplesWhere,
+          limit: initialParams.triplesLimit,
+          offset: initialParams.triplesOffset,
+          orderBy: initialParams.triplesOrderBy,
+          address: queryAddress,
+        },
+      ],
+    },
+  )
+
+  logger('Triples Result (Client):', triplesResult)
+
+  const {
+    data: positionsResult,
+    isLoading: isLoadingPositions,
+    isError: isErrorPositions,
+    error: errorPositions,
+  } = useGetPositionsQuery(
+    {
+      where: initialParams.positionsWhere,
+      limit: initialParams.positionsLimit,
+      offset: initialParams.positionsOffset,
+      orderBy: initialParams.positionsOrderBy
+        ? [{ [initialParams.positionsOrderBy]: 'desc' }]
+        : undefined,
+    },
+    {
+      queryKey: [
+        'get-atom-positions',
+        {
+          where: initialParams.positionsWhere,
+          limit: initialParams.positionsLimit,
+          offset: initialParams.positionsOffset,
+          orderBy: initialParams.positionsOrderBy,
+        },
+      ],
+    },
+  )
+
+  logger('Positions Result (Client):', positionsResult)
 
   return (
     <>
@@ -97,45 +274,55 @@ export default function ProfileDataAbout() {
             </Button>
           </div>
           <Suspense fallback={<DataHeaderSkeleton />}>
-            <Await resolve={claims} errorElement={<></>}>
-              {(resolvedClaims) => (
-                <Await resolve={claimsSummary} errorElement={<></>}>
-                  {(resolvedClaimsSummary) => (
-                    <DataAboutHeader
-                      variant="claims"
-                      userIdentity={userIdentity}
-                      totalClaims={resolvedClaims.pagination.totalEntries}
-                      totalStake={
-                        +formatBalance(
-                          resolvedClaimsSummary?.assets_sum ?? 0,
-                          18,
-                        )
-                      }
-                    />
-                  )}
-                </Await>
-              )}
-            </Await>
+            {isLoadingTriples || isLoadingAtom ? (
+              <DataHeaderSkeleton />
+            ) : isErrorTriples ? (
+              <ErrorStateCard
+                title="Failed to load claims"
+                message={
+                  (errorTriples as Error)?.message ??
+                  'An unexpected error occurred'
+                }
+              />
+            ) : (
+              <DataAboutHeader
+                variant="claims"
+                atomImage={atomResult?.atom?.image ?? ''}
+                atomLabel={atomResult?.atom?.label ?? ''}
+                atomVariant="user" // TODO: Determine based on atom type
+                totalClaims={triplesResult?.total?.aggregate?.count ?? 0}
+                totalStake={0} // TODO: need to find way to get the shares -- may need to update the schema
+                // totalStake={
+                //   +formatBalance(
+                //     triplesResult?.total?.aggregate?.sums?.shares ?? 0,
+                //     18,
+                //   )
+                // }
+              />
+            )}
           </Suspense>
           <Suspense fallback={<PaginatedListSkeleton />}>
-            <Await
-              resolve={claims}
-              errorElement={
-                <ErrorStateCard>
-                  <RevalidateButton />
-                </ErrorStateCard>
-              }
-            >
-              {(resolvedClaims) => (
-                <ClaimsAboutIdentity
-                  claims={resolvedClaims.data}
-                  pagination={resolvedClaims.pagination}
-                  paramPrefix="claims"
-                  enableSearch
-                  enableSort
-                />
-              )}
-            </Await>
+            {isLoadingTriples ? (
+              <PaginatedListSkeleton />
+            ) : isErrorTriples ? (
+              <ErrorStateCard
+                title="Failed to load claims"
+                message={
+                  (errorTriples as Error)?.message ??
+                  'An unexpected error occurred'
+                }
+              >
+                <RevalidateButton />
+              </ErrorStateCard>
+            ) : (
+              <ClaimsAboutIdentity
+                claims={triplesResult?.triples ?? []}
+                pagination={triplesResult?.total?.aggregate?.count ?? {}}
+                paramPrefix="claims"
+                enableSearch={false} // TODO: (ENG-4481) Re-enable search and sort
+                enableSort={false} // TODO: (ENG-4481) Re-enable search and sort
+              />
+            )}
           </Suspense>
         </div>
         <div className="flex flex-col pt-4 w-full gap-6">
@@ -149,33 +336,52 @@ export default function ProfileDataAbout() {
             </Text>
           </div>
           <Suspense fallback={<DataHeaderSkeleton />}>
-            <Await resolve={positions} errorElement={<></>}>
-              {(resolvedPositions) => (
-                <DataAboutHeader
-                  variant="positions"
-                  userIdentity={userIdentity}
-                  totalPositions={resolvedPositions.pagination.totalEntries}
-                  totalStake={+formatBalance(userIdentity.assets_sum, 18)}
-                />
-              )}
-            </Await>
+            {isLoadingTriples || isLoadingAtom ? (
+              <DataHeaderSkeleton />
+            ) : isErrorTriples ? (
+              <ErrorStateCard
+                title="Failed to load claims"
+                message={
+                  (errorTriples as Error)?.message ??
+                  'An unexpected error occurred'
+                }
+              />
+            ) : (
+              <DataAboutHeader
+                variant="positions"
+                atomImage={atomResult?.atom?.image ?? ''}
+                atomLabel={atomResult?.atom?.label ?? ''}
+                atomVariant="user" // TODO: Determine based on atom type
+                totalPositions={positionsResult?.total?.aggregate?.count ?? 0}
+                // totalStake={0} // TODO: need to find way to get the shares -- may need to update the schema
+                totalStake={
+                  +formatBalance(
+                    positionsResult?.total?.aggregate?.sum?.shares ?? 0,
+                    18,
+                  )
+                }
+              />
+            )}
           </Suspense>
           <Suspense fallback={<PaginatedListSkeleton />}>
-            <Await
-              resolve={positions}
-              errorElement={
-                <ErrorStateCard>
-                  <RevalidateButton />
-                </ErrorStateCard>
-              }
-            >
-              {(resolvedPositions) => (
-                <PositionsOnIdentity
-                  positions={resolvedPositions.data}
-                  pagination={resolvedPositions.pagination}
-                />
-              )}
-            </Await>
+            {isLoadingPositions ? (
+              <PaginatedListSkeleton />
+            ) : isErrorPositions ? (
+              <ErrorStateCard
+                title="Failed to load positions"
+                message={
+                  (errorPositions as Error)?.message ??
+                  'An unexpected error occurred'
+                }
+              >
+                <RevalidateButton />
+              </ErrorStateCard>
+            ) : (
+              <PositionsOnIdentity
+                positions={positionsResult?.positions ?? []}
+                pagination={positionsResult?.total?.aggregate?.count ?? {}}
+              />
+            )}
           </Suspense>
         </div>
       </div>

--- a/packages/graphql/src/queries/triples.graphql
+++ b/packages/graphql/src/queries/triples.graphql
@@ -9,9 +9,6 @@ query GetTriples(
     aggregate {
       count
     }
-    sum {
-      shares
-    }
   }
   triples(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
     ...TripleMetadata

--- a/packages/graphql/src/queries/triples.graphql
+++ b/packages/graphql/src/queries/triples.graphql
@@ -9,6 +9,9 @@ query GetTriples(
     aggregate {
       count
     }
+    sum {
+      shares
+    }
   }
   triples(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
     ...TripleMetadata


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Builds out the user profile data about route and switches to use new versions of the list components
- Pagination/search/sort still WIP but the rest of the data is loading using GraphQL now
- All fields / metadata working as expected except for the TVL on the triples query -- there is a TODO with a note about this in the code comments

## Screen Captures

![user-profile-data-about](https://github.com/user-attachments/assets/c391cf76-5cb6-4b7d-bc48-66518e808724)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
