### PR TITLE
ENG-5345 feat(launchpad): troubleshoot knowledge graph build issue

### DIFF
--- a/apps/launchpad/vite.config.ts
+++ b/apps/launchpad/vite.config.ts
@@ -46,14 +46,7 @@ export default defineConfig({
     tsconfigPaths(),
   ],
   optimizeDeps: {
-    include: [
-      'cytoscape',
-      'cytoscape-cola',
-      'cytoscape-fcose',
-      'cytoscape-popper',
-      'react-cytoscapejs',
-    ],
-    exclude: ['@0xintuition/1ui'],
+    include: ['cytoscape', 'react-cytoscapejs'],
   },
   server: {
     port: 3000,
@@ -67,41 +60,11 @@ export default defineConfig({
         return false
       }
     },
-    rollupOptions: {
-      external: [],
-      output: {
-        manualChunks: {
-          cytoscape: ['cytoscape'],
-          'cytoscape-ext': [
-            'cytoscape-cola',
-            'cytoscape-fcose',
-            'cytoscape-popper',
-          ],
-          vendor: ['react', 'react-dom', 'react-cytoscapejs'],
-        },
-      },
-    },
-    modulePreload: {
-      polyfill: true,
-    },
+  },
+  ssr: {
+    noExternal: ['react-cytoscapejs', 'cytoscape'],
   },
   resolve: {
     dedupe: ['react', 'react-dom'],
-    mainFields: ['browser', 'module', 'main'],
-  },
-  ssr: {
-    noExternal: [
-      'react-cytoscapejs',
-      'cytoscape',
-      'cytoscape-cola',
-      'cytoscape-fcose',
-      'cytoscape-popper',
-    ],
-    optimizeDeps: {
-      disabled: false,
-    },
-  },
-  define: {
-    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
   },
 })


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Minimizes the `vite.config.ts` changes to work with the knowledge graph component.
- Builds locally (previously wasn't building) and is able to be served and run without issue via `pnpm start` from the `build` output in `launchpad` -- should be good now upon merge and redeployment.

## Screen Captures

This screenshot is accessed via the build output, not the dev server, so should mimic the Render deployment environment:

![network-built-served-locally](https://github.com/user-attachments/assets/ce97e0de-e5f8-4488-83ee-cde563e65d3b)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
