### PR TITLE
ENG-4941 feat(portal): convert claim read only route to use graphql

### DIFF
--- a/apps/portal/app/components/detail-info-card.tsx
+++ b/apps/portal/app/components/detail-info-card.tsx
@@ -51,7 +51,7 @@ export const DetailInfoCardNew = ({
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-  }).format(new Date(timestamp))
+  }).format(new Date(Number(timestamp) * 1000))
 
   return (
     <div

--- a/apps/portal/app/routes/readonly+/claim+/$id+/index.tsx
+++ b/apps/portal/app/routes/readonly+/claim+/$id+/index.tsx
@@ -31,15 +31,9 @@ import {
   invariant,
 } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs } from '@remix-run/node'
-import {
-  useLoaderData,
-  useNavigation,
-  useRouteLoaderData,
-  useSearchParams,
-} from '@remix-run/react'
-import { ReadOnlyClaimDetailsLoaderData } from '@routes/readonly+/claim+/$id'
+import { useLoaderData, useNavigation, useSearchParams } from '@remix-run/react'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
-import { NO_CLAIM_ERROR, NO_PARAM_ID_ERROR } from 'app/consts'
+import { NO_PARAM_ID_ERROR } from 'app/consts'
 
 type Atom = GetAtomQuery['atom']
 
@@ -76,11 +70,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function ReadOnlyClaimOverview() {
   const { initialParams } = useLoaderData<typeof loader>()
-  const { claim } =
-    useRouteLoaderData<ReadOnlyClaimDetailsLoaderData>(
-      'routes/readonly+/claim+/$id',
-    ) ?? {}
-  invariant(claim, NO_CLAIM_ERROR)
 
   const [searchParams, setSearchParams] = useSearchParams()
   const [isNavigating, setIsNavigating] = useState(false)

--- a/apps/portal/app/routes/readonly+/claim+/$id.tsx
+++ b/apps/portal/app/routes/readonly+/claim+/$id.tsx
@@ -1,5 +1,4 @@
 import { BannerVariant, Claim, Identity } from '@0xintuition/1ui'
-import { ClaimPresenter } from '@0xintuition/api'
 import {
   fetcher,
   GetAtomQuery,
@@ -137,13 +136,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
 export interface ReadOnlyClaimDetailsLoaderData {
   wallet: string
-  claim: ClaimPresenter
   vaultDetails: VaultDetailsType
 }
 
 export default function ReadOnlyClaimDetails() {
-  const { claim, initialParams } = useLoaderData<{
-    claim: ClaimPresenter
+  const { initialParams } = useLoaderData<{
     initialParams: {
       id: string
     }
@@ -222,17 +219,18 @@ export default function ReadOnlyClaimDetails() {
         username={tripleData?.triple?.creator?.label ?? '?'}
         avatarImgSrc={tripleData?.triple?.creator?.image ?? ''}
         id={tripleData?.triple?.creator?.id ?? ''}
-        description={claim.creator?.description ?? ''}
+        description={tripleData?.triple?.creator?.label ?? ''}
         link={
-          claim.creator?.id ? `${PATHS.PROFILE}/${claim.creator?.wallet}` : ''
+          tripleData?.triple?.creator?.id
+            ? `${PATHS.PROFILE}/${tripleData?.triple?.creator?.id}`
+            : ''
         }
-        ipfsLink={`${BLOCK_EXPLORER_URL}/address/${claim.creator?.wallet}`}
-        timestamp={claim.created_at}
-        className="w-full"
+        ipfsLink={`${BLOCK_EXPLORER_URL}/address/${tripleData?.triple?.creator?.id}`}
+        timestamp={tripleData?.triple?.blockTimestamp ?? ''}
       />
       <ReadOnlyBanner
         variant={BannerVariant.warning}
-        to={`${PATHS.CLAIM}/${claim.vault_id}`}
+        to={`${PATHS.CLAIM}/${tripleData?.triple?.vaultId}`}
       />
     </div>
   )

--- a/apps/portal/app/routes/readonly+/claim+/$id.tsx
+++ b/apps/portal/app/routes/readonly+/claim+/$id.tsx
@@ -219,7 +219,7 @@ export default function ReadOnlyClaimDetails() {
         username={tripleData?.triple?.creator?.label ?? '?'}
         avatarImgSrc={tripleData?.triple?.creator?.image ?? ''}
         id={tripleData?.triple?.creator?.id ?? ''}
-        description={tripleData?.triple?.creator?.label ?? ''}
+        description={tripleData?.triple?.creator?.label ?? ''} //TODO: We don't have a description for the creator on triples, but it exists on identities, have BE add this.
         link={
           tripleData?.triple?.creator?.id
             ? `${PATHS.PROFILE}/${tripleData?.triple?.creator?.id}`


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Updates the read only claim detail route to use GraphQL.

NOTE: Marking as Do Not Merge until i7n issues are resolved and we can properly test.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
