### PR TITLE
ENG-4942 feat(portal): convert identity read only route to use graphql

### DIFF
--- a/apps/portal/app/components/list/claims.tsx
+++ b/apps/portal/app/components/list/claims.tsx
@@ -11,7 +11,10 @@ import {
   ClaimSortColumn,
   IdentityPresenter,
 } from '@0xintuition/api'
-import { GetTriplesWithPositionsQuery } from '@0xintuition/graphql'
+import {
+  GetAtomQuery,
+  GetTriplesWithPositionsQuery,
+} from '@0xintuition/graphql'
 
 import { ListHeader } from '@components/list/list-header'
 import RemixLink from '@components/remix-link'
@@ -32,6 +35,8 @@ import { useSetAtom } from 'jotai'
 
 import { SortOption } from '../sort-select'
 import { List } from './list'
+
+type Atom = GetAtomQuery['atom']
 
 type Triple = NonNullable<
   NonNullable<GetTriplesWithPositionsQuery['triples']>[number]
@@ -166,9 +171,7 @@ export function ClaimsListNew({
                   id: triple.subject?.id,
                   description: '',
                   ipfsLink: '',
-                  // TODO: ENG-4782 Replace any with correct type
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  link: getAtomLinkGQL(triple.subject as any, readOnly),
+                  link: getAtomLinkGQL(triple.subject as Atom, readOnly),
                   linkComponent: RemixLink,
                 }}
                 predicate={{
@@ -178,9 +181,7 @@ export function ClaimsListNew({
                   id: triple.predicate?.id,
                   description: '',
                   ipfsLink: '',
-                  // TODO: ENG-4782 Replace any with correct type
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  link: getAtomLinkGQL(triple.predicate as any, readOnly),
+                  link: getAtomLinkGQL(triple.predicate as Atom, readOnly),
                   linkComponent: RemixLink,
                 }}
                 object={{
@@ -190,9 +191,7 @@ export function ClaimsListNew({
                   id: triple.object?.id,
                   description: '',
                   ipfsLink: '',
-                  // TODO: ENG-4782 Replace any with correct type
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  link: getAtomLinkGQL(triple.object as any, readOnly),
+                  link: getAtomLinkGQL(triple.object as Atom, readOnly),
                   linkComponent: RemixLink,
                 }}
                 isClickable={true}

--- a/apps/portal/app/components/list/claims.tsx
+++ b/apps/portal/app/components/list/claims.tsx
@@ -23,6 +23,7 @@ import {
   getAtomIpfsLink,
   getAtomLabel,
   getAtomLink,
+  getAtomLinkGQL,
   getClaimUrl,
 } from '@lib/utils/misc'
 import { Link } from '@remix-run/react'
@@ -44,7 +45,7 @@ interface ClaimsListNewProps {
   enableHeader?: boolean
   enableSearch?: boolean
   enableSort?: boolean
-  // readOnly?: boolean
+  readOnly?: boolean
 }
 
 export function ClaimsListNew({
@@ -54,7 +55,7 @@ export function ClaimsListNew({
   enableHeader = true,
   enableSearch = true,
   enableSort = true,
-  // readOnly = false,
+  readOnly = false,
 }: ClaimsListNewProps) {
   const setStakeModalActive = useSetAtom(stakeModalAtom)
 
@@ -165,7 +166,9 @@ export function ClaimsListNew({
                   id: triple.subject?.id,
                   description: '',
                   ipfsLink: '',
-                  link: '',
+                  // TODO: ENG-4782 Replace any with correct type
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  link: getAtomLinkGQL(triple.subject as any, readOnly),
                   linkComponent: RemixLink,
                 }}
                 predicate={{
@@ -175,7 +178,9 @@ export function ClaimsListNew({
                   id: triple.predicate?.id,
                   description: '',
                   ipfsLink: '',
-                  link: '',
+                  // TODO: ENG-4782 Replace any with correct type
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  link: getAtomLinkGQL(triple.predicate as any, readOnly),
                   linkComponent: RemixLink,
                 }}
                 object={{
@@ -185,7 +190,9 @@ export function ClaimsListNew({
                   id: triple.object?.id,
                   description: '',
                   ipfsLink: '',
-                  link: '',
+                  // TODO: ENG-4782 Replace any with correct type
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  link: getAtomLinkGQL(triple.object as any, readOnly),
                   linkComponent: RemixLink,
                 }}
                 isClickable={true}

--- a/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
+++ b/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
@@ -1,63 +1,210 @@
 import { Suspense } from 'react'
 
 import { ErrorStateCard, Text } from '@0xintuition/1ui'
-import { ClaimsService } from '@0xintuition/api'
+import {
+  fetcher,
+  GetAtomDocument,
+  GetAtomQuery,
+  GetAtomQueryVariables,
+  GetPositionsDocument,
+  GetPositionsQuery,
+  GetPositionsQueryVariables,
+  GetTriplesWithPositionsDocument,
+  GetTriplesWithPositionsQuery,
+  GetTriplesWithPositionsQueryVariables,
+  useGetAtomQuery,
+  useGetPositionsQuery,
+  useGetTriplesWithPositionsQuery,
+} from '@0xintuition/graphql'
 
 import { ErrorPage } from '@components/error-page'
-import { ClaimsList as ClaimsAboutIdentity } from '@components/list/claims'
-import { PositionsOnIdentity } from '@components/list/positions-on-identity'
+import { ClaimsListNew as ClaimsAboutIdentity } from '@components/list/claims'
+import { PositionsOnIdentityNew } from '@components/list/positions-on-identity'
 import DataAboutHeader from '@components/profile/data-about-header'
 import { RevalidateButton } from '@components/revalidate-button'
 import { DataHeaderSkeleton, PaginatedListSkeleton } from '@components/skeleton'
 import { useLiveLoader } from '@lib/hooks/useLiveLoader'
-import { getClaimsAboutIdentity } from '@lib/services/claims'
-import { getPositionsOnIdentity } from '@lib/services/positions'
 import { formatBalance, invariant } from '@lib/utils/misc'
-import { defer, LoaderFunctionArgs } from '@remix-run/node'
-import { Await, useRouteLoaderData } from '@remix-run/react'
-import { fetchWrapper } from '@server/api'
+import { json, LoaderFunctionArgs } from '@remix-run/node'
+import { useRouteLoaderData } from '@remix-run/react'
+import { QueryClient } from '@tanstack/react-query'
 import { NO_IDENTITY_ERROR, NO_PARAM_ID_ERROR } from 'app/consts'
 
 import { ReadOnlyIdentityLoaderData } from '../$id'
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const id = params.id
-
   invariant(id, NO_PARAM_ID_ERROR)
 
   const url = new URL(request.url)
-  const searchParams = new URLSearchParams(url.search)
+  const queryClient = new QueryClient()
 
-  return defer({
-    positions: getPositionsOnIdentity({
-      request,
-      identityId: id,
-      searchParams,
-    }),
-    claims: getClaimsAboutIdentity({
-      request,
-      identityId: id,
-      searchParams,
-    }),
-    claimsSummary: fetchWrapper(request, {
-      method: ClaimsService.claimSummary,
-      args: {
-        identity: id,
+  const triplesLimit = parseInt(url.searchParams.get('claimsLimit') || '10')
+  const triplesOffset = parseInt(url.searchParams.get('claimsOffset') || '0')
+  const triplesOrderBy = url.searchParams.get('claimsSortBy')
+
+  const triplesWhere = {
+    _or: [
+      {
+        subjectId: {
+          _eq: id,
+        },
       },
-    }),
+      {
+        objectId: {
+          _eq: id,
+        },
+      },
+      {
+        predicateId: {
+          _eq: id,
+        },
+      },
+    ],
+  }
+
+  const positionsLimit = parseInt(
+    url.searchParams.get('positionsLimit') || '10',
+  )
+  const positionsOffset = parseInt(
+    url.searchParams.get('positionsOffset') || '0',
+  )
+  const positionsOrderBy = url.searchParams.get('positionsSortBy')
+
+  const positionsWhere = {
+    vaultId: { _eq: id },
+  }
+
+  await queryClient.prefetchQuery({
+    queryKey: ['get-atom', { id: params.id }],
+    queryFn: () =>
+      fetcher<GetAtomQuery, GetAtomQueryVariables>(GetAtomDocument, {
+        id: params.id,
+      })(),
+  })
+
+  await queryClient.prefetchQuery({
+    queryKey: [
+      'get-triples-with-positions',
+      { triplesWhere, triplesLimit, triplesOffset, triplesOrderBy },
+    ],
+    queryFn: () =>
+      fetcher<
+        GetTriplesWithPositionsQuery,
+        GetTriplesWithPositionsQueryVariables
+      >(GetTriplesWithPositionsDocument, {
+        where: triplesWhere,
+        limit: triplesLimit,
+        offset: triplesOffset,
+        orderBy: triplesOrderBy ? [{ [triplesOrderBy]: 'desc' }] : undefined,
+      })(),
+  })
+
+  await queryClient.prefetchQuery({
+    queryKey: [
+      'get-atom-positions',
+      { positionsWhere, positionsLimit, positionsOffset, positionsOrderBy },
+    ],
+    queryFn: () =>
+      fetcher<GetPositionsQuery, GetPositionsQueryVariables>(
+        GetPositionsDocument,
+        {
+          where: positionsWhere,
+          limit: positionsLimit,
+          offset: positionsOffset,
+          orderBy: positionsOrderBy
+            ? [{ [positionsOrderBy]: 'desc' }]
+            : undefined,
+        },
+      )(),
+  })
+
+  return json({
+    initialParams: {
+      triplesLimit,
+      triplesOffset,
+      triplesOrderBy,
+      triplesWhere,
+      positionsLimit,
+      positionsOffset,
+      positionsOrderBy,
+      positionsWhere,
+      atomId: params.id,
+    },
   })
 }
 
 export default function ReadOnlyProfileDataAbout() {
-  const { positions, claims, claimsSummary } = useLiveLoader<typeof loader>([
-    'attest',
-  ])
+  const { initialParams } = useLiveLoader<typeof loader>(['attest'])
 
   const { identity } =
     useRouteLoaderData<ReadOnlyIdentityLoaderData>(
       'routes/readonly+/identity+/$id',
     ) ?? {}
   invariant(identity, NO_IDENTITY_ERROR)
+
+  const { data: atomResult, isLoading: isLoadingAtom } = useGetAtomQuery(
+    {
+      id: initialParams.atomId,
+    },
+    {
+      queryKey: ['get-atom', { id: initialParams.atomId }],
+    },
+  )
+
+  const {
+    data: triplesResult,
+    isLoading: isLoadingTriples,
+    isError: isErrorTriples,
+    error: errorTriples,
+  } = useGetTriplesWithPositionsQuery(
+    {
+      where: initialParams.triplesWhere,
+      limit: initialParams.triplesLimit,
+      offset: initialParams.triplesOffset,
+      orderBy: initialParams.triplesOrderBy
+        ? [{ [initialParams.triplesOrderBy]: 'desc' }]
+        : undefined,
+    },
+    {
+      queryKey: [
+        'get-triples-with-positions',
+        {
+          where: initialParams.triplesWhere,
+          limit: initialParams.triplesLimit,
+          offset: initialParams.triplesOffset,
+          orderBy: initialParams.triplesOrderBy,
+        },
+      ],
+    },
+  )
+
+  const {
+    data: positionsResult,
+    isLoading: isLoadingPositions,
+    isError: isErrorPositions,
+    error: errorPositions,
+  } = useGetPositionsQuery(
+    {
+      where: initialParams.positionsWhere,
+      limit: initialParams.positionsLimit,
+      offset: initialParams.positionsOffset,
+      orderBy: initialParams.positionsOrderBy
+        ? [{ [initialParams.positionsOrderBy]: 'desc' }]
+        : undefined,
+    },
+    {
+      queryKey: [
+        'get-atom-positions',
+        {
+          where: initialParams.positionsWhere,
+          limit: initialParams.positionsLimit,
+          offset: initialParams.positionsOffset,
+          orderBy: initialParams.positionsOrderBy,
+        },
+      ],
+    },
+  )
 
   return (
     <>
@@ -75,46 +222,42 @@ export default function ReadOnlyProfileDataAbout() {
             </div>
           </div>
           <Suspense fallback={<DataHeaderSkeleton />}>
-            <Await resolve={claims} errorElement={<></>}>
-              {(resolvedClaims) => (
-                <Await resolve={claimsSummary} errorElement={<></>}>
-                  {(resolvedClaimsSummary) => (
-                    <DataAboutHeader
-                      variant="claims"
-                      userIdentity={identity}
-                      totalClaims={resolvedClaims.pagination.totalEntries}
-                      totalStake={
-                        +formatBalance(
-                          resolvedClaimsSummary?.assets_sum ?? 0,
-                          18,
-                        )
-                      }
-                    />
-                  )}
-                </Await>
-              )}
-            </Await>
+            {isLoadingTriples && isLoadingAtom ? (
+              <DataHeaderSkeleton />
+            ) : (
+              <DataAboutHeader
+                variant="claims"
+                atomImage={atomResult?.atom?.image ?? ''}
+                atomLabel={atomResult?.atom?.label ?? ''}
+                atomVariant="user" // TODO: Determine based on atom type
+                totalClaims={triplesResult?.total?.aggregate?.count ?? 0}
+                totalStake={0} // TODO: need to find way to get the shares
+              />
+            )}
           </Suspense>
           <Suspense fallback={<PaginatedListSkeleton />}>
-            <Await
-              resolve={claims}
-              errorElement={
-                <ErrorStateCard>
-                  <RevalidateButton />
-                </ErrorStateCard>
-              }
-            >
-              {(resolvedClaims) => (
-                <ClaimsAboutIdentity
-                  claims={resolvedClaims.data}
-                  pagination={resolvedClaims.pagination}
-                  paramPrefix="claims"
-                  enableSearch
-                  enableSort
-                  readOnly
-                />
-              )}
-            </Await>
+            {isLoadingTriples ? (
+              <PaginatedListSkeleton />
+            ) : isErrorTriples ? (
+              <ErrorStateCard
+                title="Failed to load claims"
+                message={
+                  (errorTriples as Error)?.message ??
+                  'An unexpected error occurred'
+                }
+              >
+                <RevalidateButton />
+              </ErrorStateCard>
+            ) : (
+              <ClaimsAboutIdentity
+                claims={triplesResult?.triples ?? []}
+                pagination={triplesResult?.total?.aggregate?.count ?? {}}
+                paramPrefix="claims"
+                enableSearch={false}
+                enableSort={false}
+                readOnly
+              />
+            )}
           </Suspense>
         </div>
         <div className="flex flex-col w-full gap-6">
@@ -129,33 +272,43 @@ export default function ReadOnlyProfileDataAbout() {
             </Text>
           </div>
           <Suspense fallback={<DataHeaderSkeleton />}>
-            <Await resolve={positions} errorElement={<></>}>
-              {(resolvedPositions) => (
-                <DataAboutHeader
-                  variant="positions"
-                  userIdentity={identity}
-                  totalPositions={resolvedPositions.pagination.totalEntries}
-                  totalStake={+formatBalance(identity.assets_sum, 18)}
-                />
-              )}
-            </Await>
+            {isLoadingPositions && isLoadingAtom ? (
+              <DataHeaderSkeleton />
+            ) : (
+              <DataAboutHeader
+                variant="positions"
+                atomImage={atomResult?.atom?.image ?? ''}
+                atomLabel={atomResult?.atom?.label ?? ''}
+                atomVariant="user" // TODO: Determine based on atom type
+                totalPositions={positionsResult?.total?.aggregate?.count ?? 0}
+                totalStake={
+                  +formatBalance(
+                    positionsResult?.total?.aggregate?.sum?.shares ?? 0,
+                    18,
+                  )
+                }
+              />
+            )}
           </Suspense>
           <Suspense fallback={<PaginatedListSkeleton />}>
-            <Await
-              resolve={positions}
-              errorElement={
-                <ErrorStateCard>
-                  <RevalidateButton />
-                </ErrorStateCard>
-              }
-            >
-              {(resolvedPositions) => (
-                <PositionsOnIdentity
-                  positions={resolvedPositions.data}
-                  pagination={resolvedPositions.pagination}
-                />
-              )}
-            </Await>
+            {isLoadingPositions ? (
+              <PaginatedListSkeleton />
+            ) : isErrorPositions ? (
+              <ErrorStateCard
+                title="Failed to load positions"
+                message={
+                  (errorPositions as Error)?.message ??
+                  'An unexpected error occurred'
+                }
+              >
+                <RevalidateButton />
+              </ErrorStateCard>
+            ) : (
+              <PositionsOnIdentityNew
+                positions={positionsResult?.positions ?? []}
+                pagination={positionsResult?.total?.aggregate?.count ?? {}}
+              />
+            )}
           </Suspense>
         </div>
       </div>

--- a/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
+++ b/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
@@ -231,7 +231,13 @@ export default function ReadOnlyProfileDataAbout() {
                 atomLabel={atomResult?.atom?.label ?? ''}
                 atomVariant="user" // TODO: Determine based on atom type
                 totalClaims={triplesResult?.total?.aggregate?.count ?? 0}
-                totalStake={0} // TODO: need to find way to get the shares
+                totalStake={0} // TODO: need to find way to get the shares -- may need to update the schema
+                // totalStake={
+                //   +formatBalance(
+                //     triplesResult?.total?.aggregate?.sums?.shares ?? 0,
+                //     18,
+                //   )
+                // }
               />
             )}
           </Suspense>

--- a/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
+++ b/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
@@ -12,6 +12,7 @@ import {
   GetTriplesWithPositionsDocument,
   GetTriplesWithPositionsQuery,
   GetTriplesWithPositionsQueryVariables,
+  Order_By,
   useGetAtomQuery,
   useGetPositionsQuery,
   useGetTriplesWithPositionsQuery,
@@ -37,10 +38,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const url = new URL(request.url)
   const queryClient = new QueryClient()
-
-  const triplesLimit = parseInt(url.searchParams.get('claimsLimit') || '10')
-  const triplesOffset = parseInt(url.searchParams.get('claimsOffset') || '0')
-  const triplesOrderBy = url.searchParams.get('claimsSortBy')
 
   const triplesWhere = {
     _or: [
@@ -83,19 +80,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   })
 
   await queryClient.prefetchQuery({
-    queryKey: [
-      'get-triples-with-positions',
-      { triplesWhere, triplesLimit, triplesOffset, triplesOrderBy },
-    ],
+    queryKey: ['get-triples-with-positions', { triplesWhere }],
     queryFn: () =>
       fetcher<
         GetTriplesWithPositionsQuery,
         GetTriplesWithPositionsQueryVariables
       >(GetTriplesWithPositionsDocument, {
         where: triplesWhere,
-        limit: triplesLimit,
-        offset: triplesOffset,
-        orderBy: triplesOrderBy ? [{ [triplesOrderBy]: 'desc' }] : undefined,
+        limit: 10,
+        offset: 0,
+        orderBy: {
+          blockTimestamp: 'desc' as Order_By,
+        },
+        address: '', //TODO: We don't have an address for the user since this is read-only. Do we continue to use this version of the hook or just pass in an empty string like so?
       })(),
   })
 
@@ -120,9 +117,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   return json({
     initialParams: {
-      triplesLimit,
-      triplesOffset,
-      triplesOrderBy,
       triplesWhere,
       positionsLimit,
       positionsOffset,
@@ -159,20 +153,24 @@ export default function ReadOnlyProfileDataAbout() {
   } = useGetTriplesWithPositionsQuery(
     {
       where: initialParams.triplesWhere,
-      limit: initialParams.triplesLimit,
-      offset: initialParams.triplesOffset,
-      orderBy: initialParams.triplesOrderBy
-        ? [{ [initialParams.triplesOrderBy]: 'desc' }]
-        : undefined,
+      limit: 10,
+      offset: 0,
+      orderBy: {
+        blockTimestamp: 'desc' as Order_By,
+      },
+      address: '', //TODO: We don't have an address for the user since this is read-only. Do we continue to use this version of the hook or just pass in an empty string like so?
     },
     {
       queryKey: [
         'get-triples-with-positions',
         {
           where: initialParams.triplesWhere,
-          limit: initialParams.triplesLimit,
-          offset: initialParams.triplesOffset,
-          orderBy: initialParams.triplesOrderBy,
+          limit: 10,
+          offset: 0,
+          orderBy: {
+            blockTimestamp: 'desc' as Order_By,
+          },
+          address: '', //TODO: We don't have an address for the user since this is read-only. Do we continue to use this version of the hook or just pass in an empty string like so?
         },
       ],
     },

--- a/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
+++ b/apps/portal/app/routes/readonly+/identity+/$id+/index.tsx
@@ -23,10 +23,9 @@ import { PositionsOnIdentityNew } from '@components/list/positions-on-identity'
 import DataAboutHeader from '@components/profile/data-about-header'
 import { RevalidateButton } from '@components/revalidate-button'
 import { DataHeaderSkeleton, PaginatedListSkeleton } from '@components/skeleton'
-import { useLiveLoader } from '@lib/hooks/useLiveLoader'
 import { formatBalance, invariant } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs } from '@remix-run/node'
-import { useRouteLoaderData } from '@remix-run/react'
+import { useLoaderData, useRouteLoaderData } from '@remix-run/react'
 import { QueryClient } from '@tanstack/react-query'
 import { NO_IDENTITY_ERROR, NO_PARAM_ID_ERROR } from 'app/consts'
 
@@ -135,7 +134,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 export default function ReadOnlyProfileDataAbout() {
-  const { initialParams } = useLiveLoader<typeof loader>(['attest'])
+  const { initialParams } = useLoaderData<typeof loader>()
 
   const { identity } =
     useRouteLoaderData<ReadOnlyIdentityLoaderData>(

--- a/apps/portal/app/routes/readonly+/identity+/$id.tsx
+++ b/apps/portal/app/routes/readonly+/identity+/$id.tsx
@@ -33,6 +33,14 @@ import { getIdentityOrPending } from '@lib/services/identities'
 import { imageModalAtom } from '@lib/state/store'
 import { getSpecialPredicate } from '@lib/utils/app'
 import logger from '@lib/utils/logger'
+import {
+  getAtomDescriptionGQL,
+  getAtomIdGQL,
+  getAtomImageGQL,
+  getAtomIpfsLinkGQL,
+  getAtomLabelGQL,
+  getAtomLinkGQL,
+} from '@lib/utils/misc'
 import { json, LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
 import { Outlet, useLoaderData } from '@remix-run/react'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
@@ -218,13 +226,13 @@ export default function ReadOnlyIdentityDetails() {
     <div className="flex-col justify-start items-start inline-flex gap-6 max-lg:w-full">
       <ProfileCard
         variant={Identity.nonUser}
-        avatarSrc={atomResult?.atom?.value?.thing?.image ?? ''}
-        name={atomResult?.atom?.value?.thing?.name ?? ''}
-        id={atomResult?.atom?.id ?? ''}
-        vaultId={atomResult?.atom?.id}
-        bio={atomResult?.atom?.value?.thing?.description ?? ''}
-        ipfsLink={atomResult?.atom?.data ?? ''}
-        externalLink={atomResult?.atom?.value?.thing?.url ?? ''}
+        avatarSrc={getAtomImageGQL(atomResult?.atom) ?? ''}
+        name={getAtomLabelGQL(atomResult?.atom) ?? ''}
+        id={getAtomIdGQL(atomResult?.atom) ?? ''}
+        vaultId={atomResult?.atom?.vaultId}
+        bio={getAtomDescriptionGQL(atomResult?.atom) ?? ''}
+        ipfsLink={getAtomIpfsLinkGQL(atomResult?.atom) ?? ''}
+        externalLink={getAtomLinkGQL(atomResult?.atom) ?? ''}
         onAvatarClick={() => {
           setImageModalActive({
             isOpen: true,

--- a/apps/portal/app/routes/readonly+/identity+/$id.tsx
+++ b/apps/portal/app/routes/readonly+/identity+/$id.tsx
@@ -29,13 +29,12 @@ import { ErrorPage } from '@components/error-page'
 import NavigationButton from '@components/navigation-link'
 import ImageModal from '@components/profile/image-modal'
 import ReadOnlyBanner from '@components/read-only-banner'
-import { useLiveLoader } from '@lib/hooks/useLiveLoader'
 import { getIdentityOrPending } from '@lib/services/identities'
 import { imageModalAtom } from '@lib/state/store'
 import { getSpecialPredicate } from '@lib/utils/app'
 import logger from '@lib/utils/logger'
 import { json, LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
-import { Outlet } from '@remix-run/react'
+import { Outlet, useLoaderData } from '@remix-run/react'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { BLOCK_EXPLORER_URL, CURRENT_ENV, PATHS } from 'app/consts'
 import TwoPanelLayout from 'app/layouts/two-panel-layout'
@@ -185,7 +184,7 @@ export interface ReadOnlyIdentityLoaderData {
 
 export default function ReadOnlyIdentityDetails() {
   const { identity, list, isPending, initialParams } =
-    useLiveLoader<ReadOnlyIdentityLoaderData>(['attest', 'create'])
+    useLoaderData<ReadOnlyIdentityLoaderData>()
 
   const [imageModalActive, setImageModalActive] = useAtom(imageModalAtom)
 


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Updates the read only identity detail route to use GraphQL.

NOTE: Marking as Do Not Merge until i7n issues are resolved and we can properly test.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
