### PR TITLE
ENG-4800 feat(graphql,portal): change pagination approach and migrate routes

### DIFF
--- a/apps/data-populator/app/types/pagination.ts
+++ b/apps/data-populator/app/types/pagination.ts
@@ -1,6 +1,7 @@
 export interface PaginationType {
-  currentPage: number
-  limit: number
   totalEntries: number
-  totalPages: number
+  limit: number
+  offset: number
+  onOffsetChange: (offset: number) => void
+  onLimitChange: (limit: number) => void
 }

--- a/apps/portal/app/components/list/active-positions-on-claims.tsx
+++ b/apps/portal/app/components/list/active-positions-on-claims.tsx
@@ -34,11 +34,13 @@ type Atom = GetAtomQuery['atom']
 export function ActivePositionsOnClaimsNew({
   positions,
   pagination,
+  paramPrefix,
   readOnly = false,
   positionDirection,
 }: {
   positions: Position[]
-  pagination: { aggregate?: { count: number } } | number
+  pagination: PaginationType
+  paramPrefix: string
   readOnly?: boolean
   positionDirection?: string
 }) {
@@ -72,20 +74,11 @@ export function ActivePositionsOnClaimsNew({
 
   logger('positionsMapped', { positionsMapped })
 
-  const paginationCount =
-    typeof pagination === 'number'
-      ? pagination
-      : pagination?.aggregate?.count ?? 0
-
   return (
     <List<SortColumn>
-      pagination={{
-        currentPage: 1,
-        limit: 10,
-        totalEntries: paginationCount,
-        totalPages: Math.ceil(paginationCount / 10),
-      }}
+      pagination={pagination}
       paginationLabel="positions"
+      paramPrefix={paramPrefix}
     >
       <ListHeader
         items={[

--- a/apps/portal/app/components/list/active-positions-on-identities.tsx
+++ b/apps/portal/app/components/list/active-positions-on-identities.tsx
@@ -5,7 +5,6 @@ import { GetPositionsQuery } from '@0xintuition/graphql'
 import { IdentityPositionRow } from '@components/identity/identity-position-row'
 import { ListHeader } from '@components/list/list-header'
 import { BLOCK_EXPLORER_URL } from '@consts/general'
-import logger from '@lib/utils/logger'
 import {
   formatBalance,
   getAtomDescription,

--- a/apps/portal/app/components/list/active-positions-on-identities.tsx
+++ b/apps/portal/app/components/list/active-positions-on-identities.tsx
@@ -26,10 +26,12 @@ type Position = NonNullable<GetPositionsQuery['positions']>[number]
 export function ActivePositionsOnIdentitiesNew({
   identities,
   pagination,
+  paramPrefix,
   readOnly = false,
 }: {
   identities: Position[]
-  pagination: { aggregate?: { count: number } } | number
+  pagination: PaginationType
+  paramPrefix: string
   readOnly?: boolean
 }) {
   const options: SortOption<SortColumn>[] = [
@@ -39,23 +41,12 @@ export function ActivePositionsOnIdentitiesNew({
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
 
-  const paginationCount =
-    typeof pagination === 'number'
-      ? pagination
-      : pagination?.aggregate?.count ?? 0
-
-  logger('identities in active positions component', identities)
   return (
     <List<SortColumn>
-      pagination={{
-        currentPage: 1,
-        limit: 10,
-        totalEntries: paginationCount,
-        totalPages: Math.ceil(paginationCount / 10),
-      }}
+      pagination={pagination}
       paginationLabel="positions"
       options={options}
-      paramPrefix="activeIdentities"
+      paramPrefix={paramPrefix}
     >
       <ListHeader
         items={[

--- a/apps/portal/app/components/list/activity.tsx
+++ b/apps/portal/app/components/list/activity.tsx
@@ -28,7 +28,6 @@ import { Events } from '@0xintuition/graphql'
 
 import RemixLink from '@components/remix-link'
 import { stakeModalAtom } from '@lib/state/store'
-import logger from '@lib/utils/logger'
 import {
   formatBalance,
   getAtomDescription,
@@ -79,7 +78,6 @@ export function ActivityListNew({
       `redeemed ${formatBalance(value, 18)} ETH from a claim`,
   }
 
-  logger('activities in activity list', activities)
   return (
     <List<SortColumn>
       pagination={pagination}
@@ -132,12 +130,6 @@ function ActivityItemNew({
       : eventMessage.toString()
     : ''
 
-  logger('activity', activity)
-  logger(
-    'user shares on triple',
-    activity?.triple?.vault?.positions?.[0]?.shares ?? '0',
-  )
-
   const setStakeModalActive = useSetAtom(stakeModalAtom)
 
   // Basic required fields with fallbacks
@@ -147,7 +139,7 @@ function ActivityItemNew({
 
   // Get creator from either atom or triple
   const creator = activity.atom?.creator || activity.triple?.creator
-  logger('creator', creator)
+
   const creatorAddress =
     activity?.atom?.creator?.id || activity?.triple?.creator?.id || '0x'
   const atomId = activity.atom?.id || ''
@@ -155,8 +147,6 @@ function ActivityItemNew({
   function formatTransactionHash(txHash: string): string {
     return `0x${txHash.replace('\\x', '')}`
   }
-
-  logger('format balance test', formatBalance('3726450001000000', 18))
 
   return (
     <div

--- a/apps/portal/app/components/list/claims.tsx
+++ b/apps/portal/app/components/list/claims.tsx
@@ -30,7 +30,11 @@ import {
   getClaimUrl,
 } from '@lib/utils/misc'
 import { Link } from '@remix-run/react'
-import { PaginationType } from 'app/types'
+import {
+  mapPaginationInput,
+  PaginationInput,
+  PaginationType,
+} from 'app/types/pagination'
 import { useSetAtom } from 'jotai'
 
 import { SortOption } from '../sort-select'
@@ -45,8 +49,8 @@ type Triple = NonNullable<
 // TODO: (ENG-4830) Add ReadOnly support back in and update our util functions that use it
 interface ClaimsListNewProps {
   claims: Triple[]
-  pagination: { aggregate?: { count: number } } | number
-  paramPrefix?: string
+  pagination: PaginationInput
+  paramPrefix: string
   enableHeader?: boolean
   enableSearch?: boolean
   enableSort?: boolean
@@ -64,11 +68,6 @@ export function ClaimsListNew({
 }: ClaimsListNewProps) {
   const setStakeModalActive = useSetAtom(stakeModalAtom)
 
-  const paginationCount =
-    typeof pagination === 'number'
-      ? pagination
-      : pagination?.aggregate?.count ?? 0
-
   const options: SortOption<ClaimSortColumn>[] = [
     { value: 'Total ETH', sortBy: 'AssetsSum' },
     { value: 'ETH For', sortBy: 'ForAssetsSum' },
@@ -82,12 +81,7 @@ export function ClaimsListNew({
 
   return (
     <List<ClaimSortColumn>
-      pagination={{
-        currentPage: 1,
-        limit: 10,
-        totalEntries: paginationCount,
-        totalPages: Math.ceil(paginationCount / 10),
-      }}
+      pagination={mapPaginationInput(pagination)}
       paginationLabel="claims"
       options={options}
       paramPrefix={paramPrefix}

--- a/apps/portal/app/components/list/claims.tsx
+++ b/apps/portal/app/components/list/claims.tsx
@@ -49,7 +49,7 @@ type Triple = NonNullable<
 // TODO: (ENG-4830) Add ReadOnly support back in and update our util functions that use it
 interface ClaimsListNewProps {
   claims: Triple[]
-  pagination: PaginationInput
+  pagination: PaginationType
   paramPrefix: string
   enableHeader?: boolean
   enableSearch?: boolean
@@ -81,7 +81,7 @@ export function ClaimsListNew({
 
   return (
     <List<ClaimSortColumn>
-      pagination={mapPaginationInput(pagination)}
+      pagination={pagination}
       paginationLabel="claims"
       options={options}
       paramPrefix={paramPrefix}

--- a/apps/portal/app/components/list/claims.tsx
+++ b/apps/portal/app/components/list/claims.tsx
@@ -30,11 +30,7 @@ import {
   getClaimUrl,
 } from '@lib/utils/misc'
 import { Link } from '@remix-run/react'
-import {
-  mapPaginationInput,
-  PaginationInput,
-  PaginationType,
-} from 'app/types/pagination'
+import { PaginationType } from 'app/types/pagination'
 import { useSetAtom } from 'jotai'
 
 import { SortOption } from '../sort-select'

--- a/apps/portal/app/components/list/identities.tsx
+++ b/apps/portal/app/components/list/identities.tsx
@@ -34,8 +34,8 @@ export function IdentitiesListNew({
 }: {
   variant?: 'explore' | 'positions'
   identities: Atom[]
-  pagination: { aggregate?: { count: number } } | number
-  paramPrefix?: string
+  pagination: PaginationType
+  paramPrefix: string
   enableHeader?: boolean
   enableSearch?: boolean
   enableSort?: boolean
@@ -52,19 +52,9 @@ export function IdentitiesListNew({
 
   logger('identities', identities)
 
-  const paginationCount =
-    typeof pagination === 'number'
-      ? pagination
-      : pagination?.aggregate?.count ?? 0
-
   return (
     <List<SortColumn>
-      pagination={{
-        currentPage: 1,
-        limit: 10,
-        totalEntries: paginationCount,
-        totalPages: Math.ceil(paginationCount / 10),
-      }}
+      pagination={pagination}
       paginationLabel="identities"
       options={options}
       paramPrefix={paramPrefix}

--- a/apps/portal/app/components/list/list.tsx
+++ b/apps/portal/app/components/list/list.tsx
@@ -10,7 +10,6 @@ import {
 import { Search } from '@components/search'
 import { Sort } from '@components/sort'
 import { SortOption } from '@components/sort-select'
-import { useOffsetPagination } from '@lib/hooks/useOffsetPagination'
 import { useSearchAndSortParamsHandler } from '@lib/hooks/useSearchAndSortParams'
 import {
   globalCreateClaimModalAtom,
@@ -42,7 +41,6 @@ export function List<T extends SortColumnType>({
 }) {
   const { handleSortChange, handleSearchChange } =
     useSearchAndSortParamsHandler<T>(paramPrefix)
-  const { onPageChange, onLimitChange } = useOffsetPagination(paramPrefix)
 
   const listContainerRef = useRef<HTMLDivElement>(null)
 
@@ -88,12 +86,11 @@ export function List<T extends SortColumnType>({
       )}
       {pagination && (
         <PaginationComponent
-          totalEntries={pagination.totalEntries ?? 0}
-          currentPage={pagination.currentPage ?? 0}
-          totalPages={pagination.totalPages ?? 0}
-          limit={pagination.limit ?? 0}
-          onPageChange={onPageChange}
-          onLimitChange={onLimitChange}
+          totalEntries={pagination.totalEntries}
+          offset={pagination.offset}
+          limit={pagination.limit}
+          onOffsetChange={pagination.onOffsetChange}
+          onLimitChange={pagination.onLimitChange}
           label={paginationLabel}
           listContainerRef={listContainerRef}
         />

--- a/apps/portal/app/components/list/list.tsx
+++ b/apps/portal/app/components/list/list.tsx
@@ -10,6 +10,7 @@ import {
 import { Search } from '@components/search'
 import { Sort } from '@components/sort'
 import { SortOption } from '@components/sort-select'
+import { useOffsetPagination } from '@lib/hooks/useOffsetPagination'
 import { useSearchAndSortParamsHandler } from '@lib/hooks/useSearchAndSortParams'
 import {
   globalCreateClaimModalAtom,
@@ -39,8 +40,9 @@ export function List<T extends SortColumnType>({
   enableSearch?: boolean
   enableSort?: boolean
 }) {
-  const { handleSortChange, handleSearchChange, onPageChange, onLimitChange } =
+  const { handleSortChange, handleSearchChange } =
     useSearchAndSortParamsHandler<T>(paramPrefix)
+  const { onPageChange, onLimitChange } = useOffsetPagination(paramPrefix)
 
   const listContainerRef = useRef<HTMLDivElement>(null)
 
@@ -90,9 +92,7 @@ export function List<T extends SortColumnType>({
           currentPage={pagination.currentPage ?? 0}
           totalPages={pagination.totalPages ?? 0}
           limit={pagination.limit ?? 0}
-          onPageChange={(newOffset) => {
-            onPageChange(newOffset)
-          }}
+          onPageChange={onPageChange}
           onLimitChange={onLimitChange}
           label={paginationLabel}
           listContainerRef={listContainerRef}

--- a/apps/portal/app/components/list/positions-on-claim.tsx
+++ b/apps/portal/app/components/list/positions-on-claim.tsx
@@ -4,7 +4,6 @@ import { GetPositionsQuery } from '@0xintuition/graphql'
 
 import { ClaimPositionRow } from '@components/claim/claim-position-row'
 import { ListHeader } from '@components/list/list-header'
-import logger from '@lib/utils/logger'
 import { formatBalance, getProfileUrl } from '@lib/utils/misc'
 import { BLOCK_EXPLORER_URL } from 'app/consts'
 import { PaginationType } from 'app/types/pagination'

--- a/apps/portal/app/components/list/positions-on-claim.tsx
+++ b/apps/portal/app/components/list/positions-on-claim.tsx
@@ -18,12 +18,13 @@ type Position = NonNullable<GetPositionsQuery['positions']>[number]
 export function PositionsOnClaimNew({
   vaultPositions,
   counterVaultPositions,
+  pagination,
   readOnly = false,
   positionDirection,
 }: {
   vaultPositions: Position[]
   counterVaultPositions: Position[]
-  pagination: { aggregate?: { count: number } } | number
+  pagination: PaginationType
   readOnly?: boolean
   positionDirection?: string
 }) {
@@ -32,25 +33,6 @@ export function PositionsOnClaimNew({
     { value: 'Updated At', sortBy: PositionSortColumn.UPDATED_AT },
     { value: 'Created At', sortBy: PositionSortColumn.CREATED_AT },
   ]
-
-  logger('positions in PositionsOnClaim', {
-    vaultPositions,
-    counterVaultPositions,
-  })
-
-  // Leaving in case we need this for how we approach pagination
-  // const paginationCount =
-  //   positionDirection === 'for'
-  //     ? typeof pagination === 'number'
-  //       ? pagination
-  //       : pagination?.aggregate?.count ?? 0
-  //     : positionDirection === 'against'
-  //       ? typeof pagination === 'number'
-  //         ? pagination
-  //         : pagination?.aggregate?.count ?? 0
-  //       : typeof pagination === 'number'
-  //         ? pagination
-  //         : pagination?.aggregate?.count ?? 0
 
   // Combining and transforming positions -- we can see if there is a better/different way to do this, but the issue is previously these were combined and now they're split so we need to recombine for the tabs UI
   const allPositions = [
@@ -71,12 +53,7 @@ export function PositionsOnClaimNew({
 
   return (
     <List<PositionSortColumn>
-      pagination={{
-        currentPage: 1,
-        limit: 10,
-        totalEntries: allPositions.length,
-        totalPages: Math.ceil(allPositions.length / 10),
-      }}
+      pagination={pagination}
       paginationLabel="positions"
       options={options}
       paramPrefix="positions"

--- a/apps/portal/app/components/list/positions-on-identity.tsx
+++ b/apps/portal/app/components/list/positions-on-identity.tsx
@@ -6,7 +6,11 @@ import { IdentityPositionRow } from '@components/identity/identity-position-row'
 import { ListHeader } from '@components/list/list-header'
 import { formatBalance, getProfileUrl } from '@lib/utils/misc'
 import { BLOCK_EXPLORER_URL } from 'app/consts'
-import { PaginationType } from 'app/types'
+import {
+  mapPaginationInput,
+  PaginationInput,
+  PaginationType,
+} from 'app/types/pagination'
 import { formatUnits } from 'viem'
 
 import { SortOption } from '../sort-select'
@@ -17,10 +21,12 @@ type Position = NonNullable<GetPositionsQuery['positions']>[number]
 export function PositionsOnIdentityNew({
   positions,
   pagination,
+  paramPrefix,
   readOnly = false,
 }: {
   positions: Position[]
-  pagination: { aggregate?: { count: number } } | number
+  pagination: PaginationInput
+  paramPrefix: string
   readOnly?: boolean
 }) {
   const options: SortOption<PositionSortColumn>[] = [
@@ -29,22 +35,12 @@ export function PositionsOnIdentityNew({
     { value: 'Created At', sortBy: 'CreatedAt' },
   ]
 
-  const paginationCount =
-    typeof pagination === 'number'
-      ? pagination
-      : pagination?.aggregate?.count ?? 0
-
   return (
     <List<PositionSortColumn>
-      pagination={{
-        currentPage: 1,
-        limit: 10,
-        totalEntries: paginationCount,
-        totalPages: Math.ceil(paginationCount / 10),
-      }}
+      pagination={mapPaginationInput(pagination)}
       paginationLabel="positions"
       options={options}
-      paramPrefix="positions"
+      paramPrefix={paramPrefix}
     >
       <ListHeader
         items={[

--- a/apps/portal/app/components/pagination-component.tsx
+++ b/apps/portal/app/components/pagination-component.tsx
@@ -33,19 +33,18 @@ export function PaginationComponent({
 
   // Get current values from URL
   const limit = parseInt(searchParams.get('limit') || String(defaultLimit))
-  const offset = parseInt(searchParams.get('offset') || '0')
+  const page = Math.max(1, parseInt(searchParams.get('page') || '1'))
 
-  // Calculate current page and total pages for display
-  const currentPage = Math.floor(offset / limit) + 1
+  // Calculate total pages for display
   const totalPages = Math.ceil(totalEntries / limit)
 
   // Track previous page for scroll behavior
-  const prevPageRef = useRef(currentPage)
+  const prevPageRef = useRef(page)
 
   useEffect(() => {
     if (
       hasUserInteracted &&
-      prevPageRef.current !== currentPage &&
+      prevPageRef.current !== page &&
       listContainerRef?.current
     ) {
       listContainerRef.current.scrollIntoView({
@@ -53,18 +52,18 @@ export function PaginationComponent({
         block: 'start',
       })
     }
-    prevPageRef.current = currentPage
-  }, [listContainerRef, currentPage, hasUserInteracted])
+    prevPageRef.current = page
+  }, [listContainerRef, page, hasUserInteracted])
 
   // Navigation handlers
   const handlePrevious = () => {
     setHasUserInteracted(true)
     const params = new URLSearchParams(searchParams)
-    const newOffset = Math.max(0, offset - limit)
-    if (newOffset === 0) {
-      params.delete('offset')
+    const newPage = Math.max(1, page - 1)
+    if (newPage === 1) {
+      params.delete('page')
     } else {
-      params.set('offset', String(newOffset))
+      params.set('page', String(newPage))
     }
     setSearchParams(params, { preventScrollReset: true })
   }
@@ -72,22 +71,21 @@ export function PaginationComponent({
   const handleNext = () => {
     setHasUserInteracted(true)
     const params = new URLSearchParams(searchParams)
-    params.set('offset', String(offset + limit))
+    params.set('page', String(page + 1))
     setSearchParams(params, { preventScrollReset: true })
   }
 
   const handleFirst = () => {
     setHasUserInteracted(true)
     const params = new URLSearchParams(searchParams)
-    params.delete('offset')
+    params.delete('page')
     setSearchParams(params, { preventScrollReset: true })
   }
 
   const handleLast = () => {
     setHasUserInteracted(true)
     const params = new URLSearchParams(searchParams)
-    const lastPageOffset = (totalPages - 1) * limit
-    params.set('offset', String(lastPageOffset))
+    params.set('page', String(totalPages))
     setSearchParams(params, { preventScrollReset: true })
   }
 
@@ -95,10 +93,8 @@ export function PaginationComponent({
     setHasUserInteracted(true)
     const params = new URLSearchParams(searchParams)
     params.set('limit', newLimit)
-    // If we're on the first page (offset = 0), don't include offset
-    if (offset === 0) {
-      params.delete('offset')
-    }
+    // Reset to first page when changing limit
+    params.delete('page')
     setSearchParams(params, { preventScrollReset: true })
   }
 
@@ -111,33 +107,27 @@ export function PaginationComponent({
           onValueChange={handleLimitChange}
         />
         <div className="flex items-center w-fit">
-          <PaginationPageCounter
-            currentPage={currentPage}
-            totalPages={totalPages}
-          />
+          <PaginationPageCounter currentPage={page} totalPages={totalPages} />
           <PaginationContent>
             <PaginationItem>
-              <PaginationFirst
-                onClick={handleFirst}
-                disabled={currentPage === 1}
-              />
+              <PaginationFirst onClick={handleFirst} disabled={page === 1} />
             </PaginationItem>
             <PaginationItem>
               <PaginationPrevious
                 onClick={handlePrevious}
-                disabled={currentPage === 1}
+                disabled={page === 1}
               />
             </PaginationItem>
             <PaginationItem>
               <PaginationNext
                 onClick={handleNext}
-                disabled={currentPage === totalPages}
+                disabled={page === totalPages}
               />
             </PaginationItem>
             <PaginationItem>
               <PaginationLast
                 onClick={handleLast}
-                disabled={currentPage === totalPages}
+                disabled={page === totalPages}
               />
             </PaginationItem>
           </PaginationContent>

--- a/apps/portal/app/components/pagination-component.tsx
+++ b/apps/portal/app/components/pagination-component.tsx
@@ -13,38 +13,38 @@ import {
   PaginationSummary,
 } from '@0xintuition/1ui'
 
-import { useSearchParams } from '@remix-run/react'
+import logger from '@lib/utils/logger'
 
-interface PaginationComponentProps {
+export interface PaginationComponentProps {
   totalEntries: number
-  defaultLimit?: number
-  label: string
+  offset: number
+  limit: number
+  onOffsetChange: (offset: number) => void
+  onLimitChange: (limit: number) => void
+  label?: string
   listContainerRef?: React.RefObject<HTMLDivElement>
 }
 
 export function PaginationComponent({
   totalEntries,
-  defaultLimit = 10,
+  offset,
+  limit,
+  onOffsetChange,
+  onLimitChange,
   label,
   listContainerRef,
 }: PaginationComponentProps) {
-  const [searchParams, setSearchParams] = useSearchParams()
   const [hasUserInteracted, setHasUserInteracted] = useState(false)
+  const prevOffsetRef = useRef(offset)
 
-  // Get current values from URL
-  const limit = parseInt(searchParams.get('limit') || String(defaultLimit))
-  const page = Math.max(1, parseInt(searchParams.get('page') || '1'))
-
-  // Calculate total pages for display
+  // Calculate current page and total pages for display
+  const currentPage = Math.floor(offset / limit) + 1
   const totalPages = Math.ceil(totalEntries / limit)
-
-  // Track previous page for scroll behavior
-  const prevPageRef = useRef(page)
 
   useEffect(() => {
     if (
       hasUserInteracted &&
-      prevPageRef.current !== page &&
+      prevOffsetRef.current !== offset &&
       listContainerRef?.current
     ) {
       listContainerRef.current.scrollIntoView({
@@ -52,82 +52,77 @@ export function PaginationComponent({
         block: 'start',
       })
     }
-    prevPageRef.current = page
-  }, [listContainerRef, page, hasUserInteracted])
+    prevOffsetRef.current = offset
+  }, [listContainerRef, offset, hasUserInteracted])
 
   // Navigation handlers
   const handlePrevious = () => {
     setHasUserInteracted(true)
-    const params = new URLSearchParams(searchParams)
-    const newPage = Math.max(1, page - 1)
-    if (newPage === 1) {
-      params.delete('page')
-    } else {
-      params.set('page', String(newPage))
-    }
-    setSearchParams(params, { preventScrollReset: true })
+    onOffsetChange(Math.max(0, offset - limit))
   }
 
   const handleNext = () => {
     setHasUserInteracted(true)
-    const params = new URLSearchParams(searchParams)
-    params.set('page', String(page + 1))
-    setSearchParams(params, { preventScrollReset: true })
+    onOffsetChange(offset + limit)
   }
 
   const handleFirst = () => {
     setHasUserInteracted(true)
-    const params = new URLSearchParams(searchParams)
-    params.delete('page')
-    setSearchParams(params, { preventScrollReset: true })
+    onOffsetChange(0)
   }
 
   const handleLast = () => {
     setHasUserInteracted(true)
-    const params = new URLSearchParams(searchParams)
-    params.set('page', String(totalPages))
-    setSearchParams(params, { preventScrollReset: true })
+    onOffsetChange((totalPages - 1) * limit)
   }
 
   const handleLimitChange = (newLimit: string) => {
     setHasUserInteracted(true)
-    const params = new URLSearchParams(searchParams)
-    params.set('limit', newLimit)
-    // Reset to first page when changing limit
-    params.delete('page')
-    setSearchParams(params, { preventScrollReset: true })
+    logger(
+      'PaginationComponent: handleLimitChange called with newLimit:',
+      newLimit,
+    )
+    const parsedLimit = parseInt(newLimit, 10)
+    if (isNaN(parsedLimit)) {
+      logger('PaginationComponent: Invalid limit value:', newLimit)
+      return
+    }
+    onLimitChange(parsedLimit)
   }
 
   return (
     <Pagination className="flex w-full justify-between max-sm:flex-col max-sm:items-center max-sm:gap-3">
-      <PaginationSummary totalEntries={totalEntries} label={label} />
+      <PaginationSummary totalEntries={totalEntries} label={label || ''} />
       <div className="flex max-sm:flex-col max-sm:items-center max-sm:gap-3">
         <PaginationRowSelection
           value={limit.toString()}
           onValueChange={handleLimitChange}
         />
         <div className="flex items-center w-fit">
-          <PaginationPageCounter currentPage={page} totalPages={totalPages} />
+          <PaginationPageCounter
+            currentPage={currentPage}
+            totalPages={totalPages}
+          />
           <PaginationContent>
             <PaginationItem>
-              <PaginationFirst onClick={handleFirst} disabled={page === 1} />
+              <PaginationFirst onClick={handleFirst} disabled={offset === 0} />
             </PaginationItem>
             <PaginationItem>
               <PaginationPrevious
                 onClick={handlePrevious}
-                disabled={page === 1}
+                disabled={offset === 0}
               />
             </PaginationItem>
             <PaginationItem>
               <PaginationNext
                 onClick={handleNext}
-                disabled={page === totalPages}
+                disabled={offset + limit >= totalEntries}
               />
             </PaginationItem>
             <PaginationItem>
               <PaginationLast
                 onClick={handleLast}
-                disabled={page === totalPages}
+                disabled={offset + limit >= totalEntries}
               />
             </PaginationItem>
           </PaginationContent>

--- a/apps/portal/app/lib/hooks/useOffsetPagination.ts
+++ b/apps/portal/app/lib/hooks/useOffsetPagination.ts
@@ -1,0 +1,68 @@
+import { useSearchParams } from '@remix-run/react'
+
+export interface OffsetPaginationState {
+  limit: number
+  offset: number
+}
+
+export interface OffsetPaginationParams {
+  defaultLimit?: number
+  prefix?: string
+}
+
+export const useOffsetPagination = ({
+  defaultLimit = 10,
+  prefix,
+}: OffsetPaginationParams = {}) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const getParamName = (name: string) => {
+    if (prefix) {
+      return `${prefix}${name.charAt(0).toUpperCase()}${name.slice(1)}`
+    }
+    return name
+  }
+
+  // Get current pagination state from URL
+  const getPaginationState = (): OffsetPaginationState => {
+    const limit = parseInt(
+      searchParams.get(getParamName('limit')) || String(defaultLimit),
+    )
+    const offset = parseInt(searchParams.get(getParamName('offset')) || '0')
+    return { limit, offset }
+  }
+
+  // Current pagination state
+  const { limit, offset } = getPaginationState()
+
+  // Computed values for UI
+  const currentPage = Math.floor(offset / limit) + 1
+
+  const onPageChange = (newPage: number) => {
+    const newOffset = (newPage - 1) * limit
+    setSearchParams({
+      ...Object.fromEntries(searchParams),
+      [getParamName('offset')]: newOffset.toString(),
+    })
+  }
+
+  const onLimitChange = (newLimit: number) => {
+    setSearchParams({
+      ...Object.fromEntries(searchParams),
+      [getParamName('limit')]: newLimit.toString(),
+      [getParamName('offset')]: '0', // Reset to first page when changing limit
+    })
+  }
+
+  return {
+    // Current state
+    limit,
+    offset,
+    currentPage,
+    // Actions
+    onPageChange,
+    onLimitChange,
+    // Helper for React Query
+    getPaginationState,
+  }
+}

--- a/apps/portal/app/lib/hooks/useOffsetPagination.ts
+++ b/apps/portal/app/lib/hooks/useOffsetPagination.ts
@@ -6,15 +6,11 @@ import { useSearchParams } from '@remix-run/react'
 interface UseOffsetPaginationProps {
   defaultLimit?: number
   paramPrefix?: string
-  initialOffset?: number
-  initialLimit?: number
 }
 
 export function useOffsetPagination({
   defaultLimit = 10,
   paramPrefix,
-  initialOffset = 0,
-  initialLimit = 10,
 }: UseOffsetPaginationProps = {}) {
   const [searchParams, setSearchParams] = useSearchParams()
 

--- a/apps/portal/app/lib/hooks/useOffsetPagination.ts
+++ b/apps/portal/app/lib/hooks/useOffsetPagination.ts
@@ -1,123 +1,68 @@
+import { useMemo } from 'react'
+
+import logger from '@lib/utils/logger'
 import { useSearchParams } from '@remix-run/react'
 
-export interface OffsetPaginationState {
-  limit: number
-  offset: number
-}
-
-export interface OffsetPaginationParams {
+interface UseOffsetPaginationProps {
   defaultLimit?: number
-  prefix?: string
+  paramPrefix?: string
 }
 
-export const PAGINATION_KEYS = {
-  limit: 'limit',
-  page: 'page',
-} as const
-
-/**
- * Hook for handling offset-based pagination with React Query
- * Shows page numbers in URLs for better UX but uses offset/limit for queries
- */
-export const useOffsetPagination = ({
+export function useOffsetPagination({
   defaultLimit = 10,
-  prefix,
-}: OffsetPaginationParams = {}) => {
+  paramPrefix,
+}: UseOffsetPaginationProps = {}) {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const getParamName = (name: string) => {
-    if (prefix) {
-      return `${prefix}${name.charAt(0).toUpperCase()}${name.slice(1)}`
-    }
-    return name
-  }
+  return useMemo(() => {
+    // Add prefix to param names if provided
+    const offsetParam = paramPrefix ? `${paramPrefix}Offset` : 'offset'
+    const limitParam = paramPrefix ? `${paramPrefix}Limit` : 'limit'
 
-  // Get current pagination state from URL
-  const getPaginationState = (): OffsetPaginationState => {
     const limit = parseInt(
-      searchParams.get(getParamName(PAGINATION_KEYS.limit)) ||
-        String(defaultLimit),
+      searchParams.get(limitParam) || defaultLimit.toString(),
     )
-    // Get page from URL and convert to offset
-    const page = Math.max(
-      1,
-      parseInt(searchParams.get(getParamName(PAGINATION_KEYS.page)) || '1'),
-    )
-    const offset = (page - 1) * limit
+    const offset = parseInt(searchParams.get(offsetParam) || '0')
 
-    return { limit, offset }
-  }
+    const onOffsetChange = (newOffset: number) => {
+      logger('useOffsetPagination: onOffsetChange called with:', newOffset)
+      setSearchParams(
+        (prev) => {
+          const newParams = new URLSearchParams(prev)
+          if (newOffset === 0) {
+            newParams.delete(offsetParam)
+          } else {
+            newParams.set(offsetParam, newOffset.toString())
+          }
+          return newParams
+        },
+        { preventScrollReset: true },
+      )
+    }
 
-  // Current pagination state
-  const { limit, offset } = getPaginationState()
+    const onLimitChange = (newLimit: number) => {
+      logger('useOffsetPagination: onLimitChange called with:', newLimit)
+      setSearchParams(
+        (prev) => {
+          const newParams = new URLSearchParams(prev)
+          if (newLimit === defaultLimit) {
+            newParams.delete(limitParam)
+          } else {
+            newParams.set(limitParam, newLimit.toString())
+          }
+          // Reset offset when changing limit
+          newParams.delete(offsetParam)
+          return newParams
+        },
+        { preventScrollReset: true },
+      )
+    }
 
-  // Computed values for UI
-  const currentPage = Math.floor(offset / limit) + 1
-
-  const onPageChange = (newPage: number) => {
-    setSearchParams(
-      (prev) => {
-        const newParams = new URLSearchParams(prev)
-        if (newPage === 1) {
-          newParams.delete(getParamName(PAGINATION_KEYS.page))
-        } else {
-          newParams.set(getParamName(PAGINATION_KEYS.page), newPage.toString())
-        }
-        return newParams
-      },
-      { preventScrollReset: true },
-    )
-  }
-
-  const onLimitChange = (newLimit: number) => {
-    setSearchParams(
-      (prev) => {
-        const newParams = new URLSearchParams(prev)
-        if (newLimit === defaultLimit) {
-          newParams.delete(getParamName(PAGINATION_KEYS.limit))
-        } else {
-          newParams.set(
-            getParamName(PAGINATION_KEYS.limit),
-            newLimit.toString(),
-          )
-        }
-        // Reset to first page when changing limit
-        newParams.delete(getParamName(PAGINATION_KEYS.page))
-        return newParams
-      },
-      { preventScrollReset: true },
-    )
-  }
-
-  /**
-   * Creates a query key array for React Query
-   * @param baseKey - The base key for the query (e.g., ['events', 'global'])
-   * @param additionalParams - Additional parameters to include in the query key
-   */
-  const getQueryKey = (
-    baseKey: readonly unknown[],
-    additionalParams?: Record<string, unknown>,
-  ) => {
-    return [
-      ...baseKey,
-      {
-        limit,
-        offset,
-        ...additionalParams,
-      },
-    ]
-  }
-
-  return {
-    // Current state
-    limit,
-    offset,
-    currentPage,
-    // Actions
-    onPageChange,
-    onLimitChange,
-    // React Query helpers
-    getQueryKey,
-    getPaginationState,
-  }
+    return {
+      limit,
+      offset,
+      onOffsetChange,
+      onLimitChange,
+    }
+  }, [searchParams, setSearchParams, defaultLimit, paramPrefix])
 }

--- a/apps/portal/app/lib/hooks/useOffsetPagination.ts
+++ b/apps/portal/app/lib/hooks/useOffsetPagination.ts
@@ -6,11 +6,15 @@ import { useSearchParams } from '@remix-run/react'
 interface UseOffsetPaginationProps {
   defaultLimit?: number
   paramPrefix?: string
+  initialOffset?: number
+  initialLimit?: number
 }
 
 export function useOffsetPagination({
   defaultLimit = 10,
   paramPrefix,
+  initialOffset = 0,
+  initialLimit = 10,
 }: UseOffsetPaginationProps = {}) {
   const [searchParams, setSearchParams] = useSearchParams()
 

--- a/apps/portal/app/lib/hooks/useOffsetPagination.ts
+++ b/apps/portal/app/lib/hooks/useOffsetPagination.ts
@@ -6,11 +6,15 @@ import { useSearchParams } from '@remix-run/react'
 interface UseOffsetPaginationProps {
   defaultLimit?: number
   paramPrefix?: string
+  initialOffset?: number
+  initialLimit?: number
 }
 
 export function useOffsetPagination({
   defaultLimit = 10,
   paramPrefix,
+  initialOffset,
+  initialLimit,
 }: UseOffsetPaginationProps = {}) {
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -20,9 +24,13 @@ export function useOffsetPagination({
     const limitParam = paramPrefix ? `${paramPrefix}Limit` : 'limit'
 
     const limit = parseInt(
-      searchParams.get(limitParam) || defaultLimit.toString(),
+      searchParams.get(limitParam) ||
+        initialLimit?.toString() ||
+        defaultLimit.toString(),
     )
-    const offset = parseInt(searchParams.get(offsetParam) || '0')
+    const offset = parseInt(
+      searchParams.get(offsetParam) || initialOffset?.toString() || '0',
+    )
 
     const onOffsetChange = (newOffset: number) => {
       logger('useOffsetPagination: onOffsetChange called with:', newOffset)
@@ -64,5 +72,12 @@ export function useOffsetPagination({
       onOffsetChange,
       onLimitChange,
     }
-  }, [searchParams, setSearchParams, defaultLimit, paramPrefix])
+  }, [
+    searchParams,
+    setSearchParams,
+    defaultLimit,
+    paramPrefix,
+    initialOffset,
+    initialLimit,
+  ])
 }

--- a/apps/portal/app/routes/app+/activity+/global.tsx
+++ b/apps/portal/app/routes/app+/activity+/global.tsx
@@ -67,7 +67,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function GlobalActivityFeed() {
   const { initialParams } = useLoaderData<typeof loader>()
-  const { limit, offset, currentPage } = useOffsetPagination({
+  const { limit, offset, onOffsetChange, onLimitChange } = useOffsetPagination({
     defaultLimit: 10,
   })
 
@@ -110,11 +110,7 @@ export default function GlobalActivityFeed() {
     },
   )
 
-  logger('Full events response:', eventsData)
-  logger('Addresses being passed to query:', initialParams.queryAddresses)
-
   const totalCount = eventsData?.total?.aggregate?.count ?? 0
-  logger('totalCount', totalCount)
 
   return (
     <>
@@ -140,10 +136,11 @@ export default function GlobalActivityFeed() {
           <ActivityListNew
             activities={eventsData.events as Events[]}
             pagination={{
-              currentPage,
+              offset,
               limit,
               totalEntries: totalCount,
-              totalPages: Math.ceil(totalCount / limit),
+              onOffsetChange,
+              onLimitChange,
             }}
           />
         ) : (

--- a/apps/portal/app/routes/app+/activity+/global.tsx
+++ b/apps/portal/app/routes/app+/activity+/global.tsx
@@ -97,7 +97,15 @@ export default function GlobalActivityFeed() {
         'get-events-global',
         { limit, offset, addresses: initialParams.queryAddresses },
       ],
-      // placeholderData: (previousData) => previousData,
+      placeholderData: (previousData) => {
+        if (previousData) {
+          return {
+            ...previousData,
+            events: previousData.events,
+            total: previousData.total,
+          }
+        }
+      },
       staleTime: 1000 * 60 * 5,
     },
   )

--- a/apps/portal/app/routes/app+/claim+/$id+/index.tsx
+++ b/apps/portal/app/routes/app+/claim+/$id+/index.tsx
@@ -24,7 +24,6 @@ import { PositionsOnClaimNew } from '@components/list/positions-on-claim'
 import RemixLink from '@components/remix-link'
 import { PaginatedListSkeleton, TabsSkeleton } from '@components/skeleton'
 import { useOffsetPagination } from '@lib/hooks/useOffsetPagination'
-import logger from '@lib/utils/logger'
 import {
   getAtomDescriptionGQL,
   getAtomImageGQL,

--- a/apps/portal/app/routes/app+/explore+/_index+/identities.tsx
+++ b/apps/portal/app/routes/app+/explore+/_index+/identities.tsx
@@ -23,53 +23,46 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const url = new URL(request.url)
   const searchParams = new URLSearchParams(url.search)
-  const { page, limit, sortBy, direction } = getStandardPageParams({
+  const { offset, limit, sortBy, direction } = getStandardPageParams({
     searchParams,
   })
   const displayName = searchParams.get('identity') || null
   const hasTag = searchParams.get('tagIds') || null
   const isUser = searchParams.get('isUser')
 
-  const identities = await fetchWrapper(request, {
-    method: IdentitiesService.searchIdentity,
-    args: {
-      page,
-      limit,
-      sortBy: sortBy as SortColumn,
-      direction,
-      displayName,
-      hasTag,
-      isUser: isUser === 'true' ? true : isUser === 'false' ? false : undefined,
-    },
+  const identities = await fetchWrapper(request, IdentitiesService, {
+    offset,
+    limit,
+    sortBy: sortBy as SortColumn,
+    direction,
+    displayName,
+    hasTag,
+    isUser: isUser === 'true' ? true : isUser === 'false' ? false : undefined,
   })
 
-  const totalPages = calculateTotalPages(identities?.total ?? 0, limit)
-
   return json({
-    identities: identities?.data as IdentityPresenter[],
+    identities: identities.data as IdentityPresenter[],
     sortBy,
     direction,
     pagination: {
-      currentPage: page,
+      totalEntries: identities.total ?? 0,
       limit,
-      totalEntries: identities?.total ?? 0,
-      totalPages,
+      offset,
+      onOffsetChange: () => {},
+      onLimitChange: () => {},
     },
   })
 }
 
 export default function ExploreIdentities() {
-  const { identities, pagination } = useLiveLoader<typeof loader>([
-    'create',
-    'attest',
-  ])
+  const { identities, pagination } = useLiveLoader<typeof loader>()
 
   return (
     <>
       <ExploreHeader
         title="Identities"
-        content="Decentralized identities for anything and everything - not just people."
-        icon={IconName.fingerprint}
+        description="Explore identities in the network"
+        icon={IconName.identity}
         bgImage={HEADER_BANNER_IDENTITIES}
       />
       <ExploreSearch variant="identity" />

--- a/apps/portal/app/routes/app+/identity+/$id+/index.tsx
+++ b/apps/portal/app/routes/app+/identity+/$id+/index.tsx
@@ -25,6 +25,7 @@ import DataAboutHeader from '@components/profile/data-about-header'
 import { RevalidateButton } from '@components/revalidate-button'
 import { DataHeaderSkeleton, PaginatedListSkeleton } from '@components/skeleton'
 import { useLiveLoader } from '@lib/hooks/useLiveLoader'
+import { useOffsetPagination } from '@lib/hooks/useOffsetPagination'
 import { detailCreateClaimModalAtom } from '@lib/state/store'
 import logger from '@lib/utils/logger'
 import { formatBalance, invariant } from '@lib/utils/misc'
@@ -169,6 +170,28 @@ export default function ProfileDataAbout() {
     detailCreateClaimModalAtom,
   )
 
+  const {
+    offset: triplesOffset,
+    limit: triplesLimit,
+    onOffsetChange: onTriplesOffsetChange,
+    onLimitChange: onTriplesLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'claims',
+    initialOffset: initialParams.triplesOffset,
+    initialLimit: initialParams.triplesLimit,
+  })
+
+  const {
+    offset: positionsOffset,
+    limit: positionsLimit,
+    onOffsetChange: onPositionsOffsetChange,
+    onLimitChange: onPositionsLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'positions',
+    initialOffset: initialParams.positionsOffset,
+    initialLimit: initialParams.positionsLimit,
+  })
+
   const { data: atomResult, isLoading: isLoadingAtom } = useGetAtomQuery(
     {
       id: initialParams.atomId,
@@ -294,10 +317,16 @@ export default function ProfileDataAbout() {
             ) : (
               <ClaimsAboutIdentity
                 claims={triplesResult?.triples ?? []}
-                pagination={triplesResult?.total?.aggregate?.count ?? {}}
+                pagination={{
+                  total: triplesResult?.total?.aggregate?.count ?? 0,
+                  limit: triplesLimit,
+                  offset: triplesOffset,
+                  onOffsetChange: onTriplesOffsetChange,
+                  onLimitChange: onTriplesLimitChange,
+                }}
                 paramPrefix="claims"
-                enableSearch={false} // TODO: (ENG-4481) Re-enable search and sort
-                enableSort={false} // TODO: (ENG-4481) Re-enable search and sort
+                enableSearch={false}
+                enableSort={false}
               />
             )}
           </Suspense>
@@ -348,7 +377,15 @@ export default function ProfileDataAbout() {
             ) : (
               <PositionsOnIdentityNew
                 positions={positionsResult?.positions ?? []}
-                pagination={positionsResult?.total?.aggregate?.count ?? {}}
+                pagination={{
+                  total: positionsResult?.total?.aggregate?.count ?? 0,
+                  limit: positionsLimit,
+                  offset: positionsOffset,
+                  onOffsetChange: onPositionsOffsetChange,
+                  onLimitChange: onPositionsLimitChange,
+                }}
+                paramPrefix="positions"
+                readOnly={false}
               />
             )}
           </Suspense>

--- a/apps/portal/app/routes/app+/profile+/$wallet+/data-created.tsx
+++ b/apps/portal/app/routes/app+/profile+/$wallet+/data-created.tsx
@@ -56,7 +56,7 @@ type Triple = NonNullable<
   NonNullable<GetTriplesWithPositionsQuery['triples']>[number]
 >
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await requireUser(request)
   invariant(user, 'User not found')
   invariant(user.wallet?.address, 'User wallet not found')

--- a/apps/portal/app/routes/app+/profile+/_index+/data-about.tsx
+++ b/apps/portal/app/routes/app+/profile+/_index+/data-about.tsx
@@ -28,6 +28,7 @@ import DataAboutHeader from '@components/profile/data-about-header'
 import { RevalidateButton } from '@components/revalidate-button'
 import { DataHeaderSkeleton, PaginatedListSkeleton } from '@components/skeleton'
 import { useLiveLoader } from '@lib/hooks/useLiveLoader'
+import { useOffsetPagination } from '@lib/hooks/useOffsetPagination'
 import { detailCreateClaimModalAtom } from '@lib/state/store'
 import logger from '@lib/utils/logger'
 import { formatBalance, invariant } from '@lib/utils/misc'
@@ -179,6 +180,28 @@ export default function ProfileDataAbout() {
     detailCreateClaimModalAtom,
   )
 
+  const {
+    offset: triplesOffset,
+    limit: triplesLimit,
+    onOffsetChange: onTriplesOffsetChange,
+    onLimitChange: onTriplesLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'claims',
+    initialOffset: initialParams.triplesOffset,
+    initialLimit: initialParams.triplesLimit,
+  })
+
+  const {
+    offset: positionsOffset,
+    limit: positionsLimit,
+    onOffsetChange: onPositionsOffsetChange,
+    onLimitChange: onPositionsLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'positions',
+    initialOffset: initialParams.positionsOffset,
+    initialLimit: initialParams.positionsLimit,
+  })
+
   logger('initialParams', initialParams)
   const { data: atomResult, isLoading: isLoadingAtom } = useGetAtomQuery(
     {
@@ -317,10 +340,16 @@ export default function ProfileDataAbout() {
             ) : (
               <ClaimsAboutIdentity
                 claims={triplesResult?.triples ?? []}
-                pagination={triplesResult?.total?.aggregate?.count ?? {}}
+                pagination={{
+                  total: triplesResult?.total?.aggregate?.count ?? 0,
+                  limit: triplesLimit,
+                  offset: triplesOffset,
+                  onOffsetChange: onTriplesOffsetChange,
+                  onLimitChange: onTriplesLimitChange,
+                }}
                 paramPrefix="claims"
-                enableSearch={false} // TODO: (ENG-4481) Re-enable search and sort
-                enableSort={false} // TODO: (ENG-4481) Re-enable search and sort
+                enableSearch={false}
+                enableSort={false}
               />
             )}
           </Suspense>
@@ -379,7 +408,15 @@ export default function ProfileDataAbout() {
             ) : (
               <PositionsOnIdentity
                 positions={positionsResult?.positions ?? []}
-                pagination={positionsResult?.total?.aggregate?.count ?? {}}
+                pagination={{
+                  total: positionsResult?.total?.aggregate?.count ?? 0,
+                  limit: positionsLimit,
+                  offset: positionsOffset,
+                  onOffsetChange: onPositionsOffsetChange,
+                  onLimitChange: onPositionsLimitChange,
+                }}
+                paramPrefix="positions"
+                readOnly={false}
               />
             )}
           </Suspense>

--- a/apps/portal/app/routes/readonly+/profile+/$wallet+/data-created.tsx
+++ b/apps/portal/app/routes/readonly+/profile+/$wallet+/data-created.tsx
@@ -44,12 +44,11 @@ import {
 } from '@components/skeleton'
 import { NO_WALLET_ERROR } from '@consts/errors'
 import logger from '@lib/utils/logger'
-import { formatBalance } from '@lib/utils/misc'
+import { formatBalance, invariant } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs } from '@remix-run/node'
 import { useLoaderData, useSearchParams } from '@remix-run/react'
 import { requireUserWallet } from '@server/auth'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
-import { invariant } from 'framer-motion'
 
 type Atom = NonNullable<GetAtomsQuery['atoms']>[number]
 type Triple = NonNullable<

--- a/apps/portal/app/routes/readonly+/profile+/$wallet+/data-created.tsx
+++ b/apps/portal/app/routes/readonly+/profile+/$wallet+/data-created.tsx
@@ -43,7 +43,7 @@ import {
   TabsSkeleton,
 } from '@components/skeleton'
 import { NO_WALLET_ERROR } from '@consts/errors'
-import logger from '@lib/utils/logger'
+import { useOffsetPagination } from '@lib/hooks/useOffsetPagination'
 import { formatBalance, invariant } from '@lib/utils/misc'
 import { json, LoaderFunctionArgs } from '@remix-run/node'
 import { useLoaderData, useSearchParams } from '@remix-run/react'
@@ -61,10 +61,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const queryAddress = wallet.toLowerCase()
 
   const url = new URL(request.url)
-  // const searchParams = new URLSearchParams(url.search)
+  const searchParams = new URLSearchParams(url.search)
   const queryClient = new QueryClient()
-
-  // TODO: once we fully fix sort/pagination, we'll want to update these to use triples instead of claims, and orderBy instead of sortBy in the actual query params
 
   const atomsWhere = {
     creator: {
@@ -93,7 +91,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
     },
   }
 
-  // this query is effectively the same as using a Claims query, but this query is more flexible
   const triplePositionsWhere = {
     accountId: {
       _eq: queryAddress,
@@ -104,40 +101,41 @@ export async function loader({ request }: LoaderFunctionArgs) {
       },
     },
   }
-  const atomsLimit = parseInt(url.searchParams.get('claimsLimit') || '10')
-  const atomsOffset = parseInt(url.searchParams.get('claimsOffset') || '0')
-  const atomsOrderBy = url.searchParams.get('claimsSortBy')
-  // const atomsOrderBy = [
-  //   {
-  //     vault: {
-  //       totalShares: 'desc',
-  //     },
-  //   },
-  // ] // we may want to use this as the fallback. will work on when we handle the sorts
-  const triplesLimit = parseInt(url.searchParams.get('claimsLimit') || '10')
-  const triplesOffset = parseInt(url.searchParams.get('claimsOffset') || '0')
-  const triplesOrderBy = url.searchParams.get('claimsSortBy')
+
+  const atomsLimit = parseInt(
+    searchParams.get('createdIdentities_limit') || '10',
+  )
+  const atomsOffset = parseInt(
+    searchParams.get('createdIdentities_offset') || '0',
+  )
+  const atomsOrderBy = searchParams.get('createdIdentities_sort_by')
+
+  const triplesLimit = parseInt(searchParams.get('createdClaims_limit') || '10')
+  const triplesOffset = parseInt(
+    searchParams.get('createdClaims_offset') || '0',
+  )
+  const triplesOrderBy = searchParams.get('createdClaims_sort_by')
 
   const atomPositionsLimit = parseInt(
-    url.searchParams.get('claimsLimit') || '10',
+    searchParams.get('atomPositions_limit') || '10',
   )
   const atomPositionsOffset = parseInt(
-    url.searchParams.get('claimsOffset') || '0',
+    searchParams.get('atomPositions_offset') || '0',
   )
-  const atomPositionsOrderBy = url.searchParams.get('claimsSortBy')
-    ? [{ [url.searchParams.get('claimsSortBy')!]: 'desc' }]
+  const atomPositionsOrderBy = searchParams.get('atomPositions_sort_by')
+    ? [{ [searchParams.get('atomPositions_sort_by')!]: 'desc' }]
     : undefined
 
   const triplePositionsLimit = parseInt(
-    url.searchParams.get('claimsLimit') || '10',
+    searchParams.get('triplePositions_limit') || '10',
   )
   const triplePositionsOffset = parseInt(
-    url.searchParams.get('claimsOffset') || '0',
+    searchParams.get('triplePositions_offset') || '0',
   )
-
-  const triplePositionsOrderBy = url.searchParams.get('claimsSortBy')
-    ? [{ [url.searchParams.get('claimsSortBy')!]: 'desc' }]
+  const triplePositionsOrderBy = searchParams.get('triplePositions_sort_by')
+    ? [{ [searchParams.get('triplePositions_sort_by')!]: 'desc' }]
     : undefined
+
   await queryClient.prefetchQuery({
     queryKey: [
       'get-atoms-with-positions',
@@ -185,6 +183,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         address: queryAddress,
       })(),
   })
+
   await queryClient.prefetchQuery({
     queryKey: ['get-atom-positions', { where: atomPositionsWhere }],
     queryFn: () =>
@@ -281,7 +280,49 @@ export default function ProfileDataCreated() {
     },
   )
 
-  logger('accountResult', accountResult)
+  const {
+    offset: createdIdentitiesOffset,
+    limit: createdIdentitiesLimit,
+    onOffsetChange: onCreatedIdentitiesOffsetChange,
+    onLimitChange: onCreatedIdentitiesLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'createdIdentities',
+    initialOffset: initialParams.atomsOffset,
+    initialLimit: initialParams.atomsLimit,
+  })
+
+  const {
+    offset: createdClaimsOffset,
+    limit: createdClaimsLimit,
+    onOffsetChange: onCreatedClaimsOffsetChange,
+    onLimitChange: onCreatedClaimsLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'createdClaims',
+    initialOffset: initialParams.triplesOffset,
+    initialLimit: initialParams.triplesLimit,
+  })
+
+  const {
+    offset: atomPositionsOffset,
+    limit: atomPositionsLimit,
+    onOffsetChange: onAtomPositionsOffsetChange,
+    onLimitChange: onAtomPositionsLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'atomPositions',
+    initialOffset: initialParams.atomPositionsOffset,
+    initialLimit: initialParams.atomPositionsLimit,
+  })
+
+  const {
+    offset: triplePositionsOffset,
+    limit: triplePositionsLimit,
+    onOffsetChange: onTriplePositionsOffsetChange,
+    onLimitChange: onTriplePositionsLimitChange,
+  } = useOffsetPagination({
+    paramPrefix: 'triplePositions',
+    initialOffset: initialParams.triplePositionsOffset,
+    initialLimit: initialParams.triplePositionsLimit,
+  })
 
   const {
     data: atomsCreatedResult,
@@ -291,8 +332,8 @@ export default function ProfileDataCreated() {
   } = useGetAtomsWithPositionsQuery(
     {
       where: initialParams.atomsWhere,
-      limit: initialParams.atomsLimit,
-      offset: initialParams.atomsOffset,
+      limit: createdIdentitiesLimit,
+      offset: createdIdentitiesOffset,
       orderBy: initialParams.atomsOrderBy
         ? [{ [initialParams.atomsOrderBy]: 'desc' }]
         : undefined,
@@ -303,16 +344,14 @@ export default function ProfileDataCreated() {
         'get-atoms-with-positions',
         {
           where: initialParams.atomsWhere,
-          limit: initialParams.atomsLimit,
-          offset: initialParams.atomsOffset,
+          limit: createdIdentitiesLimit,
+          offset: createdIdentitiesOffset,
           orderBy: initialParams.atomsOrderBy,
           address: initialParams.queryAddress,
         },
       ],
     },
   )
-
-  logger('Atoms Created Result (Client):', atomsCreatedResult)
 
   const {
     data: triplesCreatedResult,
@@ -322,8 +361,8 @@ export default function ProfileDataCreated() {
   } = useGetTriplesWithPositionsQuery(
     {
       where: initialParams.triplesWhere,
-      limit: initialParams.triplesLimit,
-      offset: initialParams.triplesOffset,
+      limit: createdClaimsLimit,
+      offset: createdClaimsOffset,
       orderBy: initialParams.triplesOrderBy
         ? [{ [initialParams.triplesOrderBy]: 'desc' }]
         : [
@@ -335,22 +374,19 @@ export default function ProfileDataCreated() {
           ],
       address: queryAddress,
     },
-
     {
       queryKey: [
         'get-triples-with-positions',
         {
           where: initialParams.triplesWhere,
-          limit: initialParams.triplesLimit,
-          offset: initialParams.triplesOffset,
+          limit: createdClaimsLimit,
+          offset: createdClaimsOffset,
           orderBy: initialParams.triplesOrderBy,
           address: queryAddress,
         },
       ],
     },
   )
-
-  logger('Triples Created Result (Client):', triplesCreatedResult)
 
   const {
     data: atomPositionsResult,
@@ -360,34 +396,22 @@ export default function ProfileDataCreated() {
   } = useGetPositionsQuery(
     {
       where: initialParams.atomPositionsWhere,
-      limit: initialParams.atomPositionsLimit,
-      offset: initialParams.atomPositionsOffset,
+      limit: atomPositionsLimit,
+      offset: atomPositionsOffset,
       orderBy: initialParams.atomPositionsOrderBy,
-      // orderBy: [
-      //   {
-      //     vault: {
-      //       totalShares: 'desc',
-      //     },
-      //   },
-      // ],
-      // orderBy: initialParams.atomsOrderBy
-      //   ? [{ [initialParams.atomsOrderBy]: 'desc' }]
-      //   : undefined,
     },
     {
       queryKey: [
         'get-atom-positions',
         {
           where: initialParams.atomPositionsWhere,
-          limit: initialParams.atomPositionsLimit,
-          offset: initialParams.atomPositionsOffset,
+          limit: atomPositionsLimit,
+          offset: atomPositionsOffset,
           orderBy: initialParams.atomPositionsOrderBy,
         },
       ],
     },
   )
-
-  logger('Atom Positions Result (Client):', atomPositionsResult)
 
   const {
     data: triplePositionsResult,
@@ -397,8 +421,8 @@ export default function ProfileDataCreated() {
   } = useGetPositionsQuery(
     {
       where: initialParams.triplePositionsWhere,
-      limit: initialParams.triplePositionsLimit,
-      offset: initialParams.triplePositionsOffset,
+      limit: triplePositionsLimit,
+      offset: triplePositionsOffset,
       orderBy: initialParams.triplePositionsOrderBy,
     },
     {
@@ -406,15 +430,13 @@ export default function ProfileDataCreated() {
         'get-triple-positions',
         {
           where: initialParams.triplePositionsWhere,
-          limit: initialParams.triplePositionsLimit,
-          offset: initialParams.triplePositionsOffset,
+          limit: triplePositionsLimit,
+          offset: triplePositionsOffset,
           orderBy: initialParams.triplePositionsOrderBy,
         },
       ],
     },
   )
-
-  logger('Triple Positions Result (Client):', triplePositionsResult)
 
   const [searchParams] = useSearchParams()
   const positionDirection = searchParams.get('positionDirection')
@@ -436,30 +458,20 @@ export default function ProfileDataCreated() {
             defaultValue={DataCreatedHeaderVariants.activeIdentities}
             className="w-full"
           >
-            <Suspense
-              fallback={
-                <div className="mb-6">
-                  <TabsSkeleton numOfTabs={2} />
-                </div>
-              }
-            >
-              <TabsList className="mb-6">
-                <TabsTrigger
-                  value={DataCreatedHeaderVariants.activeIdentities}
-                  label="Identities"
-                  totalCount={atomPositionsResult?.total?.aggregate?.count ?? 0}
-                  disabled={atomPositionsResult === undefined}
-                />
-                <TabsTrigger
-                  value={DataCreatedHeaderVariants.activeClaims}
-                  label="Claims"
-                  totalCount={
-                    triplePositionsResult?.total?.aggregate?.count ?? 0
-                  }
-                  disabled={triplePositionsResult === undefined}
-                />
-              </TabsList>
-            </Suspense>
+            <TabsList className="mb-6">
+              <TabsTrigger
+                value={DataCreatedHeaderVariants.activeIdentities}
+                label="Identities"
+                totalCount={atomPositionsResult?.total?.aggregate?.count ?? 0}
+                disabled={atomPositionsResult === undefined}
+              />
+              <TabsTrigger
+                value={DataCreatedHeaderVariants.activeClaims}
+                label="Claims"
+                totalCount={triplePositionsResult?.total?.aggregate?.count ?? 0}
+                disabled={triplePositionsResult === undefined}
+              />
+            </TabsList>
             <Suspense
               fallback={
                 <div className="mb-6">
@@ -499,9 +511,15 @@ export default function ProfileDataCreated() {
                   {atomPositionsResult && (
                     <ActivePositionsOnIdentities
                       identities={atomPositionsResult.positions}
-                      pagination={
-                        atomPositionsResult.total?.aggregate?.count ?? 0
-                      }
+                      pagination={{
+                        totalEntries:
+                          atomPositionsResult.total?.aggregate?.count ?? 0,
+                        limit: atomPositionsLimit,
+                        offset: atomPositionsOffset,
+                        onOffsetChange: onAtomPositionsOffsetChange,
+                        onLimitChange: onAtomPositionsLimitChange,
+                      }}
+                      paramPrefix="atomPositions"
                     />
                   )}
                 </TabContent>
@@ -548,11 +566,14 @@ export default function ProfileDataCreated() {
                     <ActivePositionsOnClaims
                       positions={triplePositionsResult?.positions ?? []}
                       pagination={{
-                        aggregate: {
-                          count:
-                            triplePositionsResult?.total?.aggregate?.count ?? 0,
-                        },
+                        totalEntries:
+                          triplePositionsResult?.total?.aggregate?.count ?? 0,
+                        limit: triplePositionsLimit,
+                        offset: triplePositionsOffset,
+                        onOffsetChange: onTriplePositionsOffsetChange,
+                        onLimitChange: onTriplePositionsLimitChange,
                       }}
+                      paramPrefix="triplePositions"
                       positionDirection={positionDirection ?? undefined}
                     />
                   )}
@@ -627,19 +648,21 @@ export default function ProfileDataCreated() {
                 totalResults={atomsCreatedResult?.total?.aggregate?.count}
                 atomImage={accountResult?.account?.image ?? ''}
                 atomLabel={accountResult?.account?.label ?? ''}
-                // totalStake={
-                //   +formatBalance(resolvedIdentitiesSummary?.assets ?? '0', 18)
-                // }  // Can't get TVL on created atoms at the moment
                 variant={DataCreatedHeaderVariants.createdIdentities}
               >
                 {atomsCreatedResult && (
                   <IdentitiesList
                     identities={atomsCreatedResult.atoms as Atom[]}
-                    pagination={
-                      atomsCreatedResult?.total?.aggregate?.count ?? 0
-                    }
+                    pagination={{
+                      totalEntries:
+                        atomsCreatedResult?.total?.aggregate?.count ?? 0,
+                      limit: createdIdentitiesLimit,
+                      offset: createdIdentitiesOffset,
+                      onOffsetChange: onCreatedIdentitiesOffsetChange,
+                      onLimitChange: onCreatedIdentitiesLimitChange,
+                    }}
                     paramPrefix="createdIdentities"
-                    enableSearch //
+                    enableSearch
                     enableSort
                   />
                 )}
@@ -675,19 +698,21 @@ export default function ProfileDataCreated() {
                 totalResults={triplesCreatedResult?.total?.aggregate?.count}
                 atomImage={accountResult?.account?.image ?? ''}
                 atomLabel={accountResult?.account?.label ?? ''}
-                // totalStake={
-                //   +formatBalance(resolvedIdentitiesSummary?.assets ?? '0', 18)
-                // }  // Can't get TVL on created atoms at the moment
                 variant={DataCreatedHeaderVariants.createdClaims}
               >
                 {triplesCreatedResult && (
                   <ClaimsList
                     claims={triplesCreatedResult.triples as Triple[]}
-                    pagination={
-                      triplesCreatedResult?.total?.aggregate?.count ?? 0
-                    }
+                    pagination={{
+                      totalEntries:
+                        triplesCreatedResult?.total?.aggregate?.count ?? 0,
+                      limit: createdClaimsLimit,
+                      offset: createdClaimsOffset,
+                      onOffsetChange: onCreatedClaimsOffsetChange,
+                      onLimitChange: onCreatedClaimsLimitChange,
+                    }}
                     paramPrefix="createdClaims"
-                    enableSearch //
+                    enableSearch
                     enableSort
                   />
                 )}

--- a/apps/portal/app/types/pagination.ts
+++ b/apps/portal/app/types/pagination.ts
@@ -1,7 +1,25 @@
-export interface PaginationType {
-  offset: number
+export interface PaginationInput {
+  total: number
   limit: number
-  totalEntries: number
+  offset: number
   onOffsetChange: (offset: number) => void
   onLimitChange: (limit: number) => void
+}
+
+export interface PaginationType {
+  totalEntries: number
+  limit: number
+  offset: number
+  onOffsetChange: (offset: number) => void
+  onLimitChange: (limit: number) => void
+}
+
+export function mapPaginationInput(input: PaginationInput): PaginationType {
+  return {
+    totalEntries: input.total,
+    limit: input.limit,
+    offset: input.offset,
+    onOffsetChange: input.onOffsetChange,
+    onLimitChange: input.onLimitChange,
+  }
 }

--- a/apps/portal/app/types/pagination.ts
+++ b/apps/portal/app/types/pagination.ts
@@ -1,6 +1,7 @@
 export interface PaginationType {
-  currentPage: number
+  offset: number
   limit: number
   totalEntries: number
-  totalPages: number
+  onOffsetChange: (offset: number) => void
+  onLimitChange: (limit: number) => void
 }

--- a/apps/template/app/types/pagination.ts
+++ b/apps/template/app/types/pagination.ts
@@ -1,6 +1,7 @@
 export interface PaginationType {
-  currentPage: number
-  limit: number
   totalEntries: number
-  totalPages: number
+  limit: number
+  offset: number
+  onOffsetChange: (offset: number) => void
+  onLimitChange: (limit: number) => void
 }

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -12680,6 +12680,8 @@ export type GetTriplesCountQuery = {
 
 export type GetTripleQueryVariables = Exact<{
   tripleId: Scalars['numeric']['input']
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
 }>
 
 export type GetTripleQuery = {
@@ -12703,6 +12705,72 @@ export type GetTripleQuery = {
       id: string
       atomId?: any | null
       type: string
+    } | null
+    vault?: {
+      __typename?: 'vaults'
+      totalShares: any
+      currentSharePrice: any
+      allPositions: {
+        __typename?: 'positions_aggregate'
+        aggregate?: {
+          __typename?: 'positions_aggregate_fields'
+          count: number
+          sum?: {
+            __typename?: 'positions_sum_fields'
+            shares?: any | null
+          } | null
+        } | null
+      }
+      paginatedPositions: Array<{
+        __typename?: 'positions'
+        id: string
+        vaultId: any
+        shares: any
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
+      }>
+      positions: Array<{
+        __typename?: 'positions'
+        shares: any
+        account?: { __typename?: 'accounts'; id: string; label: string } | null
+      }>
+    } | null
+    counterVault?: {
+      __typename?: 'vaults'
+      totalShares: any
+      currentSharePrice: any
+      allPositions: {
+        __typename?: 'positions_aggregate'
+        aggregate?: {
+          __typename?: 'positions_aggregate_fields'
+          count: number
+          sum?: {
+            __typename?: 'positions_sum_fields'
+            shares?: any | null
+          } | null
+        } | null
+      }
+      paginatedPositions: Array<{
+        __typename?: 'positions'
+        id: string
+        vaultId: any
+        shares: any
+        account?: {
+          __typename?: 'accounts'
+          id: string
+          label: string
+          image?: string | null
+        } | null
+      }>
+      positions: Array<{
+        __typename?: 'positions'
+        shares: any
+        account?: { __typename?: 'accounts'; id: string; label: string } | null
+      }>
     } | null
     subject?: {
       __typename?: 'atoms'
@@ -12832,62 +12900,6 @@ export type GetTripleQuery = {
           url?: string | null
         } | null
       } | null
-    } | null
-    vault?: {
-      __typename?: 'vaults'
-      totalShares: any
-      currentSharePrice: any
-      allPositions: {
-        __typename?: 'positions_aggregate'
-        aggregate?: {
-          __typename?: 'positions_aggregate_fields'
-          count: number
-          sum?: {
-            __typename?: 'positions_sum_fields'
-            shares?: any | null
-          } | null
-        } | null
-      }
-      positions: Array<{
-        __typename?: 'positions'
-        id: string
-        vaultId: any
-        shares: any
-        account?: {
-          __typename?: 'accounts'
-          id: string
-          label: string
-          image?: string | null
-        } | null
-      }>
-    } | null
-    counterVault?: {
-      __typename?: 'vaults'
-      totalShares: any
-      currentSharePrice: any
-      allPositions: {
-        __typename?: 'positions_aggregate'
-        aggregate?: {
-          __typename?: 'positions_aggregate_fields'
-          count: number
-          sum?: {
-            __typename?: 'positions_sum_fields'
-            shares?: any | null
-          } | null
-        } | null
-      }
-      positions: Array<{
-        __typename?: 'positions'
-        id: string
-        vaultId: any
-        shares: any
-        account?: {
-          __typename?: 'accounts'
-          id: string
-          label: string
-          image?: string | null
-        } | null
-      }>
     } | null
   } | null
 }
@@ -17845,13 +17857,56 @@ useGetTriplesCountQuery.fetcher = (
   )
 
 export const GetTripleDocument = `
-    query GetTriple($tripleId: numeric!) {
+    query GetTriple($tripleId: numeric!, $limit: Int, $offset: Int) {
   triple(id: $tripleId) {
     ...TripleMetadata
     ...TripleTxn
-    ...TripleVaultDetails
     creator {
       ...AccountMetadata
+    }
+    vault {
+      totalShares
+      currentSharePrice
+      allPositions: positions_aggregate {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+      paginatedPositions: positions(limit: $limit, offset: $offset) {
+        id
+        vaultId
+        shares
+        account {
+          id
+          label
+          image
+        }
+      }
+    }
+    counterVault {
+      totalShares
+      currentSharePrice
+      allPositions: positions_aggregate {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+      paginatedPositions: positions(limit: $limit, offset: $offset) {
+        id
+        vaultId
+        shares
+        account {
+          id
+          label
+          image
+        }
+      }
     }
   }
 }
@@ -17860,8 +17915,7 @@ ${AtomValueFragmentDoc}
 ${AccountMetadataFragmentDoc}
 ${PositionAggregateFieldsFragmentDoc}
 ${PositionFieldsFragmentDoc}
-${TripleTxnFragmentDoc}
-${TripleVaultDetailsFragmentDoc}`
+${TripleTxnFragmentDoc}`
 
 export const useGetTripleQuery = <TData = GetTripleQuery, TError = unknown>(
   variables: GetTripleQueryVariables,
@@ -38720,6 +38774,22 @@ export const GetTriple = {
             },
           },
         },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'limit' },
+          },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'offset' },
+          },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
       ],
       selectionSet: {
         kind: 'SelectionSet',
@@ -38749,10 +38819,6 @@ export const GetTriple = {
                   name: { kind: 'Name', value: 'TripleTxn' },
                 },
                 {
-                  kind: 'FragmentSpread',
-                  name: { kind: 'Name', value: 'TripleVaultDetails' },
-                },
-                {
                   kind: 'Field',
                   name: { kind: 'Name', value: 'creator' },
                   selectionSet: {
@@ -38761,6 +38827,240 @@ export const GetTriple = {
                       {
                         kind: 'FragmentSpread',
                         name: { kind: 'Name', value: 'AccountMetadata' },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'vault' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'totalShares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'currentSharePrice' },
+                      },
+                      {
+                        kind: 'Field',
+                        alias: { kind: 'Name', value: 'allPositions' },
+                        name: { kind: 'Name', value: 'positions_aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'aggregate' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'count' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'sum' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'shares',
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        alias: { kind: 'Name', value: 'paginatedPositions' },
+                        name: { kind: 'Name', value: 'positions' },
+                        arguments: [
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'limit' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'limit' },
+                            },
+                          },
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'offset' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'offset' },
+                            },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'vaultId' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'shares' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'account' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'id' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'label' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'image' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'counterVault' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'totalShares' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'currentSharePrice' },
+                      },
+                      {
+                        kind: 'Field',
+                        alias: { kind: 'Name', value: 'allPositions' },
+                        name: { kind: 'Name', value: 'positions_aggregate' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'aggregate' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'count' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'sum' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'shares',
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        alias: { kind: 'Name', value: 'paginatedPositions' },
+                        name: { kind: 'Name', value: 'positions' },
+                        arguments: [
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'limit' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'limit' },
+                            },
+                          },
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'offset' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'offset' },
+                            },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'vaultId' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'shares' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'account' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'id' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'label' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'image' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
                       },
                     ],
                   },
@@ -39143,117 +39443,6 @@ export const GetTriple = {
           { kind: 'Field', name: { kind: 'Name', value: 'blockTimestamp' } },
           { kind: 'Field', name: { kind: 'Name', value: 'transactionHash' } },
           { kind: 'Field', name: { kind: 'Name', value: 'creatorId' } },
-        ],
-      },
-    },
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'TripleVaultDetails' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'triples' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'vaultId' } },
-          { kind: 'Field', name: { kind: 'Name', value: 'counterVaultId' } },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'vault' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'positions' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'vaultId' },
-                      },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'shares' },
-                      },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'account' },
-                        selectionSet: {
-                          kind: 'SelectionSet',
-                          selections: [
-                            {
-                              kind: 'Field',
-                              name: { kind: 'Name', value: 'id' },
-                            },
-                            {
-                              kind: 'Field',
-                              name: { kind: 'Name', value: 'label' },
-                            },
-                            {
-                              kind: 'Field',
-                              name: { kind: 'Name', value: 'image' },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'counterVault' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'positions' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'vaultId' },
-                      },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'shares' },
-                      },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'account' },
-                        selectionSet: {
-                          kind: 'SelectionSet',
-                          selections: [
-                            {
-                              kind: 'Field',
-                              name: { kind: 'Name', value: 'id' },
-                            },
-                            {
-                              kind: 'Field',
-                              name: { kind: 'Name', value: 'label' },
-                            },
-                            {
-                              kind: 'Field',
-                              name: { kind: 'Name', value: 'image' },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
         ],
       },
     },

--- a/packages/graphql/src/queries/triples.graphql
+++ b/packages/graphql/src/queries/triples.graphql
@@ -55,13 +55,56 @@ query GetTriplesCount($where: triples_bool_exp) {
   }
 }
 
-query GetTriple($tripleId: numeric!) {
+query GetTriple($tripleId: numeric!, $limit: Int, $offset: Int) {
   triple(id: $tripleId) {
     ...TripleMetadata
     ...TripleTxn
-    ...TripleVaultDetails
     creator {
       ...AccountMetadata
+    }
+    vault {
+      totalShares
+      currentSharePrice
+      allPositions: positions_aggregate {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+      paginatedPositions: positions(limit: $limit, offset: $offset) {
+        id
+        vaultId
+        shares
+        account {
+          id
+          label
+          image
+        }
+      }
+    }
+    counterVault {
+      totalShares
+      currentSharePrice
+      allPositions: positions_aggregate {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+      paginatedPositions: positions(limit: $limit, offset: $offset) {
+        id
+        vaultId
+        shares
+        account {
+          id
+          label
+          image
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Migrates our pagination strategy to work with GraphQL
- Changes the PaginationComponent to support this -- changes multiple consumers and routes, and makes sure that all queries work with the new pagination approach.
- Routes with multiple pagination components work as they did previously using prefixes.
- Note: The build isn't working due to `typecheck` issues -- this is because I had to make changes that are breaking the non-migrated Lists (and Explore) routes. Since we need to migrate these changes again to the no-ponder feature branch, additional work here isn't efficient. It'll be handled on that branch.
- This updates all the core routes and we can use these directly in the no-ponder branch after re-migrating that branch (which will take less effort than this, but not a small amount). We'll fix all type/build issues once we're fully settled.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
