### PR TITLE
ENG-5006 fix(data-populator): atom existence bugs and db optimizations

### DIFF
--- a/apps/data-populator/app/lib/services/attestor.ts
+++ b/apps/data-populator/app/lib/services/attestor.ts
@@ -345,7 +345,7 @@ export async function bulkEVMRead<T, P>(
           await new Promise((resolve) => setTimeout(resolve, delayBetweenReads))
         }
         const result = await evmReadFn(param)
-        console.log('Bulk EVM Read Result: ', result)
+        // console.log('Bulk EVM Read Result: ', result)
         return result
       }),
     )

--- a/apps/data-populator/app/lib/services/offchain-store.ts
+++ b/apps/data-populator/app/lib/services/offchain-store.ts
@@ -58,7 +58,7 @@ export async function getAtomIDs(uris: string[]): Promise<string[]> {
     }
   }
 
-  console.log('URIs to fetch from EVM:', urisToFetchFromEVM)
+  // console.log('URIs to fetch from EVM:', urisToFetchFromEVM)
 
   // Fetch missing IDs in bulk from EVM
   const fetchedEVMIDs = await bulkEVMRead(

--- a/apps/data-populator/app/lib/services/populate.ts
+++ b/apps/data-populator/app/lib/services/populate.ts
@@ -169,9 +169,9 @@ export async function checkAndFilterURIs(
   console.log('Updating requestHash again...')
   requestHash
     ? await pushUpdate(
-        requestHash,
-        `Checked ${URIs.length} URIs, found ${existingURIs.length} existing URIs and ${newURIs.length} new URIs`,
-      )
+      requestHash,
+      `Checked ${URIs.length} URIs, found ${existingURIs.length} existing URIs and ${newURIs.length} new URIs`,
+    )
     : null
   return { existingURIs, newURIs }
 }
@@ -701,9 +701,9 @@ export async function pinAllData(
   // Process duplicate atoms after unique atoms
   requestHash
     ? await pushUpdate(
-        requestHash,
-        'Pinning atom data with duplicate images...',
-      )
+      requestHash,
+      'Pinning atom data with duplicate images...',
+    )
     : null
   const duplicatePinnedData = await processAtomDataBatches(
     duplicateAtoms,
@@ -978,9 +978,9 @@ export async function processBatchAtoms(
   console.log('Predetermining number of chunks to process batch atoms...')
   requestHash
     ? await pushUpdate(
-        requestHash,
-        'Predetermining number of chunks to process batch atoms...',
-      )
+      requestHash,
+      'Predetermining number of chunks to process batch atoms...',
+    )
     : null
   let numChunks = 1
 
@@ -1017,9 +1017,9 @@ export async function processBatchAtoms(
     if (staticExecutionReverted) {
       requestHash
         ? await pushUpdate(
-            requestHash,
-            'static execution reverted with chunk size of 1',
-          )
+          requestHash,
+          'static execution reverted with chunk size of 1',
+        )
         : null
       throw new Error('static execution reverted with chunk size of 1')
     }
@@ -1034,9 +1034,9 @@ export async function processBatchAtoms(
     console.log('Number of batch atom chunks: ', numChunks)
     requestHash
       ? await pushUpdate(
-          requestHash,
-          `Number of batch atom chunks: ${numChunks}`,
-        )
+        requestHash,
+        `Number of batch atom chunks: ${numChunks}`,
+      )
       : null
     console.log(
       'Chunk lengths: ',
@@ -1044,9 +1044,9 @@ export async function processBatchAtoms(
     )
     requestHash
       ? await pushUpdate(
-          requestHash,
-          `Chunk lengths: ${chunks.map((chunk) => chunk.length)}`,
-        )
+        requestHash,
+        `Chunk lengths: ${chunks.map((chunk) => chunk.length)}`,
+      )
       : null
     for (const batch of chunks) {
       lastChunkForDebug = batch
@@ -1090,9 +1090,9 @@ export async function processBatchTriples(
     console.log('Predetermining number of chunks to process batch triples...')
     requestHash
       ? await pushUpdate(
-          requestHash,
-          'Predetermining number of chunks to process batch triples...',
-        )
+        requestHash,
+        'Predetermining number of chunks to process batch triples...',
+      )
       : null
     while (staticExecutionReverted && numChunks < triples.length) {
       try {
@@ -1128,9 +1128,9 @@ export async function processBatchTriples(
     if (staticExecutionReverted) {
       requestHash
         ? await pushUpdate(
-            requestHash,
-            'static execution reverted with chunk size of 1',
-          )
+          requestHash,
+          'static execution reverted with chunk size of 1',
+        )
         : null
       throw new Error('static execution reverted with chunk size of 1')
     }
@@ -1145,9 +1145,9 @@ export async function processBatchTriples(
     console.log('Number of batch triple chunks: ', numChunks)
     requestHash
       ? await pushUpdate(
-          requestHash,
-          `Number of batch triple chunks: ${numChunks}`,
-        )
+        requestHash,
+        `Number of batch triple chunks: ${numChunks}`,
+      )
       : null
     console.log(
       'Chunk lengths: ',
@@ -1155,9 +1155,9 @@ export async function processBatchTriples(
     )
     requestHash
       ? await pushUpdate(
-          requestHash,
-          `Chunk lengths: ${chunks.map((chunk) => chunk.length)}`,
-        )
+        requestHash,
+        `Chunk lengths: ${chunks.map((chunk) => chunk.length)}`,
+      )
       : null
     for (const batch of chunks) {
       lastChunkForDebug = batch
@@ -1177,9 +1177,9 @@ export async function processBatchTriples(
     console.error('Error processing batch triples...', lastChunkForDebug)
     requestHash
       ? await pushUpdate(
-          requestHash,
-          `Error processing batch triples: ${error}`,
-        )
+        requestHash,
+        `Error processing batch triples: ${error}`,
+      )
       : null
     return result
   }

--- a/apps/data-populator/app/routes/app+/index.tsx
+++ b/apps/data-populator/app/routes/app+/index.tsx
@@ -1055,6 +1055,7 @@ export default function CSVEditor() {
         const formData = new FormData()
         formData.append('action', 'checkAtomExists')
         formData.append('csvData', JSON.stringify(csvData))
+        formData.append('selectedType', selectedType)
         formData.append('index', (rowIndex - 1).toString())
 
         try {


### PR DESCRIPTION
There were:

Issues in how the database was remembering Atom IDs and their associated URIs

This was consistently failing and falling back on batch EVM reads

Issues in how an existing atom was being checked when its info was edited

The Type was not being provided, so edited atoms were checked as if their full metadata was just  { https://schema.org/ }

Issues in how the database was being polled or written with large batches of data (like a CSV full of atom data or their image src urls)

Batches were chunked into requests of 100, without accounting for the length of each item - causing header overflow

This took a couple hours to resolve and track down as I was testing very thoroughly and tracing all the internal steps.  But good thing we fixed this.  This will:

Enhance stability and performance of Data Populator when checking if atoms exist

Fix issues in Data Populator History Modal

Reduce excessive calls to Alchemy API (!!!)

This was detected by MK while trying to upload Berachain stuff.  After he published ~240 atoms they all showed up as green.  He came back later and loaded the same CSV to tag them, and only ~32 or so showed up as green (published).

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
