### PR TITLE
ENG-4472 feat(portal,graphql): query consumer claim details

### DIFF
--- a/apps/portal/app/components/detail-info-card.tsx
+++ b/apps/portal/app/components/detail-info-card.tsx
@@ -14,11 +14,12 @@ import {
   TextVariant,
   Trunctacular,
 } from '@0xintuition/1ui'
+import { ClaimPresenter } from '@0xintuition/api'
 import { GetTripleQuery } from '@0xintuition/graphql'
 
 import { getListUrl } from '@lib/utils/misc'
 
-export interface DetailInfoCardProps
+export interface DetailInfoCardPropsNew
   extends React.HTMLAttributes<HTMLDivElement> {
   variant: IdentityType
   list?: GetTripleQuery['triple']
@@ -32,7 +33,7 @@ export interface DetailInfoCardProps
   readOnly?: boolean
 }
 
-const DetailInfoCard = ({
+export const DetailInfoCardNew = ({
   variant = Identity.user,
   list,
   username,
@@ -45,7 +46,7 @@ const DetailInfoCard = ({
   className,
   readOnly = false,
   ...props
-}: DetailInfoCardProps) => {
+}: DetailInfoCardPropsNew) => {
   const formattedDate = new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
     month: 'long',
@@ -132,4 +133,117 @@ const DetailInfoCard = ({
   )
 }
 
-export { DetailInfoCard }
+// Legacy implementation included to not break the build for the Readonly routes. We can remove once done migrating
+export interface DetailInfoCardProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  variant: IdentityType
+  list?: ClaimPresenter
+  username: string
+  avatarImgSrc: string
+  id: string
+  description: string
+  link: string
+  ipfsLink: string
+  timestamp: string
+  readOnly?: boolean
+}
+
+export const DetailInfoCard = ({
+  variant = Identity.user,
+  list,
+  username,
+  avatarImgSrc,
+  id,
+  description,
+  link,
+  ipfsLink,
+  timestamp,
+  className,
+  readOnly = false,
+  ...props
+}: DetailInfoCardProps) => {
+  const formattedDate = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(timestamp))
+
+  return (
+    <div
+      className={cn(
+        `flex flex-col gap-5 theme-border p-5 rounded-lg max-sm:items-center`,
+        className,
+      )}
+      {...props}
+    >
+      {list && (
+        <div>
+          <Text variant={TextVariant.caption} className="text-muted-foreground">
+            List
+          </Text>
+          <div className="flex justify-start items-center gap-1">
+            <a href={getListUrl(list.vault_id, '', readOnly)}>
+              <IdentityTag
+                variant={list.object?.user ? Identity.user : Identity.nonUser}
+                imgSrc={list.object?.image ?? ''}
+              >
+                <Trunctacular
+                  value={
+                    list.object?.user_display_name ??
+                    list.object?.display_name ??
+                    'Unknown'
+                  }
+                  maxStringLength={32}
+                />
+              </IdentityTag>
+            </a>
+          </div>
+        </div>
+      )}
+      <div>
+        <Text variant={TextVariant.caption} className="text-muted-foreground">
+          Creator
+        </Text>
+        <div className="flex justify-start items-center gap-1">
+          <HoverCard openDelay={150} closeDelay={150}>
+            <HoverCardTrigger>
+              <a href={link}>
+                <IdentityTag variant={variant} imgSrc={avatarImgSrc}>
+                  <Trunctacular value={username} maxStringLength={18} />
+                </IdentityTag>
+              </a>
+            </HoverCardTrigger>
+            <HoverCardContent side="right" className="w-max">
+              <div className="flex flex-col gap-4 w-80 max-md:w-[80%]">
+                <ProfileCard
+                  variant={variant}
+                  avatarSrc={avatarImgSrc ?? ''}
+                  name={username}
+                  id={id ?? ''}
+                  bio={description ?? ''}
+                  ipfsLink={ipfsLink}
+                  className="profile-card"
+                />
+                {link && (
+                  <a href={link}>
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      className="w-full"
+                    >
+                      View Identity{' '}
+                      <Icon name={'arrow-up-right'} className="h-3 w-3" />
+                    </Button>
+                  </a>
+                )}
+              </div>
+            </HoverCardContent>
+          </HoverCard>
+          <span className="bg-muted-foreground h-0.5 w-0.5 block rounded-full" />
+          <Text variant={TextVariant.body} className="text-muted-foreground">
+            {formattedDate}
+          </Text>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/portal/app/components/detail-info-card.tsx
+++ b/apps/portal/app/components/detail-info-card.tsx
@@ -14,14 +14,14 @@ import {
   TextVariant,
   Trunctacular,
 } from '@0xintuition/1ui'
-import { ClaimPresenter } from '@0xintuition/api'
+import { GetTripleQuery } from '@0xintuition/graphql'
 
 import { getListUrl } from '@lib/utils/misc'
 
 export interface DetailInfoCardProps
   extends React.HTMLAttributes<HTMLDivElement> {
   variant: IdentityType
-  list?: ClaimPresenter
+  list?: GetTripleQuery['triple']
   username: string
   avatarImgSrc: string
   id: string
@@ -66,17 +66,17 @@ const DetailInfoCard = ({
             List
           </Text>
           <div className="flex justify-start items-center gap-1">
-            <a href={getListUrl(list.vault_id, '', readOnly)}>
+            <a href={getListUrl(list.id, '', readOnly)}>
               <IdentityTag
-                variant={list.object?.user ? Identity.user : Identity.nonUser}
+                variant={
+                  list.object?.type === 'Person'
+                    ? Identity.user
+                    : Identity.nonUser
+                }
                 imgSrc={list.object?.image ?? ''}
               >
                 <Trunctacular
-                  value={
-                    list.object?.user_display_name ??
-                    list.object?.display_name ??
-                    'Unknown'
-                  }
+                  value={list.object?.label ?? 'Unknown'}
                   maxStringLength={32}
                 />
               </IdentityTag>

--- a/apps/portal/app/components/list/positions-on-claim.tsx
+++ b/apps/portal/app/components/list/positions-on-claim.tsx
@@ -1,8 +1,10 @@
 import { ClaimPosition, IconName } from '@0xintuition/1ui'
 import { PositionPresenter, PositionSortColumn } from '@0xintuition/api'
+import { GetPositionsQuery } from '@0xintuition/graphql'
 
 import { ClaimPositionRow } from '@components/claim/claim-position-row'
 import { ListHeader } from '@components/list/list-header'
+import logger from '@lib/utils/logger'
 import { formatBalance, getProfileUrl } from '@lib/utils/misc'
 import { BLOCK_EXPLORER_URL } from 'app/consts'
 import { PaginationType } from 'app/types/pagination'
@@ -11,6 +13,116 @@ import { formatUnits } from 'viem'
 import { SortOption } from '../sort-select'
 import { List } from './list'
 
+type Position = NonNullable<GetPositionsQuery['positions']>[number]
+
+export function PositionsOnClaimNew({
+  vaultPositions,
+  counterVaultPositions,
+  readOnly = false,
+  positionDirection,
+}: {
+  vaultPositions: Position[]
+  counterVaultPositions: Position[]
+  pagination: { aggregate?: { count: number } } | number
+  readOnly?: boolean
+  positionDirection?: string
+}) {
+  const options: SortOption<PositionSortColumn>[] = [
+    { value: 'Amount', sortBy: PositionSortColumn.ASSETS },
+    { value: 'Updated At', sortBy: PositionSortColumn.UPDATED_AT },
+    { value: 'Created At', sortBy: PositionSortColumn.CREATED_AT },
+  ]
+
+  logger('positions in PositionsOnClaim', {
+    vaultPositions,
+    counterVaultPositions,
+  })
+
+  // Leaving in case we need this for how we approach pagination
+  // const paginationCount =
+  //   positionDirection === 'for'
+  //     ? typeof pagination === 'number'
+  //       ? pagination
+  //       : pagination?.aggregate?.count ?? 0
+  //     : positionDirection === 'against'
+  //       ? typeof pagination === 'number'
+  //         ? pagination
+  //         : pagination?.aggregate?.count ?? 0
+  //       : typeof pagination === 'number'
+  //         ? pagination
+  //         : pagination?.aggregate?.count ?? 0
+
+  // Combining and transforming positions -- we can see if there is a better/different way to do this, but the issue is previously these were combined and now they're split so we need to recombine for the tabs UI
+  const allPositions = [
+    ...vaultPositions.map((p) => ({ ...p, direction: 'for' as const })),
+    ...counterVaultPositions.map((p) => ({
+      ...p,
+      direction: 'against' as const,
+    })),
+  ].filter((position) => {
+    if (positionDirection === 'for') {
+      return position.direction === 'for'
+    }
+    if (positionDirection === 'against') {
+      return position.direction === 'against'
+    }
+    return true
+  })
+
+  return (
+    <List<PositionSortColumn>
+      pagination={{
+        currentPage: 1,
+        limit: 10,
+        totalEntries: allPositions.length,
+        totalPages: Math.ceil(allPositions.length / 10),
+      }}
+      paginationLabel="positions"
+      options={options}
+      paramPrefix="positions"
+    >
+      <ListHeader
+        items={[
+          { label: 'User', icon: IconName.cryptoPunk },
+          { label: 'Position Amount', icon: IconName.ethereum },
+        ]}
+      />
+      {allPositions.map((position) => (
+        <div
+          key={position.id}
+          className={`grow shrink basis-0 self-stretch bg-black first:rounded-t-xl last:rounded-b-xl theme-border flex-col justify-start items-start gap-5 inline-flex`}
+        >
+          <ClaimPositionRow
+            variant="user"
+            avatarSrc={position.account?.image ?? ''}
+            name={position.account?.label ?? ''}
+            description={position.account?.label ?? ''}
+            id={position.account?.id ?? ''}
+            amount={+formatBalance(BigInt(position.shares), 18)}
+            position={
+              position.direction === 'for'
+                ? ClaimPosition.claimFor
+                : ClaimPosition.claimAgainst
+            }
+            feesAccrued={Number(
+              formatUnits(
+                // @ts-ignore // TODO: Fix this when we determine what the value should be
+                BigInt(+position.shares - +(position.value ?? position.shares)),
+                18,
+              ),
+            )}
+            // updatedAt={position.updated_at} // TODO: Fix this when we have the updated_at
+
+            link={getProfileUrl(position.account?.id, readOnly)}
+            ipfsLink={`${BLOCK_EXPLORER_URL}/address/${position.account?.id}`}
+          />
+        </div>
+      ))}
+    </List>
+  )
+}
+
+// Legacy component -- will be removed after migration
 export function PositionsOnClaim({
   positions,
   pagination,

--- a/apps/portal/app/routes/app+/claim+/$id+/index.tsx
+++ b/apps/portal/app/routes/app+/claim+/$id+/index.tsx
@@ -1,3 +1,4 @@
+import { URL } from 'url'
 import { Suspense, useEffect, useState } from 'react'
 
 import {
@@ -8,34 +9,42 @@ import {
   TabsTrigger,
   Text,
 } from '@0xintuition/1ui'
-import { ClaimsService, IdentityPresenter, VaultType } from '@0xintuition/api'
+import { VaultType } from '@0xintuition/api'
+import {
+  fetcher,
+  GetAtomQuery,
+  GetTripleDocument,
+  GetTripleQuery,
+  GetTripleQueryVariables,
+  useGetTripleQuery,
+} from '@0xintuition/graphql'
 
 import { ErrorPage } from '@components/error-page'
-import { PositionsOnClaim } from '@components/list/positions-on-claim'
+import { PositionsOnClaimNew } from '@components/list/positions-on-claim'
 import RemixLink from '@components/remix-link'
 import { PaginatedListSkeleton, TabsSkeleton } from '@components/skeleton'
 import { useLiveLoader } from '@lib/hooks/useLiveLoader'
-import { getPositionsOnClaim } from '@lib/services/positions'
+import logger from '@lib/utils/logger'
 import {
-  getAtomDescription,
-  getAtomImage,
-  getAtomIpfsLink,
-  getAtomLabel,
-  getAtomLink,
+  getAtomDescriptionGQL,
+  getAtomImageGQL,
+  getAtomIpfsLinkGQL,
+  getAtomLabelGQL,
+  getAtomLinkGQL,
   invariant,
 } from '@lib/utils/misc'
-import { defer, LoaderFunctionArgs } from '@remix-run/node'
+import { json, LoaderFunctionArgs } from '@remix-run/node'
 import {
-  Await,
   useNavigation,
   useRouteLoaderData,
   useSearchParams,
 } from '@remix-run/react'
 import { ClaimDetailsLoaderData } from '@routes/app+/claim+/$id'
-import { fetchWrapper } from '@server/api'
 import { requireUserWallet } from '@server/auth'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { NO_CLAIM_ERROR, NO_PARAM_ID_ERROR, NO_WALLET_ERROR } from 'app/consts'
-import { PaginationType } from 'app/types/pagination'
+
+type Atom = GetAtomQuery['atom']
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const id = params.id
@@ -43,30 +52,46 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const wallet = await requireUserWallet(request)
   invariant(wallet, NO_WALLET_ERROR)
 
+  if (!id) {
+    throw new Error('Claim ID not found in the URL.')
+  }
+
   const url = new URL(request.url)
   const searchParams = new URLSearchParams(url.search)
 
-  return defer({
-    positionsData: getPositionsOnClaim({
-      request,
-      claimId: id,
-      searchParams,
-    }),
-    claim: fetchWrapper(request, {
-      method: ClaimsService.getClaimById,
-      args: { id },
-    }),
+  const queryClient = new QueryClient()
+
+  await queryClient.prefetchQuery({
+    queryKey: [
+      'get-triple',
+      {
+        id: params.id,
+        positionDirection: searchParams.get('positionDirection'),
+      },
+    ],
+    queryFn: () =>
+      fetcher<GetTripleQuery, GetTripleQueryVariables>(GetTripleDocument, {
+        tripleId: id,
+      })(),
+  })
+
+  return json({
+    dehydratedState: dehydrate(queryClient),
+    initialParams: {
+      id,
+    },
   })
 }
 
 export default function ClaimOverview() {
-  const { positionsData } = useLiveLoader<typeof loader>(['attest', 'create'])
+  const { initialParams } = useLiveLoader<typeof loader>(['attest', 'create'])
   const { claim } =
     useRouteLoaderData<ClaimDetailsLoaderData>('routes/app+/claim+/$id') ?? {}
   invariant(claim, NO_CLAIM_ERROR)
 
   const [searchParams, setSearchParams] = useSearchParams()
   const [isNavigating, setIsNavigating] = useState(false)
+  const positionDirection = searchParams.get('positionDirection')
 
   const { state } = useNavigation()
 
@@ -79,7 +104,11 @@ export default function ClaimOverview() {
     }
     newParams.delete('positionsSearch')
     newParams.set('page', '1')
-    setSearchParams(newParams)
+
+    setSearchParams(newParams, {
+      replace: true,
+      preventScrollReset: true,
+    })
     setIsNavigating(true)
   }
 
@@ -89,6 +118,23 @@ export default function ClaimOverview() {
     }
   }, [state])
 
+  const { data: tripleData, isLoading } = useGetTripleQuery(
+    {
+      tripleId: initialParams.id,
+    },
+    {
+      queryKey: [
+        'get-triple',
+        {
+          id: initialParams.id,
+          positionDirection,
+        },
+      ],
+    },
+  )
+
+  logger('tripleData', tripleData)
+
   return (
     <div className="flex-col justify-start items-start flex w-full gap-6">
       <div className="flex-row hidden md:flex">
@@ -96,37 +142,48 @@ export default function ClaimOverview() {
           size="xl"
           maxIdentityLength={60}
           subject={{
-            variant: claim.subject?.is_user ? Identity.user : Identity.nonUser,
-            label: getAtomLabel(claim.subject as IdentityPresenter),
-            imgSrc: getAtomImage(claim.subject as IdentityPresenter),
-            id: claim.subject?.identity_id,
-            description: getAtomDescription(claim.subject as IdentityPresenter),
-            ipfsLink: getAtomIpfsLink(claim.subject as IdentityPresenter),
-            link: getAtomLink(claim.subject as IdentityPresenter),
+            variant:
+              tripleData?.triple?.subject?.type === 'Person'
+                ? Identity.user
+                : Identity.nonUser,
+            label: getAtomLabelGQL(tripleData?.triple?.subject as Atom),
+            imgSrc: getAtomImageGQL(tripleData?.triple?.subject as Atom),
+            id: tripleData?.triple?.subject?.id,
+            description: getAtomDescriptionGQL(
+              tripleData?.triple?.subject as Atom,
+            ),
+            ipfsLink: getAtomIpfsLinkGQL(tripleData?.triple?.subject as Atom),
+            link: getAtomLinkGQL(tripleData?.triple?.subject as Atom),
             linkComponent: RemixLink,
           }}
           predicate={{
-            variant: claim.predicate?.is_user
-              ? Identity.user
-              : Identity.nonUser,
-            label: getAtomLabel(claim.predicate as IdentityPresenter),
-            imgSrc: getAtomImage(claim.predicate as IdentityPresenter),
-            id: claim.predicate?.identity_id,
-            description: getAtomDescription(
-              claim.predicate as IdentityPresenter,
+            variant:
+              tripleData?.triple?.predicate?.type === 'Person'
+                ? Identity.user
+                : Identity.nonUser,
+            label: getAtomLabelGQL(tripleData?.triple?.predicate as Atom),
+            imgSrc: getAtomImageGQL(tripleData?.triple?.predicate as Atom),
+            id: tripleData?.triple?.predicate?.id,
+            description: getAtomDescriptionGQL(
+              tripleData?.triple?.predicate as Atom,
             ),
-            ipfsLink: getAtomIpfsLink(claim.predicate as IdentityPresenter),
-            link: getAtomLink(claim.predicate as IdentityPresenter),
+            ipfsLink: getAtomIpfsLinkGQL(tripleData?.triple?.predicate as Atom),
+            link: getAtomLinkGQL(tripleData?.triple?.predicate as Atom),
             linkComponent: RemixLink,
           }}
           object={{
-            variant: claim.object?.is_user ? Identity.user : Identity.nonUser,
-            label: getAtomLabel(claim.object as IdentityPresenter),
-            imgSrc: getAtomImage(claim.object as IdentityPresenter),
-            id: claim.object?.identity_id,
-            description: getAtomDescription(claim.object as IdentityPresenter),
-            ipfsLink: getAtomIpfsLink(claim.object as IdentityPresenter),
-            link: getAtomLink(claim.object as IdentityPresenter),
+            variant:
+              tripleData?.triple?.object?.type === 'Person'
+                ? Identity.user
+                : Identity.nonUser,
+            label: getAtomLabelGQL(tripleData?.triple?.object as Atom),
+            imgSrc: getAtomImageGQL(tripleData?.triple?.object as Atom),
+            id: tripleData?.triple?.object?.id,
+            description: getAtomDescriptionGQL(
+              tripleData?.triple?.object as Atom,
+            ),
+            ipfsLink: getAtomIpfsLinkGQL(tripleData?.triple?.object as Atom),
+            link: getAtomLinkGQL(tripleData?.triple?.object as Atom),
             linkComponent: RemixLink,
           }}
         />
@@ -142,12 +199,19 @@ export default function ClaimOverview() {
       </div>
       <Tabs defaultValue="all">
         <Suspense fallback={<TabsSkeleton numOfTabs={3} />}>
-          <Await resolve={positionsData}>
+          {isLoading ? (
+            <TabsSkeleton numOfTabs={3} />
+          ) : (
             <TabsList>
               <TabsTrigger
                 value="all"
                 label="All"
-                totalCount={claim.num_positions}
+                totalCount={
+                  (tripleData?.triple?.vault?.allPositions?.aggregate?.count ??
+                    0) +
+                  (tripleData?.triple?.counterVault?.allPositions?.aggregate
+                    ?.count ?? 0)
+                }
                 onClick={(e) => {
                   e.preventDefault()
                   handleTabChange(null)
@@ -156,7 +220,9 @@ export default function ClaimOverview() {
               <TabsTrigger
                 value="for"
                 label="For"
-                totalCount={claim.for_num_positions}
+                totalCount={
+                  tripleData?.triple?.vault?.allPositions?.aggregate?.count ?? 0
+                }
                 onClick={(e) => {
                   e.preventDefault()
                   handleTabChange('for')
@@ -165,28 +231,39 @@ export default function ClaimOverview() {
               <TabsTrigger
                 value="against"
                 label="Against"
-                totalCount={claim.against_num_positions}
+                totalCount={
+                  tripleData?.triple?.counterVault?.allPositions?.aggregate
+                    ?.count ?? 0
+                }
                 onClick={(e) => {
                   e.preventDefault()
                   handleTabChange('against')
                 }}
               />
             </TabsList>
-          </Await>
+          )}
         </Suspense>
       </Tabs>
       <Suspense fallback={<PaginatedListSkeleton />}>
         {isNavigating ? (
           <PaginatedListSkeleton />
         ) : (
-          <Await resolve={positionsData}>
-            {(resolvedPositionsData) => (
-              <PositionsOnClaim
-                positions={resolvedPositionsData.data}
-                pagination={resolvedPositionsData.pagination as PaginationType}
-              />
-            )}
-          </Await>
+          <PositionsOnClaimNew
+            vaultPositions={tripleData?.triple?.vault?.positions ?? []}
+            counterVaultPositions={
+              tripleData?.triple?.counterVault?.positions ?? []
+            }
+            pagination={{
+              aggregate: {
+                count:
+                  (tripleData?.triple?.vault?.allPositions?.aggregate?.count ??
+                    0) +
+                  (tripleData?.triple?.counterVault?.allPositions?.aggregate
+                    ?.count ?? 0),
+              },
+            }}
+            positionDirection={positionDirection ?? undefined}
+          />
         )}
       </Suspense>
     </div>

--- a/apps/portal/app/routes/app+/claim+/$id.tsx
+++ b/apps/portal/app/routes/app+/claim+/$id.tsx
@@ -394,14 +394,14 @@ export default function ClaimDetails() {
       <DetailInfoCard
         variant={Identity.user}
         list={
-          claim?.predicate?.id ===
-          getSpecialPredicate(CURRENT_ENV).tagPredicate.id
-            ? claim
+          String(tripleData?.triple?.predicate?.id) ===
+          String(getSpecialPredicate(CURRENT_ENV).tagPredicate.vaultId)
+            ? tripleData?.triple
             : undefined
         }
-        username={claim.creator?.display_name ?? '?'}
-        avatarImgSrc={claim.creator?.image ?? ''}
-        id={claim.creator?.wallet ?? ''}
+        username={tripleData?.triple?.creator?.label ?? '?'}
+        avatarImgSrc={tripleData?.triple?.creator?.image ?? ''}
+        id={tripleData?.triple?.creator?.id ?? ''}
         description={claim.creator?.description ?? ''}
         link={
           claim.creator?.id ? `${PATHS.PROFILE}/${claim.creator?.wallet}` : ''

--- a/packages/graphql/src/fragments/triple.graphql
+++ b/packages/graphql/src/fragments/triple.graphql
@@ -72,10 +72,28 @@ fragment TripleVaultDetails on triples {
   vaultId
   counterVaultId
   vault {
-    ...VaultDetails
+    positions {
+      id
+      vaultId
+      shares
+      account {
+        id
+        label
+        image
+      }
+    }
   }
   counterVault {
-    ...VaultDetails
+    positions {
+      id
+      vaultId
+      shares
+      account {
+        id
+        label
+        image
+      }
+    }
   }
 }
 

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -8251,39 +8251,33 @@ export type TripleVaultDetailsFragment = {
   counterVaultId: any
   vault?: {
     __typename?: 'vaults'
-    id: any
-    currentSharePrice: any
-    totalShares: any
-    atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-    triple?: {
-      __typename?: 'triples'
-      id: any
-      subject?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      predicate?: {
-        __typename?: 'atoms'
-        id: any
-        label?: string | null
+    positions: Array<{
+      __typename?: 'positions'
+      id: string
+      vaultId: any
+      shares: any
+      account?: {
+        __typename?: 'accounts'
+        id: string
+        label: string
+        image?: string | null
       } | null
-      object?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-    } | null
+    }>
   } | null
   counterVault?: {
     __typename?: 'vaults'
-    id: any
-    currentSharePrice: any
-    totalShares: any
-    atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-    triple?: {
-      __typename?: 'triples'
-      id: any
-      subject?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      predicate?: {
-        __typename?: 'atoms'
-        id: any
-        label?: string | null
+    positions: Array<{
+      __typename?: 'positions'
+      id: string
+      vaultId: any
+      shares: any
+      account?: {
+        __typename?: 'accounts'
+        id: string
+        label: string
+        image?: string | null
       } | null
-      object?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-    } | null
+    }>
   } | null
 }
 
@@ -10495,55 +10489,33 @@ export type GetListItemsQuery = {
       counterVaultId: any
       vault?: {
         __typename?: 'vaults'
-        id: any
-        currentSharePrice: any
-        totalShares: any
-        atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-        triple?: {
-          __typename?: 'triples'
-          id: any
-          subject?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
+        positions: Array<{
+          __typename?: 'positions'
+          id: string
+          vaultId: any
+          shares: any
+          account?: {
+            __typename?: 'accounts'
+            id: string
+            label: string
+            image?: string | null
           } | null
-          predicate?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-          object?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-        } | null
+        }>
       } | null
       counterVault?: {
         __typename?: 'vaults'
-        id: any
-        currentSharePrice: any
-        totalShares: any
-        atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-        triple?: {
-          __typename?: 'triples'
-          id: any
-          subject?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
+        positions: Array<{
+          __typename?: 'positions'
+          id: string
+          vaultId: any
+          shares: any
+          account?: {
+            __typename?: 'accounts'
+            id: string
+            label: string
+            image?: string | null
           } | null
-          predicate?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-          object?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-        } | null
+        }>
       } | null
     }>
   }
@@ -11274,7 +11246,6 @@ export type GetTriplesQuery = {
       __typename?: 'vaults'
       totalShares: any
       currentSharePrice: any
-      id: any
       allPositions: {
         __typename?: 'positions_aggregate'
         aggregate?: {
@@ -11288,31 +11259,21 @@ export type GetTriplesQuery = {
       }
       positions: Array<{
         __typename?: 'positions'
+        id: string
+        vaultId: any
         shares: any
-        account?: { __typename?: 'accounts'; id: string; label: string } | null
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
       }>
-      atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      triple?: {
-        __typename?: 'triples'
-        id: any
-        subject?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        predicate?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        object?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      } | null
     } | null
     counterVault?: {
       __typename?: 'vaults'
       totalShares: any
       currentSharePrice: any
-      id: any
       allPositions: {
         __typename?: 'positions_aggregate'
         aggregate?: {
@@ -11326,25 +11287,16 @@ export type GetTriplesQuery = {
       }
       positions: Array<{
         __typename?: 'positions'
+        id: string
+        vaultId: any
         shares: any
-        account?: { __typename?: 'accounts'; id: string; label: string } | null
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
       }>
-      atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      triple?: {
-        __typename?: 'triples'
-        id: any
-        subject?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        predicate?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        object?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      } | null
     } | null
   }>
 }
@@ -11511,7 +11463,6 @@ export type GetTriplesWithAggregatesQuery = {
         __typename?: 'vaults'
         totalShares: any
         currentSharePrice: any
-        id: any
         allPositions: {
           __typename?: 'positions_aggregate'
           aggregate?: {
@@ -11525,39 +11476,21 @@ export type GetTriplesWithAggregatesQuery = {
         }
         positions: Array<{
           __typename?: 'positions'
+          id: string
+          vaultId: any
           shares: any
           account?: {
             __typename?: 'accounts'
             id: string
             label: string
+            image?: string | null
           } | null
         }>
-        atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-        triple?: {
-          __typename?: 'triples'
-          id: any
-          subject?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-          predicate?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-          object?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-        } | null
       } | null
       counterVault?: {
         __typename?: 'vaults'
         totalShares: any
         currentSharePrice: any
-        id: any
         allPositions: {
           __typename?: 'positions_aggregate'
           aggregate?: {
@@ -11571,33 +11504,16 @@ export type GetTriplesWithAggregatesQuery = {
         }
         positions: Array<{
           __typename?: 'positions'
+          id: string
+          vaultId: any
           shares: any
           account?: {
             __typename?: 'accounts'
             id: string
             label: string
+            image?: string | null
           } | null
         }>
-        atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-        triple?: {
-          __typename?: 'triples'
-          id: any
-          subject?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-          predicate?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-          object?: {
-            __typename?: 'atoms'
-            id: any
-            label?: string | null
-          } | null
-        } | null
       } | null
     }>
   }
@@ -11768,7 +11684,6 @@ export type GetTripleQuery = {
       __typename?: 'vaults'
       totalShares: any
       currentSharePrice: any
-      id: any
       allPositions: {
         __typename?: 'positions_aggregate'
         aggregate?: {
@@ -11782,31 +11697,21 @@ export type GetTripleQuery = {
       }
       positions: Array<{
         __typename?: 'positions'
+        id: string
+        vaultId: any
         shares: any
-        account?: { __typename?: 'accounts'; id: string; label: string } | null
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
       }>
-      atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      triple?: {
-        __typename?: 'triples'
-        id: any
-        subject?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        predicate?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        object?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      } | null
     } | null
     counterVault?: {
       __typename?: 'vaults'
       totalShares: any
       currentSharePrice: any
-      id: any
       allPositions: {
         __typename?: 'positions_aggregate'
         aggregate?: {
@@ -11820,25 +11725,16 @@ export type GetTripleQuery = {
       }
       positions: Array<{
         __typename?: 'positions'
+        id: string
+        vaultId: any
         shares: any
-        account?: { __typename?: 'accounts'; id: string; label: string } | null
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
       }>
-      atom?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      triple?: {
-        __typename?: 'triples'
-        id: any
-        subject?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        predicate?: {
-          __typename?: 'atoms'
-          id: any
-          label?: string | null
-        } | null
-        object?: { __typename?: 'atoms'; id: any; label?: string | null } | null
-      } | null
     } | null
   } | null
 }
@@ -12663,6 +12559,36 @@ export const TripleTxnFragmentDoc = `
   creatorId
 }
     `
+export const TripleVaultDetailsFragmentDoc = `
+    fragment TripleVaultDetails on triples {
+  vaultId
+  counterVaultId
+  vault {
+    positions {
+      id
+      vaultId
+      shares
+      account {
+        id
+        label
+        image
+      }
+    }
+  }
+  counterVault {
+    positions {
+      id
+      vaultId
+      shares
+      account {
+        id
+        label
+        image
+      }
+    }
+  }
+}
+    `
 export const VaultBasicDetailsFragmentDoc = `
     fragment VaultBasicDetails on vaults {
   id
@@ -12687,23 +12613,6 @@ export const VaultBasicDetailsFragmentDoc = `
   }
   currentSharePrice
   totalShares
-}
-    `
-export const VaultDetailsFragmentDoc = `
-    fragment VaultDetails on vaults {
-  ...VaultBasicDetails
-}
-    `
-export const TripleVaultDetailsFragmentDoc = `
-    fragment TripleVaultDetails on triples {
-  vaultId
-  counterVaultId
-  vault {
-    ...VaultDetails
-  }
-  counterVault {
-    ...VaultDetails
-  }
 }
     `
 export const VaultFilteredPositionsFragmentDoc = `
@@ -12736,6 +12645,11 @@ export const VaultUnfilteredPositionsFragmentDoc = `
   positions {
     ...PositionFields
   }
+}
+    `
+export const VaultDetailsFragmentDoc = `
+    fragment VaultDetails on vaults {
+  ...VaultBasicDetails
 }
     `
 export const VaultPositionsAggregateFragmentDoc = `
@@ -14998,9 +14912,7 @@ export const GetListItemsDocument = `
     }
   }
 }
-    ${TripleVaultDetailsFragmentDoc}
-${VaultDetailsFragmentDoc}
-${VaultBasicDetailsFragmentDoc}`
+    ${TripleVaultDetailsFragmentDoc}`
 
 export const useGetListItemsQuery = <
   TData = GetListItemsQuery,
@@ -15855,9 +15767,7 @@ ${AccountMetadataFragmentDoc}
 ${PositionAggregateFieldsFragmentDoc}
 ${PositionFieldsFragmentDoc}
 ${TripleTxnFragmentDoc}
-${TripleVaultDetailsFragmentDoc}
-${VaultDetailsFragmentDoc}
-${VaultBasicDetailsFragmentDoc}`
+${TripleVaultDetailsFragmentDoc}`
 
 export const useGetTriplesQuery = <TData = GetTriplesQuery, TError = unknown>(
   variables?: GetTriplesQueryVariables,
@@ -15961,9 +15871,7 @@ ${AccountMetadataFragmentDoc}
 ${PositionAggregateFieldsFragmentDoc}
 ${PositionFieldsFragmentDoc}
 ${TripleTxnFragmentDoc}
-${TripleVaultDetailsFragmentDoc}
-${VaultDetailsFragmentDoc}
-${VaultBasicDetailsFragmentDoc}`
+${TripleVaultDetailsFragmentDoc}`
 
 export const useGetTriplesWithAggregatesQuery = <
   TData = GetTriplesWithAggregatesQuery,
@@ -16166,9 +16074,7 @@ ${AccountMetadataFragmentDoc}
 ${PositionAggregateFieldsFragmentDoc}
 ${PositionFieldsFragmentDoc}
 ${TripleTxnFragmentDoc}
-${TripleVaultDetailsFragmentDoc}
-${VaultDetailsFragmentDoc}
-${VaultBasicDetailsFragmentDoc}`
+${TripleVaultDetailsFragmentDoc}`
 
 export const useGetTripleQuery = <TData = GetTripleQuery, TError = unknown>(
   variables: GetTripleQueryVariables,
@@ -19960,6 +19866,122 @@ export const TripleTxn = {
     },
   ],
 } as unknown as DocumentNode
+export const TripleVaultDetails = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'TripleVaultDetails' },
+      typeCondition: {
+        kind: 'NamedType',
+        name: { kind: 'Name', value: 'triples' },
+      },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          { kind: 'Field', name: { kind: 'Name', value: 'vaultId' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'counterVaultId' } },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'vault' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'counterVault' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode
 export const VaultBasicDetails = {
   kind: 'Document',
   definitions: [
@@ -20030,231 +20052,6 @@ export const VaultBasicDetails = {
           },
           { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
           { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode
-export const VaultDetails = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'FragmentSpread',
-            name: { kind: 'Name', value: 'VaultBasicDetails' },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultBasicDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'triple' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'subject' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'predicate' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'object' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-          { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode
-export const TripleVaultDetails = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'TripleVaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'triples' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'vaultId' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'counterVaultId' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'vault' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
-                },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'counterVault' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultBasicDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'triple' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'subject' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'predicate' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'object' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-          { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'FragmentSpread',
-            name: { kind: 'Name', value: 'VaultBasicDetails' },
-          },
         ],
       },
     },
@@ -20795,6 +20592,98 @@ export const VaultUnfilteredPositions = {
             },
           },
           { kind: 'Field', name: { kind: 'Name', value: 'shares' } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode
+export const VaultDetails = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'VaultDetails' },
+      typeCondition: {
+        kind: 'NamedType',
+        name: { kind: 'Name', value: 'vaults' },
+      },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'FragmentSpread',
+            name: { kind: 'Name', value: 'VaultBasicDetails' },
+          },
+        ],
+      },
+    },
+    {
+      kind: 'FragmentDefinition',
+      name: { kind: 'Name', value: 'VaultBasicDetails' },
+      typeCondition: {
+        kind: 'NamedType',
+        name: { kind: 'Name', value: 'vaults' },
+      },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'atom' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+              ],
+            },
+          },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'triple' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'subject' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'predicate' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'object' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
         ],
       },
     },
@@ -30528,8 +30417,43 @@ export const GetListItems = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
                 },
               ],
             },
@@ -30541,98 +30465,46 @@ export const GetListItems = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultBasicDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'triple' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'subject' },
+                  name: { kind: 'Name', value: 'positions' },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'predicate' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'object' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
               ],
             },
-          },
-          { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'FragmentSpread',
-            name: { kind: 'Name', value: 'VaultBasicDetails' },
           },
         ],
       },
@@ -32939,8 +32811,43 @@ export const GetTriples = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
                 },
               ],
             },
@@ -32952,98 +32859,46 @@ export const GetTriples = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultBasicDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'triple' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'subject' },
+                  name: { kind: 'Name', value: 'positions' },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'predicate' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'object' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
               ],
             },
