### PR TITLE
ENG-4886 feat(portal): handle invalidateQueries better on stake action

### DIFF
--- a/apps/portal/app/lib/hooks/mutations/useStakeMutation.tsx
+++ b/apps/portal/app/lib/hooks/mutations/useStakeMutation.tsx
@@ -76,11 +76,13 @@ export function useStakeMutation(contract: string, mode: 'deposit' | 'redeem') {
           predicate: (query) => {
             const [key, contract, vaultId, counterVaultId] = query.queryKey
             return (
-              (key === 'get-vault-details' &&
+              (key === 'get-vault-details' && // TODO: This doesn't seem to be working at the moment, but it's not a big deal. We can figure it out later.
                 contract === variables.contract &&
                 vaultId === variables.vaultId &&
                 counterVaultId === variables.claim?.counter_vault_id) ||
-              key === 'get-stats'
+              key === 'get-stats' ||
+              key === 'get-triple' ||
+              key === 'get-vault-details' // TODO: Remove this once we figure out the issue with the above queryKey for get-vault-details.
             )
           },
         })

--- a/apps/portal/app/routes/app+/claim+/$id+/index.tsx
+++ b/apps/portal/app/routes/app+/claim+/$id+/index.tsx
@@ -23,7 +23,6 @@ import { ErrorPage } from '@components/error-page'
 import { PositionsOnClaimNew } from '@components/list/positions-on-claim'
 import RemixLink from '@components/remix-link'
 import { PaginatedListSkeleton, TabsSkeleton } from '@components/skeleton'
-import { useLiveLoader } from '@lib/hooks/useLiveLoader'
 import logger from '@lib/utils/logger'
 import {
   getAtomDescriptionGQL,
@@ -35,6 +34,7 @@ import {
 } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs } from '@remix-run/node'
 import {
+  useLoaderData,
   useNavigation,
   useRouteLoaderData,
   useSearchParams,
@@ -84,7 +84,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 export default function ClaimOverview() {
-  const { initialParams } = useLiveLoader<typeof loader>(['attest', 'create'])
+  const { initialParams } = useLoaderData<typeof loader>()
   const { claim } =
     useRouteLoaderData<ClaimDetailsLoaderData>('routes/app+/claim+/$id') ?? {}
   invariant(claim, NO_CLAIM_ERROR)


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Added better handling for invalidating queries on stake actions

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
