### PR TITLE
ENG-0000 fix(repo): removes the localhost fallback for codegen

### DIFF
--- a/packages/graphql/codegen.ts
+++ b/packages/graphql/codegen.ts
@@ -1,6 +1,8 @@
 import { CodegenConfig } from '@graphql-codegen/cli'
 import type { Types } from '@graphql-codegen/plugin-helpers'
 
+import { API_URL_DEV } from './src/constants'
+
 const commonGenerateOptions: Types.ConfiguredOutput = {
   config: {
     reactQueryVersion: 5,
@@ -34,8 +36,7 @@ const commonGenerateOptions: Types.ConfiguredOutput = {
 const config: CodegenConfig = {
   overwrite: true,
   hooks: { afterAllFileWrite: ['prettier --write'] },
-  schema:
-    process.env.HASURA_PROJECT_ENDPOINT || 'http://localhost:8080/v1/graphql',
+  schema: process.env.HASURA_PROJECT_ENDPOINT || API_URL_DEV,
   ignoreNoDocuments: true,
   documents: ['**/*.graphql'],
   generates: {


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Overview of the changes in the PR.

## Screen Captures

- Removes the fallback for localhost -- uses the dev API URL instead.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