-          },
-          { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'FragmentSpread',
-            name: { kind: 'Name', value: 'VaultBasicDetails' },
           },
         ],
       },
@@ -33582,8 +33437,43 @@ export const GetTriplesWithAggregates = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
                 },
               ],
             },
@@ -33595,98 +33485,46 @@ export const GetTriplesWithAggregates = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultBasicDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'triple' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'subject' },
+                  name: { kind: 'Name', value: 'positions' },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'predicate' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'object' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
               ],
             },
-          },
-          { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'FragmentSpread',
-            name: { kind: 'Name', value: 'VaultBasicDetails' },
           },
         ],
       },
@@ -34210,8 +34048,43 @@ export const GetTriple = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'positions' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
                 },
               ],
             },
@@ -34223,98 +34096,46 @@ export const GetTriple = {
               kind: 'SelectionSet',
               selections: [
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'VaultDetails' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultBasicDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'atom' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'triple' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'subject' },
+                  name: { kind: 'Name', value: 'positions' },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'predicate' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'object' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'label' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'vaultId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'shares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'account' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'image' },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
               ],
             },
-          },
-          { kind: 'Field', name: { kind: 'Name', value: 'currentSharePrice' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'totalShares' } },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'VaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'vaults' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'FragmentSpread',
-            name: { kind: 'Name', value: 'VaultBasicDetails' },
           },
         ],
       },


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Converts the Claim Details pages (index and id) to use GraphQL. Adds the necessary queries to get the data as well as check if the Claim is part of a List and also to pull the For/Against positions. Creates a new version of the DetailInfoCard component to not break the Readonly route build until we fully migrate and then we can remove
- Handling the positions was the biggest change from the previous implementation. Previously, all positions came through in a single list with a `for` and `against` direction as a property. This isn't the case now, so we needed to combine the vault and counterVault positions together. This works, but there are definitely performance improvements, especially since we should likely be doing the tab filtering client side instead of a refresh. There's room for us to continue to improve in the future.
- Also, the search/sort/pagination will be wired up to the UI component in a future PR, but the query supports it!
- @Vitalsine85 -- The staking modals will need to be updated as part of the sweep you do. That should cover all the bases here!

## Screen Captures

![claim-details-graphql](https://github.com/user-attachments/assets/14c75f5a-d71c-484c-b78f-3c4a2eb814cf)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
