### PR TITLE
ENG-5376 feat(graphql): update constants.ts with new testnet deployment url

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xintuition/graphql",
   "description": "GraphQL",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/graphql/src/client.ts
+++ b/packages/graphql/src/client.ts
@@ -1,13 +1,13 @@
 import { GraphQLClient } from 'graphql-request'
 
-import { API_URL_DEV } from './constants'
+import { API_URL_PROD } from './constants'
 
 export interface ClientConfig {
   headers: HeadersInit
   apiUrl?: string
 }
 
-const DEFAULT_API_URL = API_URL_DEV
+const DEFAULT_API_URL = API_URL_PROD
 
 let globalConfig: { apiUrl?: string } = {
   apiUrl: DEFAULT_API_URL,

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -1,3 +1,4 @@
 export const API_URL_LOCAL = 'http://localhost:8080/v1/graphql'
-export const API_URL_DEV = 'https://dev.base.intuition-api.com/v1/graphql'
+export const API_URL_DEV =
+  'https://dev.base-sepolia.intuition-api.com/v1/graphql'
 export const API_URL_PROD = 'https://dev.base.intuition-api.com/v1/graphql'


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Updates the exported `API_URL_DEV` in `constants.ts` to use the new deployment URL
- Switches the default URL for the client as `API_URL_PROD` -- this is what it's been since Dev and Prod were the same URL
- Consumers can leverage the `configureClient` approach to override / set to `API_URL_DEV` in the consuming application: https://tech.docs.intuition.systems/dev/graphql-onboarding (the process is the same, but this page will be updated to note that the Dev/Prod URLs are now different)

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
