### PR TITLE
ENG-5279 feat(graphql,sdk): remove api dependencies from sdk and graphql

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xintuition/graphql",
   "description": "GraphQL",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -41,7 +41,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@0xintuition/api": "workspace:^",
     "@graphql-codegen/typescript-document-nodes": "^4.0.11",
     "@tanstack/react-query": "^5.32.0",
     "graphql": "^16.9.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xintuition/sdk",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "Backend SDK",
   "main": "src/index.js",
   "exports": {
@@ -21,9 +21,7 @@
     "url": "https://github.com/0xIntuition/intuition-ts",
     "directory": "packages/sdk"
   },
-  "dependencies": {
-    "@0xintuition/api": "workspace:^"
-  },
+  "dependencies": {},
   "devDependencies": {
     "typescript": "^5.4.5",
     "vite": "^5.2.11",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,1 @@
-import { IdentitiesService } from '@0xintuition/api'
-
-console.log('test', IdentitiesService)
+console.log('test')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -997,9 +997,6 @@ importers:
 
   packages/graphql:
     dependencies:
-      '@0xintuition/api':
-        specifier: workspace:^
-        version: link:../api
       '@graphql-codegen/typescript-document-nodes':
         specifier: ^4.0.11
         version: 4.0.11(encoding@0.1.13)(graphql@16.9.0)
@@ -1085,10 +1082,6 @@ importers:
         version: 1.6.0(@types/node@20.14.2)(@vitest/ui@1.6.0)(jsdom@22.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.31.1)
 
   packages/sdk:
-    dependencies:
-      '@0xintuition/api':
-        specifier: workspace:^
-        version: link:../api
     devDependencies:
       typescript:
         specifier: ^5.4.5
@@ -13908,6 +13901,7 @@ packages:
 
   sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   superstruct@1.0.4:
     resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}
@@ -23980,7 +23974,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.0.1
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.14.2)(@vitest/ui@1.6.0)(jsdom@22.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.31.1)
+      vitest: 1.6.0(@types/node@18.16.9)(@vitest/ui@1.6.0)(jsdom@22.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.31.1)
 
   '@vitest/utils@1.3.1':
     dependencies:


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [x] sdk

Tools

- [ ] tools

## Overview

- Removes the inclusion of the `0xintuition/api` package as dependency in `graphql` and `sdk` packages
- Ran a `pnpm install` afterward so the `pnpm-lock.yaml` change reflects this
- This resolves installation issues for apps outside of the monorepo
- Note: Leaving it in the `template` and `data-populator` for now because it's more integrated as part of certain flows. We can remove these gradually -- don't want to disrupt any working flows at the moment.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
