### PR TITLE
ENG-4995 feat(1ui,graphql): update feature branch main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,19 @@ dist/
 tmp/
 
 .nx/cache
+.nx/workspace-data
 packages/1ui/storybook-static
 
 .env*
 !.env.example
 .secrets
 act.sh
+
+# Verdaccio local registry files
+.verdaccio-db.json
+.npmrc
+
+# Build outputs
+/dist/
+**/dist/
+packages/*/dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 **/*.yaml
 **/*.template
+/.nx/workspace-data

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -15,7 +15,27 @@ uplinks:
     fail_timeout: 2m
 
 packages:
+  '@0xintuition/*':
+    # give all users (including non-authenticated users) full access
+    # because it is a local registry
+    access: $all
+    publish: $all
+    unpublish: $all
+
+    # if package is not available locally, proxy requests to npm registry
+    proxy: npmjs
+
   '@*/*':
+    # give all users (including non-authenticated users) full access
+    # because it is a local registry
+    access: $all
+    publish: $all
+    unpublish: $all
+
+    # if package is not available locally, proxy requests to npm registry
+    proxy: npmjs
+
+  '**':
     # give all users (including non-authenticated users) full access
     # because it is a local registry
     access: $all
@@ -29,7 +49,7 @@ packages:
 logs:
   type: stdout
   format: pretty
-  level: warn
+  level: http
 
 publish:
   allow_offline: true # set offline to true to allow publish offline

--- a/packages/1ui/project.json
+++ b/packages/1ui/project.json
@@ -58,6 +58,19 @@
       "options": {
         "packageRoot": "dist/{projectRoot}"
       }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": "dependencies"
+        }
+      ],
+      "options": {
+        "command": "tsc --noEmit -p packages/1ui/tsconfig.typecheck.json",
+        "cwd": "."
+      }
     }
   }
 }

--- a/packages/1ui/tsconfig.json
+++ b/packages/1ui/tsconfig.json
@@ -5,7 +5,8 @@
     "baseUrl": "./src",
     "outDir": "../../dist/packages/1ui",
     "composite": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["jest", "node", "vitest"]
   },
   "include": ["src"]
 }

