### PR TITLE
ENG-5229 feat(repo): scaffold atom details in launchpad

### DIFF
--- a/apps/launchpad/app/routes/preferences+/item+/$itemId.tsx
+++ b/apps/launchpad/app/routes/preferences+/item+/$itemId.tsx
@@ -91,14 +91,75 @@ export default function ItemView() {
           </Button>
         </div>
       </div>
-      <Button variant="secondary" className="px-4">
+      <Button variant="secondary">
         <Icon name="eye-open" className="h-4 w-4" />
         View Metadata
       </Button>
 
-      {/* Chart Area */}
-      <div className="h-[400px] rounded-lg border border-border/10 bg-gradient-to-b from-[#060504] to-[#101010]">
-        {/* Chart will go here */}
+      {/* Chart Card */}
+      <div className="rounded-lg border border-border/10 bg-gradient-to-b from-[#060504] to-[#101010] p-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-1">
+            <Text variant="caption" className="text-muted-foreground">
+              Share Price
+            </Text>
+            <Text variant="headline" weight="medium">
+              $235.70
+            </Text>
+          </div>
+          <Text variant="caption" className="text-[#E6B17E]">
+            Vault ID 1337
+          </Text>
+        </div>
+
+        {/* Chart Area */}
+        <div className="h-[300px]">{/* Chart will go here */}</div>
+
+        {/* Time Period Selector */}
+        <div className="flex items-center gap-4 border-t border-dashed border-border/10 pt-4">
+          {['1D', '1W', '1M', '3M', '1Y', 'YTD'].map((period) => (
+            <button
+              key={period}
+              className={`text-sm ${
+                period === 'YTD'
+                  ? 'text-[#E6B17E]'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {period}
+            </button>
+          ))}
+          <Icon
+            name={IconName.filter1}
+            className="ml-auto size-4 text-muted-foreground"
+          />
+        </div>
+      </div>
+
+      {/* Position Info */}
+      <div className="flex items-center justify-between rounded-lg bg-[#060504] px-6 py-3">
+        <div className="flex flex-col gap-1">
+          <Text
+            variant="caption"
+            weight="medium"
+            className="text-muted-foreground"
+          >
+            Your Position
+          </Text>
+          <div className="flex items-center gap-2">
+            <Text variant="headline" weight="medium">
+              $0.0
+            </Text>
+            <Text variant="body" className="text-success">
+              +0.0 (+0.0%)
+            </Text>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="secondary">Sell</Button>
+          <Button variant="secondary">Buy</Button>
+        </div>
       </div>
 
       {/* Stats Grid */}
@@ -119,33 +180,7 @@ export default function ItemView() {
             </Text>
           </div>
         ))}
-      </div>
-
-      {/* Position Info */}
-      <div className="flex items-center justify-between bg-[#060504] px-6 py-3 rounded-lg">
-        <div className="flex-col items-center gap-2">
-          <Text
-            variant="caption"
-            weight="regular"
-            className="text-muted-foreground"
-          >
-            Your Position
-          </Text>
-          <div className="flex items-center gap-2">
-            <Text variant="headline" weight="medium" className="font-medium">
-              $0.0
-            </Text>
-            <Text variant="body" weight="medium" className="text-success">
-              +0.0%
-            </Text>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Button variant="outline" className="bg-[#060504]">
-            Sell
-          </Button>
-          <Button>Buy</Button>
-        </div>
+        {/* <div className="h-[400px] w-100 rounded-lg border border-border/10 bg-gradient-to-b from-[#060504] to-[#101010]"></div> */}
       </div>
     </div>
   )

--- a/apps/launchpad/app/routes/preferences+/item+/$itemId.tsx
+++ b/apps/launchpad/app/routes/preferences+/item+/$itemId.tsx
@@ -1,17 +1,152 @@
 import * as React from 'react'
 
-import { Text, TextVariant } from '@0xintuition/1ui'
+import { Button, Icon, IconName, Text } from '@0xintuition/1ui'
 
 import { useParams } from '@remix-run/react'
 
+import { preferencesTree } from '../_layout'
+
+type FileNode = {
+  id: string
+  name: string
+  path: string
+  icon?: (typeof IconName)[keyof typeof IconName]
+  type: 'folder' | 'item'
+  items?: FileNode[]
+}
+
+function findItemById(tree: FileNode[], id: string): FileNode | null {
+  for (const node of tree) {
+    if (node.id === id) {
+      return node
+    }
+    if (node.type === 'folder' && node.items) {
+      const found = findItemById(node.items, id)
+      if (found) {
+        return found
+      }
+    }
+  }
+  return null
+}
+
+function getParentFolderName(path: string): string {
+  const parts = path.split('/')
+  // Remove empty strings and current folder name
+  const filteredParts = parts.filter(Boolean)
+  if (filteredParts.length < 2) {
+    return ''
+  }
+  return filteredParts[filteredParts.length - 2].replace(/-/g, '_')
+}
+
 export default function ItemView() {
   const { itemId } = useParams()
+  const item = React.useMemo(() => {
+    if (!itemId) {
+      return null
+    }
+    return findItemById(preferencesTree, itemId)
+  }, [itemId])
+
+  if (!item) {
+    return (
+      <div className="space-y-4">
+        <Text variant="heading1">Item Not Found</Text>
+        <Text variant="body">Could not find item with ID: {itemId}</Text>
+      </div>
+    )
+  }
+
+  const parentFolderName = getParentFolderName(item.path)
 
   return (
-    <div className="space-y-4">
-      <Text variant={TextVariant.heading1}>Item View</Text>
-      <Text variant={TextVariant.body}>Viewing item with ID: {itemId}</Text>
-      {/* TODO: Add item details */}
+    <div className="space-y-6">
+      {/* Top Section */}
+      <div className="flex items-center gap-4">
+        <div className="size-8 rounded bg-muted/50" />
+        <div className="flex flex-col">
+          <Text variant="body" className="text-muted-foreground">
+            {parentFolderName}
+          </Text>
+          <div className="flex items-center gap-2">
+            <Text variant="headline" weight="regular">
+              {item.name}
+            </Text>
+            <Text
+              variant="caption"
+              weight="regular"
+              className="rounded-lg border border-border/10 bg-gradient-to-b from-[#060504] to-[#101010] p-0.5 px-1"
+            >
+              Brief description or label?
+            </Text>
+          </div>
+        </div>
+        <div className="ml-auto flex items-center gap-4">
+          <Text variant="headline" weight="medium">
+            $235.70
+          </Text>
+          <Button variant="secondary" className="min-w-16">
+            Sell
+          </Button>
+        </div>
+      </div>
+      <Button variant="secondary" className="px-4">
+        <Icon name="eye-open" className="h-4 w-4" />
+        View Metadata
+      </Button>
+
+      {/* Chart Area */}
+      <div className="h-[400px] rounded-lg border border-border/10 bg-gradient-to-b from-[#060504] to-[#101010]">
+        {/* Chart will go here */}
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid grid-cols-5 gap-8">
+        {[
+          { label: 'Total Assets', value: '1.23 ETH' },
+          { label: 'Positions', value: '25' },
+          { label: 'Triples', value: '4.20k' },
+          { label: 'Signals', value: '4.20k' },
+          { label: 'Users', value: '4.20k' },
+        ].map((stat) => (
+          <div key={stat.label} className="flex flex-col gap-1">
+            <Text variant="caption" className="text-muted-foreground/50">
+              {stat.label}
+            </Text>
+            <Text variant="headline" weight="medium">
+              {stat.value}
+            </Text>
+          </div>
+        ))}
+      </div>
+
+      {/* Position Info */}
+      <div className="flex items-center justify-between bg-[#060504] px-6 py-3 rounded-lg">
+        <div className="flex-col items-center gap-2">
+          <Text
+            variant="caption"
+            weight="regular"
+            className="text-muted-foreground"
+          >
+            Your Position
+          </Text>
+          <div className="flex items-center gap-2">
+            <Text variant="headline" weight="medium" className="font-medium">
+              $0.0
+            </Text>
+            <Text variant="body" weight="medium" className="text-success">
+              +0.0%
+            </Text>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" className="bg-[#060504]">
+            Sell
+          </Button>
+          <Button>Buy</Button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/launchpad/app/routes/preferences+/item+/$itemId.tsx
+++ b/apps/launchpad/app/routes/preferences+/item+/$itemId.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { Button, Icon, IconName, Text } from '@0xintuition/1ui'
 
-import { useParams } from '@remix-run/react'
+import { useParams, useSearchParams } from '@remix-run/react'
 
 import { preferencesTree } from '../_layout'
 
@@ -42,6 +42,9 @@ function getParentFolderName(path: string): string {
 
 export default function ItemView() {
   const { itemId } = useParams()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const timeFilter = searchParams.get('timeFilter') || 'YTD'
+
   const item = React.useMemo(() => {
     if (!itemId) {
       return null
@@ -121,8 +124,9 @@ export default function ItemView() {
           {['1D', '1W', '1M', '3M', '1Y', 'YTD'].map((period) => (
             <button
               key={period}
-              className={`text-sm ${
-                period === 'YTD'
+              onClick={() => setSearchParams({ timeFilter: period })}
+              className={`text-sm transition-colors ${
+                period === timeFilter
                   ? 'text-[#E6B17E]'
                   : 'text-muted-foreground hover:text-foreground'
               }`}


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Scaffolds the atom details route in Launchpad -- this can be viewed for testing the UX in the `/preferences` route and by selecting a single item (not a folder) in the sidebar
- Builds out the UI from the Figma with placeholder data for now, but this will come in from the actual atom once we wire up the query
- Uses the dynamic placeholder data and dynamic routes

## Screen Captures

![launchpad-atom-details](https://github.com/user-attachments/assets/3af7572c-839f-4ae5-ad88-8b949395274d)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
