### PR TITLE
ENG-5171 feat(launchpad,1ui): create activity feed and add to network route

### DIFF
--- a/apps/launchpad/app/components/ActivityFeed.tsx
+++ b/apps/launchpad/app/components/ActivityFeed.tsx
@@ -1,0 +1,232 @@
+import { useState } from 'react'
+
+import {
+  Button,
+  cn,
+  IconNameType,
+  Identity,
+  IdentityTag,
+  Skeleton,
+  Text,
+  Trunctacular,
+} from '@0xintuition/1ui'
+import { Events, GetEventsQuery } from '@0xintuition/graphql'
+
+import { BLOCK_EXPLORER_URL } from '@consts/general'
+import { formatDistanceToNow } from 'date-fns'
+import { Badge, Filter, SortAsc, SortDesc } from 'lucide-react'
+
+export type ActivityItem = {
+  id: string
+  user: {
+    address: string
+    name: string
+    avatar?: string
+  }
+  type: 'created' | 'redeemed' | 'deposited'
+  indicator?: {
+    text: string
+    icon?: IconNameType
+    isUser?: boolean
+  }
+  amount?: string
+  direction?: 'from' | 'on' | 'for' | 'against'
+  target?: string
+  tags?: string[]
+  timestamp: string
+  hash: string
+}
+
+export interface ActivityFeedProps {
+  activities?: GetEventsQuery
+  isLoading?: boolean
+}
+
+function ActivityRow({ activity }: { activity: Events }) {
+  let direction: 'on' | 'from' | undefined
+
+  if (activity.type === 'Deposited') {
+    direction = 'on'
+  } else if (activity.type === 'Redeemed') {
+    direction = 'from'
+  } else if (activity.type === 'AtomCreated') {
+    direction = undefined
+  } else if (activity.type === 'TripleCreated') {
+    direction = undefined
+  }
+
+  const value =
+    activity.type === 'Deposited'
+      ? activity.deposit?.shares_for_receiver // #TODO: we should be showing assets here, but we only get shares. In addition, we should know the share price at the time of the deposit, otherwise we have to use the current share price which will skew the value, since we are going to show $USD.
+      : activity.type === 'Redeemed'
+        ? activity.redemption?.shares_redeemed_by_sender
+        : null
+
+  // Basic required fields with fallbacks
+  const timestamp = activity.block_timestamp
+    ? new Date(parseInt(activity.block_timestamp.toString()) * 1000)
+    : new Date()
+
+  // Get creator from either atom or triple
+  const creator = activity.atom?.creator || activity.triple?.creator
+
+  const dataType = activity.atom
+    ? 'atom'
+    : activity.triple
+      ? 'triple'
+      : 'unknown'
+
+  const getAmountColor = (type: string, amount?: string) => {
+    if (!amount) {
+      return 'text-primary'
+    }
+    return type === 'redeemed' ? 'text-red-500' : 'text-green-500'
+  }
+
+  function formatTransactionHash(txHash: string): string {
+    return `0x${txHash.replace('\\x', '')}`
+  }
+
+  return (
+    <div key={activity.id} className="flex items-start gap-3 py-2 group">
+      <div className="relative flex flex-col items-center pt-2">
+        <div className="w-4 h-4 rounded-full bg-background theme-border flex items-center justify-center relative">
+          <div className="w-1.5 h-1.5 rounded-full bg-primary" />
+        </div>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 text-sm">
+          <IdentityTag variant={Identity.user} imgSrc={creator?.image}>
+            {creator?.label}
+          </IdentityTag>
+          <span className="text-muted-foreground">
+            {activity.type.toLowerCase()}
+          </span>
+          {value && (
+            <Badge
+              className={cn(
+                getAmountColor(activity.type, value),
+                'bg-transparent theme-border',
+              )}
+            >
+              {value}
+            </Badge>
+          )}
+          {direction && (
+            <span className="text-muted-foreground">{direction}</span>
+          )}
+          {dataType && <span className="text-primary">{dataType}</span>}
+          <IdentityTag
+            variant={
+              dataType === 'triple'
+                ? Identity.user
+                : activity.atom?.type === ('Default' || 'Account')
+                  ? Identity.user
+                  : Identity.nonUser
+            }
+            icon={dataType === 'triple' ? 'claim' : 'fingerprint'}
+          >
+            <Text>
+              {activity.atom?.label ||
+                [
+                  activity.triple?.subject?.label,
+                  activity.triple?.predicate?.label,
+                  activity.triple?.object?.label,
+                ]
+                  .filter(Boolean)
+                  .join('')}
+            </Text>
+          </IdentityTag>
+        </div>
+
+        <div className="flex items-center gap-2 mt-1">
+          <span className="text-xs text-muted-foreground">
+            {formatDistanceToNow(timestamp, { addSuffix: true })}
+          </span>
+          <a
+            href={`${BLOCK_EXPLORER_URL}/tx/${formatTransactionHash(activity.transaction_hash)}`} //#TODO: this is not a transaction hash, I believe it's a block hash? It doesn't resolve to a transaction on basescan
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-accent hover:text-primary truncate"
+          >
+            <Trunctacular
+              value={formatTransactionHash(activity.transaction_hash)}
+            />
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const ActivityFeed = ({
+  activities = { events: [], total: { aggregate: { count: 0 } } },
+  isLoading,
+}: ActivityFeedProps) => {
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-start gap-3">
+            <Skeleton className="w-3 h-3 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <RealtimeSort />
+        <Button variant="secondary">
+          <Filter className="w-4 h-4" />
+          <Text>Filter</Text>
+        </Button>
+      </div>
+
+      <div className="relative space-y-1 pl-3">
+        <div className="absolute left-[19px] top-0 w-[2px] h-full bg-muted" />
+        {activities.events.map((activity) => (
+          <ActivityRow key={activity.id} activity={activity as Events} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface RealtimeSortProps {
+  onSortChange?: (direction: 'asc' | 'desc') => void
+}
+
+const RealtimeSort = ({ onSortChange }: RealtimeSortProps) => {
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
+
+  const handleSortClick = () => {
+    const newDirection = sortDirection === 'asc' ? 'desc' : 'asc'
+    setSortDirection(newDirection)
+    onSortChange?.(newDirection)
+  }
+
+  return (
+    <Button
+      variant="text"
+      className="flex items-center gap-2 text-sm text-accent hover:text-foreground"
+      onClick={handleSortClick}
+    >
+      {sortDirection === 'asc' ? (
+        <SortAsc className="w-4 h-4" />
+      ) : (
+        <SortDesc className="w-4 h-4" />
+      )}
+      <Text className="text-inherit">Realtime</Text>
+    </Button>
+  )
+}
+
+export default ActivityFeed

--- a/apps/launchpad/app/consts/general.ts
+++ b/apps/launchpad/app/consts/general.ts
@@ -1,0 +1,4 @@
+export const BLOCK_EXPLORER_URL =
+  // CURRENT_ENV === 'development'
+  //   ? 'https://sepolia.basescan.org :'
+  'https://basescan.org'

--- a/apps/launchpad/package.json
+++ b/apps/launchpad/package.json
@@ -24,6 +24,7 @@
     "@remix-run/serve": "^2.15.1",
     "@tanstack/react-query": "^5.32.0",
     "class-variance-authority": "^0.7.0",
+    "date-fns": "^3.6.0",
     "isbot": "^4.1.0",
     "lucide-react": "^0.441.0",
     "react": "^18.2.0",

--- a/packages/1ui/src/components/Avatar/Avatar.tsx
+++ b/packages/1ui/src/components/Avatar/Avatar.tsx
@@ -4,7 +4,7 @@ import * as AvatarPrimitive from '@radix-ui/react-avatar'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { Identity } from 'types'
 
-import { Icon, IconName } from '..'
+import { Icon, IconName, IconNameType } from '..'
 import { cn } from '../../styles'
 
 const AvatarContainer = React.forwardRef<
@@ -65,10 +65,18 @@ export interface AvatarProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof avatarVariants> {
   src?: string
+  icon?: string
   name: string
 }
 
-const Avatar = ({ className, variant, src, name, onClick }: AvatarProps) => {
+const Avatar = ({
+  className,
+  variant,
+  src,
+  name,
+  icon,
+  onClick,
+}: AvatarProps) => {
   return (
     <AvatarContainer
       className={cn(avatarVariants({ variant }), className)}
@@ -78,9 +86,11 @@ const Avatar = ({ className, variant, src, name, onClick }: AvatarProps) => {
       <AvatarFallback className="bg-inherit">
         <Icon
           name={
-            variant === Identity.nonUser
-              ? IconName.fingerprint
-              : IconName.cryptoPunk
+            icon
+              ? (icon as IconNameType)
+              : variant === Identity.nonUser
+                ? IconName.fingerprint
+                : IconName.cryptoPunk
           }
           className="text-primary/30 w-[80%] h-[80%]"
         />

--- a/packages/1ui/src/components/IdentityTag/IdentityTag.tsx
+++ b/packages/1ui/src/components/IdentityTag/IdentityTag.tsx
@@ -3,7 +3,13 @@ import * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { Identity, IdentityType } from 'types'
 
-import { Avatar, HoverCard, HoverCardContent, HoverCardTrigger } from '..'
+import {
+  Avatar,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+  IconNameType,
+} from '..'
 import { cn } from '../../styles'
 
 export const IdentityTagSize = {
@@ -45,6 +51,7 @@ export const identityTagVariants = cva(
 const IdentityTagButton = ({
   className,
   imgSrc,
+  icon,
   variant,
   size,
   disabled,
@@ -60,7 +67,12 @@ const IdentityTagButton = ({
       disabled={disabled}
       {...props}
     >
-      <Avatar variant={variant} src={imgSrc || ''} name="identity avatar" />
+      <Avatar
+        variant={variant}
+        src={imgSrc || ''}
+        icon={icon || ''}
+        name="identity avatar"
+      />
       {children || '?'}
     </button>
   )
@@ -71,6 +83,7 @@ export interface IdentityTagProps
     VariantProps<typeof identityTagVariants> {
   disabled?: boolean
   imgSrc?: string | null
+  icon?: IconNameType | null
   variant?: IdentityType
   hoverCardContent?: React.ReactNode | null
   shouldHover?: boolean

--- a/packages/1ui/src/components/NetworkStats/NetworkStats.spec.tsx
+++ b/packages/1ui/src/components/NetworkStats/NetworkStats.spec.tsx
@@ -18,13 +18,13 @@ describe('NetworkStats', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
       <DocumentFragment>
         <div
-          class="grid grid-cols-2 gap-4 rounded-lg bg-background/20 p-4 sm:grid-cols-4 lg:grid-cols-5"
+          class="grid grid-cols-2 gap-4 p-4 sm:grid-cols-4 lg:grid-cols-5"
         >
           <div
-            class="relative text-center px-12 after:absolute after:right-0 after:top-1/2 after:-translate-y-1/2 after:h-8 after:w-px after:bg-border/20"
+            class="relative text-center px-12 after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20"
           >
             <div
-              class="text-sm text-muted-foreground"
+              class="text-sm text-foreground/70"
             >
               TVL
             </div>
@@ -35,10 +35,10 @@ describe('NetworkStats', () => {
             </div>
           </div>
           <div
-            class="relative text-center px-12 after:absolute after:right-0 after:top-1/2 after:-translate-y-1/2 after:h-8 after:w-px after:bg-border/20"
+            class="relative text-center px-12 after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20"
           >
             <div
-              class="text-sm text-muted-foreground"
+              class="text-sm text-foreground/70"
             >
               Atoms
             </div>
@@ -49,10 +49,10 @@ describe('NetworkStats', () => {
             </div>
           </div>
           <div
-            class="relative text-center px-12 after:absolute after:right-0 after:top-1/2 after:-translate-y-1/2 after:h-8 after:w-px after:bg-border/20"
+            class="relative text-center px-12 after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20"
           >
             <div
-              class="text-sm text-muted-foreground"
+              class="text-sm text-foreground/70"
             >
               Triples
             </div>
@@ -63,10 +63,10 @@ describe('NetworkStats', () => {
             </div>
           </div>
           <div
-            class="relative text-center px-12 hidden lg:block after:absolute after:right-0 after:top-1/2 after:-translate-y-1/2 after:h-8 after:w-px after:bg-border/20"
+            class="relative text-center px-12 hidden lg:block after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20"
           >
             <div
-              class="text-sm text-muted-foreground"
+              class="text-sm text-foreground/70"
             >
               Signals
             </div>
@@ -80,7 +80,7 @@ describe('NetworkStats', () => {
             class="relative text-center px-12"
           >
             <div
-              class="text-sm text-muted-foreground"
+              class="text-sm text-foreground/70"
             >
               Users
             </div>

--- a/packages/1ui/src/components/PageHeader/PageHeader.stories.tsx
+++ b/packages/1ui/src/components/PageHeader/PageHeader.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 } satisfies Meta<typeof PageHeader>
 
 export default meta

--- a/packages/1ui/src/components/Sidebar/Sidebar.spec.tsx
+++ b/packages/1ui/src/components/Sidebar/Sidebar.spec.tsx
@@ -47,17 +47,20 @@ describe('Sidebar', () => {
           style="--sidebar-width: 16rem; --sidebar-width-icon: 3rem;"
         >
           <div
-            class="group peer hidden md:block"
+            class="group peer hidden md:block text-sidebar-foreground"
             data-collapsible=""
             data-side="left"
             data-state="expanded"
             data-variant="sidebar"
           >
             <div
-              class="duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex bg-[#0D0D0D] text-white/80 left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
+              class="duration-200 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear group-data-[collapsible=offcanvas]:w-0 group-data-[side=right]:rotate-180 group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
+            />
+            <div
+              class="duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l"
             >
               <div
-                class="flex h-full w-full flex-col"
+                class="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
                 data-sidebar="sidebar"
               >
                 <div
@@ -95,7 +98,7 @@ describe('Sidebar', () => {
                           data-sidebar="menu-item"
                         >
                           <button
-                            class="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium outline-none transition-colors text-white/80 hover:bg-white/5"
+                            class="peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left outline-none ring-sidebar-ring transition-[width,height,padding] focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground h-8 text-sm"
                             data-active="false"
                             data-sidebar="menu-button"
                             data-size="default"
@@ -164,17 +167,20 @@ describe('Sidebar', () => {
           style="--sidebar-width: 16rem; --sidebar-width-icon: 3rem;"
         >
           <div
-            class="group peer hidden md:block"
+            class="group peer hidden md:block text-sidebar-foreground"
             data-collapsible=""
             data-side="left"
             data-state="expanded"
             data-variant="sidebar"
           >
             <div
-              class="duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex bg-[#0D0D0D] text-white/80 left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
+              class="duration-200 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear group-data-[collapsible=offcanvas]:w-0 group-data-[side=right]:rotate-180 group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
+            />
+            <div
+              class="duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l"
             >
               <div
-                class="flex h-full w-full flex-col"
+                class="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
                 data-sidebar="sidebar"
               >
                 <div
@@ -198,7 +204,7 @@ describe('Sidebar', () => {
                           data-sidebar="menu-item"
                         >
                           <button
-                            class="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium outline-none transition-colors text-white/80 hover:bg-white/5"
+                            class="peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left outline-none ring-sidebar-ring transition-[width,height,padding] focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground h-8 text-sm"
                             data-active="false"
                             data-sidebar="menu-button"
                             data-size="default"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       isbot:
         specifier: ^4.1.0
         version: 4.4.0
@@ -22798,8 +22801,8 @@ snapshots:
   '@solana/web3.js@1.95.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.4)':
     dependencies:
       '@babel/runtime': 7.25.7
-      '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.5.0
       bigint-buffer: 1.1.5


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [x] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Initially started building this in 1ui but then came to the conclusion that it is tied too heavily into our logic for this to be a fit. Moved into the launchpad and got it up on the Network route. Definitely needs some more love and will have to work out some of the data with BE once they're deployed.

## Screen Captures

![network](https://github.com/user-attachments/assets/eb2e3990-398d-41c2-be50-9a3540096e10)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
