### PR TITLE
ENG-0000 fix(portal): add quest set cards back to quest route

### DIFF
--- a/apps/portal/app/routes/app+/quest+/index.tsx
+++ b/apps/portal/app/routes/app+/quest+/index.tsx
@@ -17,18 +17,21 @@ import {
 import { ErrorPage } from '@components/error-page'
 import ExploreHeader from '@components/explore/ExploreHeader'
 import { PointsEarnedCard } from '@components/points-card/points-card'
+import { QuestSetCard } from '@components/quest/quest-set-card'
 import { QuestSetProgressCard } from '@components/quest/quest-set-progress-card'
 import { ReferralCard } from '@components/referral-card/referral-card'
 import RelicPointCard from '@components/relic-point-card/relic-point-card'
 import { invariant } from '@lib/utils/misc'
 import { LoaderFunctionArgs } from '@remix-run/node'
-import { Await, useLoaderData } from '@remix-run/react'
+import { Await, Link, useLoaderData } from '@remix-run/react'
 import { fetchWrapper } from '@server/api'
 import { requireUserWallet } from '@server/auth'
 import { getQuestsProgress } from '@server/quest'
 import {
   BLOCK_EXPLORER_URL,
+  COMING_SOON_QUEST_SET,
   HEADER_BANNER_HELP_CENTER,
+  QUEST_LOG_DESCRIPTION,
   STANDARD_QUEST_SET,
 } from 'app/consts'
 import { fetchProtocolFees } from 'app/lib/services/protocol'
@@ -195,6 +198,45 @@ export default function Quests() {
               )}
             </Await>
           </Suspense>
+        </div>
+        <div className="flex flex-col gap-10 max-md:gap-5">
+          <div className="space-y-5 max-md:space-y-3">
+            <Text variant="headline">Quest Log</Text>
+            <Text variant="body" className="text-foreground/70">
+              {QUEST_LOG_DESCRIPTION}
+            </Text>
+          </div>
+          <ul className="grid grid-cols-1 gap-10 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 max-md:gap-5">
+            <Suspense fallback={<Skeleton className="h-full w-full" />}>
+              <Await resolve={details}>
+                {(resolvedDetails) => (
+                  <Link to={STANDARD_QUEST_SET.navigatePath} prefetch="intent">
+                    <li className="col-span-1 h-full">
+                      <QuestSetCard
+                        imgSrc={STANDARD_QUEST_SET.imgSrc}
+                        title={STANDARD_QUEST_SET.title}
+                        description={STANDARD_QUEST_SET.description}
+                        numberQuests={resolvedDetails.numQuests}
+                        numberCompletedQuests={
+                          resolvedDetails.numCompletedQuests
+                        }
+                      />
+                    </li>
+                  </Link>
+                )}
+              </Await>
+            </Suspense>
+            <li className="col-span-1 h-full">
+              <QuestSetCard
+                disabled
+                imgSrc={COMING_SOON_QUEST_SET.imgSrc}
+                title={COMING_SOON_QUEST_SET.title}
+                description={COMING_SOON_QUEST_SET.description}
+                numberQuests={0}
+                numberCompletedQuests={0}
+              />
+            </li>
+          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Reintroduces the QuestSetCards which accidentally got deleted in points rework.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
