### PR TITLE
ENG-4898 feat(data-populator): Fix CSV header proofreading, update app header, fix toast, add title

### DIFF
--- a/apps/data-populator/app/components/header.tsx
+++ b/apps/data-populator/app/components/header.tsx
@@ -15,8 +15,228 @@ import PrivyLogoutButton from '@client/privy-logout-button'
 import { getTooltip, TooltipKey } from '@lib/utils/tooltips'
 import { Link } from '@remix-run/react'
 import { CURRENT_ENV } from 'app/consts'
+import { AnimatePresence, motion } from 'framer-motion'
 import { HelpCircle, History } from 'lucide-react'
 import { ClientOnly } from 'remix-utils/client-only'
+
+const CHARS = '!@#$%^&*(){}[]<>~`_-+=ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+const SHUFFLE_DURATION = 1000 // Total duration of shuffle animation
+const DISPLAY_DURATION = 5000 // How long to show the final word
+const FRAMES_PER_SHUFFLE = 15 // Number of random characters to show for each position
+
+const BETA_LABELS = [
+  '[BETA]',
+  '[EXPERIMENTAL]',
+  '[WIP]',
+  '[EARLY ACCESS]',
+  '[TOP SECRET]',
+  '[PROTOTYPE]',
+  '[PREVIEW]',
+  '[ALPHA]',
+  '[PRE-RELEASE]',
+  '[CONFIDENTIAL]',
+  '[CLASSIFIED]',
+  '[IN DEVELOPMENT]',
+  '[TESTING]',
+  '[UNDER CONSTRUCTION]',
+  '[COMING SOON]',
+  '[UNRELEASED]',
+  '[PRIVATE BUILD]',
+  '[UNSTABLE]',
+  '[BLEEDING EDGE]',
+  '[DRAFT]',
+  '[PROOF OF CONCEPT]',
+  '[LIMITED ACCESS]',
+  '[INVITE ONLY]',
+  '[SNEAK PEEK]',
+  '[DEVELOPMENT BUILD]',
+  '[RESTRICTED]',
+  '[INTERNAL USE]',
+  '[PILOT]',
+  '[SANDBOX]',
+  '[TRIAL VERSION]',
+  '[UNFINISHED]',
+  '[WORK IN PROGRESS]',
+  '[BETA TESTING]',
+  '[PRE-ALPHA]',
+  '[CLOSED BETA]',
+  '[UNDER REVIEW]',
+  '[PRELIMINARY]',
+  '[EVALUATION]',
+  '[BETA PHASE]',
+  '[DEVELOPMENT MODE]',
+  '[NOT FINAL]',
+  '[SUBJECT TO CHANGE]',
+  '[TESTING PHASE]',
+  '[PRIVATE PREVIEW]',
+  '[EARLY BIRD]',
+  '[INSIDER BUILD]',
+  '[FEATURE PREVIEW]',
+  '[TECHNICAL PREVIEW]',
+  '[DEVELOPMENT PREVIEW]',
+  '[ALPHA TESTING]',
+  '[BETA ACCESS]',
+  '[PROTOTYPE PHASE]',
+  '[INTERNAL TESTING]',
+  '[QUALITY ASSURANCE]',
+  '[DEBUG MODE]',
+  '[PRE-PRODUCTION]',
+  '[STAGING]',
+  '[VALIDATION]',
+  '[EARLY PROTOTYPE]',
+  '[CONCEPT TESTING]',
+  '[INTERNAL PREVIEW]',
+  '[CLOSED TESTING]',
+  '[DEVELOPMENT STAGE]',
+  '[FEATURE TESTING]',
+  '[INITIAL RELEASE]',
+  '[PRIVATE TESTING]',
+  '[RESTRICTED ACCESS]',
+  '[EARLY DEVELOPMENT]',
+  '[INTERNAL BETA]',
+  '[PREVIEW BUILD]',
+  '[TEST FLIGHT]',
+  '[CANARY BUILD]',
+  '[NIGHTLY BUILD]',
+  '[EDGE VERSION]',
+  '[DEVELOPER BUILD]',
+  '[UNSTABLE BUILD]',
+  '[EXPERIMENTAL BUILD]',
+  '[ALPHA CHANNEL]',
+  '[BETA CHANNEL]',
+  '[DEV CHANNEL]',
+  '[PREVIEW CHANNEL]',
+  '[INSIDER CHANNEL]',
+  '[EARLY PREVIEW]',
+  '[INTERNAL ALPHA]',
+  '[CLOSED ALPHA]',
+  '[PRIVATE ALPHA]',
+  '[DEVELOPMENT ALPHA]',
+  '[FEATURE INCOMPLETE]',
+  '[IN TESTING]',
+  '[PRE-BETA]',
+  '[DEVELOPMENT SNAPSHOT]',
+  '[MILESTONE BUILD]',
+  '[RELEASE CANDIDATE]',
+  '[TECH DEMO]',
+  '[INNOVATION LAB]',
+  '[RESEARCH BUILD]',
+  '[EXPLORATORY]',
+  '[ITERATION]',
+  '[PROTOTYPE BUILD]',
+  '[CONCEPT PHASE]',
+  '[DISCOVERY PHASE]',
+  '[INTERNAL RELEASE]',
+  '[VERIFICATION BUILD]',
+]
+
+const AnimatedBetaText = () => {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [displayText, setDisplayText] = useState(BETA_LABELS[0])
+  const [shuffling, setShuffling] = useState(false)
+  const [isDisplaying, setIsDisplaying] = useState(true)
+
+  useEffect(() => {
+    const timeouts: NodeJS.Timeout[] = []
+
+    const shuffleLetterAtPosition = (
+      finalText: string,
+      position: number,
+      onComplete: () => void,
+    ) => {
+      let frame = 0
+
+      const animate = () => {
+        if (frame >= FRAMES_PER_SHUFFLE) {
+          setDisplayText(
+            (prev) =>
+              prev.substring(0, position) +
+              finalText[position] +
+              prev.substring(position + 1),
+          )
+          onComplete()
+          return
+        }
+
+        setDisplayText(
+          (prev) =>
+            prev.substring(0, position) +
+            CHARS[Math.floor(Math.random() * CHARS.length)] +
+            prev.substring(position + 1),
+        )
+
+        frame++
+        const timeout = setTimeout(
+          animate,
+          SHUFFLE_DURATION / (FRAMES_PER_SHUFFLE * finalText.length),
+        )
+        timeouts.push(timeout)
+      }
+
+      animate()
+    }
+
+    const startNewCycle = () => {
+      if (!isDisplaying) {
+        setShuffling(true)
+        const nextIndex = (currentIndex + 1) % BETA_LABELS.length
+        const targetText = BETA_LABELS[nextIndex]
+
+        // Initialize with random characters of the same length
+        setDisplayText(Array(targetText.length).fill('_').join(''))
+
+        // Shuffle each position with slight delays
+        let completedPositions = 0
+
+        for (let i = 0; i < targetText.length; i++) {
+          const timeout = setTimeout(
+            () => {
+              shuffleLetterAtPosition(targetText, i, () => {
+                completedPositions++
+                if (completedPositions === targetText.length) {
+                  setShuffling(false)
+                  setCurrentIndex(nextIndex)
+                  setDisplayText(targetText)
+                  setIsDisplaying(true)
+                }
+              })
+            },
+            i * (SHUFFLE_DURATION / targetText.length) * 0.5,
+          )
+
+          timeouts.push(timeout)
+        }
+      }
+    }
+
+    // Handle display duration and cycle start
+    const displayTimeout = setTimeout(() => {
+      setIsDisplaying(false)
+      startNewCycle()
+    }, DISPLAY_DURATION)
+
+    timeouts.push(displayTimeout)
+
+    // Cleanup
+    return () => {
+      timeouts.forEach(clearTimeout)
+    }
+  }, [currentIndex, isDisplaying])
+
+  return (
+    <div className="relative font-mono min-w-[250px]">
+      <motion.div
+        key={displayText}
+        className={cn(
+          'transition-colors text-muted-foreground',
+          shuffling ? 'opacity-80' : 'opacity-100',
+        )}
+      >
+        {displayText}
+      </motion.div>
+    </div>
+  )
+}
 
 export function Header({ onOpenHistory }: { onOpenHistory: () => void }) {
   const [, setTheme] = useState<'light' | 'dark'>('light')
@@ -56,38 +276,46 @@ export function Header({ onOpenHistory }: { onOpenHistory: () => void }) {
               className="h-8"
             />
           </Link>
-          {tooltipsEnabled ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Text
-                  className={`px-2 py-1 rounded-lg text-sm tracking-widest font-medium ${
-                    CURRENT_ENV === 'production'
-                      ? 'text-accent bg-accent/15 border border-accent/20'
-                      : 'text-warning bg-warning/15 border border-warning/20'
-                  }`}
-                >
-                  {CURRENT_ENV === 'production' ? 'MAINNET' : 'TESTNET'}
-                </Text>
-              </TooltipTrigger>
-              <TooltipContent>
-                {getTooltip(
-                  CURRENT_ENV === 'production'
-                    ? TooltipKey.NETWORK_STATUS_MAINNET
-                    : TooltipKey.NETWORK_STATUS_TESTNET,
-                )}
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <Text
-              className={`px-2 py-1 rounded-lg text-sm tracking-widest font-medium ${
-                CURRENT_ENV === 'production'
-                  ? 'text-accent bg-accent/15 border border-accent/20'
-                  : 'text-warning bg-warning/15 border border-warning/20'
-              }`}
-            >
-              {CURRENT_ENV === 'production' ? 'MAINNET' : 'TESTNET'}
+          <div className="flex items-center gap-3 border-l border-primary/30 pl-4">
+            <Text className="text-xl font-semibold tracking-tight text-foreground/90">
+              Data Populator
             </Text>
-          )}
+            {tooltipsEnabled ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Text
+                    className={`px-2 py-1 rounded-lg text-sm tracking-widest font-medium ${
+                      CURRENT_ENV === 'production'
+                        ? 'text-accent bg-accent/15 border border-accent/20'
+                        : 'text-warning bg-warning/15 border border-warning/20'
+                    }`}
+                  >
+                    {CURRENT_ENV === 'production' ? 'MAINNET' : 'TESTNET'}
+                  </Text>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {getTooltip(
+                    CURRENT_ENV === 'production'
+                      ? TooltipKey.NETWORK_STATUS_MAINNET
+                      : TooltipKey.NETWORK_STATUS_TESTNET,
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Text
+                className={`px-2 py-1 rounded-lg text-sm tracking-widest font-medium ${
+                  CURRENT_ENV === 'production'
+                    ? 'text-accent bg-accent/15 border border-accent/20'
+                    : 'text-warning bg-warning/15 border border-warning/20'
+                }`}
+              >
+                {CURRENT_ENV === 'production' ? 'MAINNET' : 'TESTNET'}
+              </Text>
+            )}
+          </div>
+          <div className="flex items-center">
+            <AnimatedBetaText />
+          </div>
         </div>
         <nav className="flex items-center space-x-4">
           {/* Tooltip Toggle Button */}

--- a/apps/data-populator/app/root.tsx
+++ b/apps/data-populator/app/root.tsx
@@ -123,7 +123,7 @@ function App() {
 
   return (
     <Document nonce={nonce} theme={theme}>
-      <Toaster position="top-right" />
+      <Toaster position="top-right" closeButton={true} />
       <ClientOnly>
         {() => (
           <Providers privyAppId={env.PRIVY_APP_ID}>

--- a/apps/data-populator/app/routes/app+/index.tsx
+++ b/apps/data-populator/app/routes/app+/index.tsx
@@ -426,6 +426,7 @@ export default function CSVEditor() {
   >([])
   const [showProofreadModal, setShowProofreadModal] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingCSV, setIsLoadingCSV] = useState(false)
 
   const [formatChangeDialog, setFormatChangeDialog] = useState<{
     isOpen: boolean
@@ -735,6 +736,7 @@ export default function CSVEditor() {
 
   // Update processLoadedData to include CAIP10 proofing
   const processLoadedData = (rows: string[][], type: AtomDataTypeKey) => {
+    setIsLoadingCSV(true)
     // Batch our updates together
     const newRows = [...rows]
     const newSelectedRows = newRows.slice(1).map((_, index) => index)
@@ -1573,11 +1575,11 @@ export default function CSVEditor() {
 
   // Effect to handle row selection after data load
   useEffect(() => {
-    if (isLoading && csvData.length > 0) {
+    if (isLoadingCSV && csvData.length > 0) {
       setSelectedRows(csvData.slice(1).map((_, index) => index))
-      setIsLoading(false)
+      setIsLoadingCSV(false)
     }
-  }, [csvData, isLoading])
+  }, [csvData, isLoadingCSV])
 
   return (
     <>
@@ -2414,10 +2416,10 @@ export default function CSVEditor() {
       </Dialog>
 
       <ProgressModal
-        isOpen={isLoading || isTagLoading}
+        isOpen={isBatchLoading || isTagLoading}
         onClose={() => {
-          if (isLoading || isTagLoading) {
-            console.log('Progress modal closed') // Leaving this here because this gets triggered when the modal loses focus
+          if (isBatchLoading || isTagLoading) {
+            console.log('Progress modal closed')
           }
         }}
         step={isTagLoading ? tagStep : step}


### PR DESCRIPTION
Fixed these:
https://linear.app/0xintuition/issue/ENG-4892/[data-populator]-not-sure-if-tag-was-actually-created-not-sure-what-to
https://linear.app/0xintuition/issue/ENG-4890/[data-populator]-no-handling-of-additional-table-columns
https://linear.app/0xintuition/issue/ENG-4898/[data-populator]-add-a-beta-flag-so-that-people-understand-this-is
https://linear.app/0xintuition/issue/ENG-4895/[data-populator]-pre-select-all-of-the-uploaded-atoms-for-publishing
https://linear.app/0xintuition/issue/ENG-4894/[data-populator]-cant-close-toast-messages
https://linear.app/0xintuition/issue/ENG-4799/[data-populator]-notify-user-is-bunk-header-is-loaded-in-csv

Summary:

- Loading a CSV causes all the atom rows to be auto-selected
- Headers and columns are parsed and compared against expected default.  User has the option to clean these.  If header is incomplete after cleaning, they are notified.
- Added [BETA] tag to header (with nice animation)
- Made Toast messages closable by overriding the default settings we were loading from 1UI
- Fixed a visual flicker issue when loading the CSV file
- Added a "Data Populator" title!

Suggested QA (I tested all of this, of course, but more people should test if they have time):
- Load a CSV
- Make sure it detects any previously uploaded atoms
- Load a CSV with a bad header (we have a lot of these) and see if it's detected
- See if a CSV with extra columns gets fixed by the app
- Reject a signature and see if you can close the red toast
- Verify the [BETA] tag looks ok
- Verify the Data Populator title looks ok - everything in the header should be nicely vertically aligned now
- Verify you can create a tag
- Verify you can tag selected atoms after creating the tag
- You should not have to select the atoms manually anymore
- You should still be able to de-select a few atoms and have them not upload (until you select them of course)


## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