--- a/packages/1ui/tsconfig.typecheck.json
+++ b/packages/1ui/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "types": ["node"],
+    "typeRoots": ["./types.d.ts", "../../node_modules/@types"]
+  },
+  "include": ["src/**/*", ".storybook/**/*", "**/*.mdx", "types.d.ts"],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/1ui/types.d.ts
+++ b/packages/1ui/types.d.ts
@@ -1,0 +1,5 @@
+declare module '*.mdx' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let MDXComponent: (props: any) => JSX.Element
+  export default MDXComponent
+}

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -44,6 +44,80 @@ You can also run this from the monorepo root:
 pnpm graphql:test
 ```
 
+### Testing with Local Registry
+
+#### Setup
+
+1. Copy `.npmrc.example` from the root to `.npmrc` to configure the local registry.
+
+2. Start the local registry:
+
+```bash
+pnpm nx local-registry
+```
+
+#### Version Management
+
+Before publishing, you may need to update the package version. Use one of these commands:
+
+```bash
+pnpm version:patch  # For bug fixes (0.0.x)
+pnpm version:minor  # For new features (0.x.0)
+pnpm version:major  # For breaking changes (x.0.0)
+pnpm version:beta   # For beta releases
+```
+
+#### Testing in Monorepo Apps (Recommended)
+
+1. Make changes to the package and build:
+
+```bash
+cd packages/graphql
+# This will run codegen first (prebuild) and then build
+pnpm build
+```
+
+2. Test the build before publishing (optional):
+
+```bash
+pnpm publish-dry
+```
+
+3. Publish to local registry using one of these commands:
+
+```bash
+# For local testing only
+npm publish --registry http://localhost:4873
+
+# For publishing to npm registry with tags (when ready)
+pnpm publish-latest  # Publishes with 'latest' tag
+pnpm publish-next   # Publishes with 'next' tag
+```
+
+4. In your test app, update the package version in package.json:
+
+```json
+{
+  "dependencies": {
+    "@0xintuition/graphql": "^x.x.x" // Use the version from package.json
+  }
+}
+```
+
+5. Install the updated package:
+
+```bash
+pnpm install
+```
+
+#### Notes
+
+- The local registry persists packages in `tmp/local-registry/storage`
+- Clear storage by stopping and restarting the registry
+- First-time publishing requires creating a user (any username/password works)
+- The registry runs on port 4873 by default
+- The build process automatically runs codegen before building
+
 ## Usage
 
 ### Client Setup

--- a/packages/graphql/codegen.ts
+++ b/packages/graphql/codegen.ts
@@ -4,7 +4,10 @@ import type { Types } from '@graphql-codegen/plugin-helpers'
 const commonGenerateOptions: Types.ConfiguredOutput = {
   config: {
     reactQueryVersion: 5,
-    fetcher: '../client#fetcher',
+    fetcher: {
+      func: '../client#fetcher',
+      isReactHook: false,
+    },
     exposeDocument: true,
     exposeFetcher: true,
     exposeQueryKeys: true,
@@ -50,7 +53,7 @@ const config: CodegenConfig = {
       },
     },
   },
-  watch: true,
+  watch: process.env.NODE_ENV === 'development',
 }
 
 export default config

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,28 +1,44 @@
 {
   "name": "@0xintuition/graphql",
-  "version": "0.0.1",
   "description": "GraphQL",
-  "main": "src/index.js",
+  "version": "0.3.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
   },
-  "types": "src/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "dev": "dotenv graphql-codegen --config codegen.ts --watch",
-    "codegen": "dotenv graphql-codegen --config codegen.ts",
+    "prebuild": "pnpm codegen:build",
+    "build": "tsup",
+    "dev": "concurrently \"pnpm codegen:watch\" \"tsup --watch\"",
+    "publish-dry": "pnpm build && pnpm publish --dry-run --no-git-checks --ignore-scripts",
+    "publish-next": "pnpm build && pnpm publish --tag next --no-git-checks --ignore-scripts",
+    "publish-latest": "pnpm build && pnpm publish --tag latest --no-git-checks --ignore-scripts",
+    "version:patch": "pnpm version patch --no-git-tag-version",
+    "version:minor": "pnpm version minor --no-git-tag-version",
+    "version:major": "pnpm version major --no-git-tag-version",
+    "version:beta": "pnpm version prerelease --preid beta --no-git-tag-version",
+    "codegen:build": "NODE_ENV=production graphql-codegen --config codegen.ts",
+    "codegen:watch": "NODE_ENV=development dotenv graphql-codegen --config codegen.ts",
     "test": "vitest",
     "lint:fix": "pnpm lint --fix"
   },
-  "files": [
-    "dist/**/*",
-    "src/**/*",
-    "README.md",
-    "LICENSE"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/0xIntuition/intuition-ts",
     "directory": "packages/graphql"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "@0xintuition/api": "workspace:^",
@@ -44,6 +60,8 @@
     "@graphql-codegen/typescript-react-query": "^6.1.0",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@parcel/watcher": "^2.4.1",
+    "concurrently": "^8.2.2",
+    "tsup": "^6.7.0",
     "typescript": "^5.4.5",
     "vite": "^5.2.11",
     "vitest": "^1.3.1"

--- a/packages/graphql/project.json
+++ b/packages/graphql/project.json
@@ -5,17 +5,6 @@
   "projectType": "library",
   "tags": [],
   "targets": {
-    "build": {
-      "executor": "@nx/js:tsc",
-      "outputs": ["{options.outputPath}"],
-      "options": {
-        "outputPath": "dist/packages/graphql",
-        "tsConfig": "packages/graphql/tsconfig.lib.json",
-        "packageJson": "packages/graphql/package.json",
-        "main": "packages/graphql/src/index.ts",
-        "assets": ["packages/graphql/*.md"]
-      }
-    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "options": {

--- a/packages/graphql/src/client.ts
+++ b/packages/graphql/src/client.ts
@@ -1,7 +1,20 @@
 import { GraphQLClient } from 'graphql-request'
 
+import { API_URL_DEV } from './constants'
+
 export interface ClientConfig {
   headers: HeadersInit
+  apiUrl?: string
+}
+
+const DEFAULT_API_URL = API_URL_DEV
+
+let globalConfig: { apiUrl?: string } = {
+  apiUrl: DEFAULT_API_URL,
+}
+
+export function configureClient(config: { apiUrl: string }) {
+  globalConfig = { ...globalConfig, ...config }
 }
 
 export function getClientConfig(token?: string): ClientConfig {
@@ -10,15 +23,18 @@ export function getClientConfig(token?: string): ClientConfig {
       ...(token && { authorization: `Bearer ${token}` }),
       'Content-Type': 'application/json',
     },
+    apiUrl: globalConfig.apiUrl,
   }
 }
 
-// add userId back in when we need to add user auth for mutations
 export function createServerClient({ token }: { token?: string }) {
-  return new GraphQLClient(
-    'https://api.i7n.dev/v1/graphql',
-    getClientConfig(token),
-  )
+  const config = getClientConfig(token)
+  if (!config.apiUrl) {
+    throw new Error(
+      'GraphQL API URL not configured. Call configureClient first.',
+    )
+  }
+  return new GraphQLClient(config.apiUrl, config)
 }
 
 export const fetchParams = () => {
@@ -35,7 +51,13 @@ export function fetcher<TData, TVariables>(
   options?: RequestInit['headers'],
 ) {
   return async () => {
-    const res = await fetch('https://api.i7n.dev/v1/graphql', {
+    if (!globalConfig.apiUrl) {
+      throw new Error(
+        'GraphQL API URL not configured. Call configureClient first.',
+      )
+    }
+
+    const res = await fetch(globalConfig.apiUrl, {
       method: 'POST',
       ...fetchParams(),
       ...options,

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -1,0 +1,2 @@
+export const API_URL_DEV = 'https://api.i7n.dev/v1/graphql'
+export const API_URL_PROD = 'https://api.i7n.app/v1/graphql'

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,2 +1,8 @@
 export * from './generated/index'
-export * from './client'
+export * from './constants'
+export {
+  configureClient,
+  fetcher,
+  createServerClient,
+  type ClientConfig,
+} from './client'

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -8,11 +8,4 @@
     "rootDir": "src",
     "outDir": "../../dist/packages/graphql"
   }
-  // "compilerOptions": {
-  //   "moduleResolution": "bundler",
-  //   "baseUrl": ".",
-  //   "paths": {
-  //     "@/*": ["src/*"]
-  //   }
-  // }
 }

--- a/packages/graphql/tsup.config.ts
+++ b/packages/graphql/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: ['react', 'graphql'],
+  treeshake: true,
+  noExternal: ['./src/generated/**'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,6 +1052,12 @@ importers:
       '@parcel/watcher':
         specifier: ^2.4.1
         version: 2.4.1
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
+      tsup:
+        specifier: ^6.7.0
+        version: 6.7.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.11))(@types/node@20.14.2)(typescript@5.4.5))(typescript@5.4.5)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -8153,6 +8159,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@8.2.2:
+    resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
+    engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
+
   confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
 
@@ -13666,6 +13677,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spawn-command@0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
 
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
@@ -25978,6 +25992,18 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@8.2.2:
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.1
+      spawn-command: 0.0.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   confbox@0.1.7: {}
 
   confusing-browser-globals@1.0.11: {}
@@ -33150,6 +33176,8 @@ snapshots:
       whatwg-url: 7.1.0
 
   space-separated-tokens@2.0.2: {}
+
+  spawn-command@0.0.2: {}
 
   spdx-correct@3.2.0:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,6 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
-    "declaration": true,
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [x] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Brings in crucial parts of the most recent PRs into `main` so that we can continue working on migrating to the new schema/architecture on the `feature/graphql-migration` branch
- This includes the logic in #969 -- we'll want to review that first so any changes can also be reflected in here. Including that logic will make working with the local API/schema more direct since we can configure the URL a bit easier.
- I'm reasonably sure that I got everything. We'll have to deal with this again when we merge this branch into `main` but now that the GraphQL package is published #969 should be the last PR until we merge this feature branch in. If we change approaches we can modify the feature branch accordingly

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
