### PR TITLE
ENG-5353 ENG-5362 feat(launchpad): v0 scaffolding rewards route and mid-fi implementation

### DIFF
--- a/apps/launchpad/app/components/AppSidebar.tsx
+++ b/apps/launchpad/app/components/AppSidebar.tsx
@@ -30,6 +30,7 @@ import {
   Activity,
   Circle,
   FileText,
+  Gem,
   Github,
   Globe,
   Home,
@@ -100,6 +101,12 @@ export function AppSidebar({
       label: 'Network',
       href: '/network',
       isAccent: location.pathname === '/network',
+    },
+    {
+      icon: Gem,
+      label: 'Rewards',
+      href: '/rewards',
+      isAccent: location.pathname === '/rewards',
     },
   ]
 

--- a/apps/launchpad/app/components/aggregate-iq.tsx
+++ b/apps/launchpad/app/components/aggregate-iq.tsx
@@ -40,7 +40,7 @@ export function AggregateIQ({ totalIQ }: AggregateIQProps) {
       transition={{ duration: 0.5 }}
       whileHover={{ y: -5 }}
     >
-      <Card className="rounded-lg overflow-hidden shadow-xl bg-background border-border/10">
+      <Card className="rounded-lg overflow-hidden bg-background border border-border/10">
         <div className="absolute inset-0 bg-gradient-subtle opacity-70" />
         <div className="absolute inset-0 shadow-inner-pop" />
         <CardContent className="p-10 relative">
@@ -69,7 +69,7 @@ export function AggregateIQ({ totalIQ }: AggregateIQProps) {
               className="text-7xl font-bold tracking-tight"
               style={{
                 background:
-                  'linear-gradient(to right, var(--gradient-start, #E5E5E5), var(--gradient-end,#E6A068))',
+                  'linear-gradient(to right, var(--gradient-start, #E5E5E5), var(--gradient-end, #F59E11 ))',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent',
                 textShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',

--- a/apps/launchpad/app/components/aggregate-iq.tsx
+++ b/apps/launchpad/app/components/aggregate-iq.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+
+import { Card, CardContent } from '@0xintuition/1ui'
+
+import { motion, useAnimation } from 'framer-motion'
+import { Sparkles } from 'lucide-react'
+
+interface AggregateIQProps {
+  totalIQ: number
+}
+
+export function AggregateIQ({ totalIQ }: AggregateIQProps) {
+  const [count, setCount] = useState(0)
+  const controls = useAnimation()
+
+  useEffect(() => {
+    const duration = 2000
+    const steps = 60
+    const increment = totalIQ / steps
+    let current = 0
+
+    const timer = setInterval(() => {
+      current += increment
+      if (current >= totalIQ) {
+        clearInterval(timer)
+        setCount(totalIQ)
+        controls.start({ scale: [1, 1.05, 1], transition: { duration: 0.3 } })
+      } else {
+        setCount(Math.floor(current))
+      }
+    }, duration / steps)
+
+    return () => clearInterval(timer)
+  }, [totalIQ, controls])
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      whileHover={{ y: -5 }}
+    >
+      <Card
+        className="border-none overflow-hidden rounded-2xl shadow-pop-xl relative"
+        style={{
+          background: 'linear-gradient(135deg, #F5F5F5, #FFFFFF)',
+        }}
+      >
+        <div className="absolute inset-0 bg-gradient-subtle opacity-70" />
+        <div className="absolute inset-0 shadow-inner-pop" />
+        <CardContent className="p-10 relative">
+          <motion.div
+            className="flex items-start gap-4 mb-6"
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: 0.2, duration: 0.5 }}
+          >
+            <div className="p-3 rounded-xl bg-analytics-copper/10 shadow-pop-lg">
+              <Sparkles className="w-6 h-6 text-analytics-copper" />
+            </div>
+            <div>
+              <h3
+                className="text-2xl font-semibold text-analytics-shadow mb-1"
+                style={{ textShadow: '0 1px 2px rgba(0,0,0,0.1)' }}
+              >
+                Total Intuition IQ
+              </h3>
+              <p className="text-analytics-shadow/60">Across all skill trees</p>
+            </div>
+          </motion.div>
+
+          <motion.div className="relative" animate={controls}>
+            <span
+              className="text-7xl font-bold tracking-tight"
+              style={{
+                background: 'linear-gradient(to right, #2C2C2C, #D4A181)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+                textShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',
+              }}
+            >
+              {count.toLocaleString()}
+            </span>
+            <div className="mt-6 grid grid-cols-3 gap-4">
+              {[
+                { label: 'Daily Gain', value: '+124' },
+                { label: 'Weekly Average', value: '+892' },
+                { label: 'Rank', value: '#42' },
+              ].map((stat) => (
+                <div
+                  key={stat.label}
+                  className="bg-analytics-white p-4 rounded-xl shadow-pop-lg"
+                >
+                  <div className="text-sm text-analytics-shadow/60 mb-1">
+                    {stat.label}
+                  </div>
+                  <div className="text-lg font-semibold text-analytics-copper">
+                    {stat.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}

--- a/apps/launchpad/app/components/aggregate-iq.tsx
+++ b/apps/launchpad/app/components/aggregate-iq.tsx
@@ -40,7 +40,7 @@ export function AggregateIQ({ totalIQ }: AggregateIQProps) {
       transition={{ duration: 0.5 }}
       whileHover={{ y: -5 }}
     >
-      <Card className="theme-border rounded-lg overflow-hidden shadow-xl bg-background">
+      <Card className="rounded-lg overflow-hidden shadow-xl bg-background border-border/10">
         <div className="absolute inset-0 bg-gradient-subtle opacity-70" />
         <div className="absolute inset-0 shadow-inner-pop" />
         <CardContent className="p-10 relative">
@@ -69,7 +69,7 @@ export function AggregateIQ({ totalIQ }: AggregateIQProps) {
               className="text-7xl font-bold tracking-tight"
               style={{
                 background:
-                  'linear-gradient(to right, var(--gradient-start, #E5E5E5), var(--gradient-end, #B88E6E))',
+                  'linear-gradient(to right, var(--gradient-start, #E5E5E5), var(--gradient-end,#E6A068))',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent',
                 textShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',

--- a/apps/launchpad/app/components/aggregate-iq.tsx
+++ b/apps/launchpad/app/components/aggregate-iq.tsx
@@ -40,12 +40,7 @@ export function AggregateIQ({ totalIQ }: AggregateIQProps) {
       transition={{ duration: 0.5 }}
       whileHover={{ y: -5 }}
     >
-      <Card
-        className="border-none overflow-hidden rounded-2xl shadow-pop-xl relative"
-        style={{
-          background: 'linear-gradient(135deg, #F5F5F5, #FFFFFF)',
-        }}
-      >
+      <Card className="theme-border rounded-lg overflow-hidden shadow-xl bg-background">
         <div className="absolute inset-0 bg-gradient-subtle opacity-70" />
         <div className="absolute inset-0 shadow-inner-pop" />
         <CardContent className="p-10 relative">
@@ -73,7 +68,8 @@ export function AggregateIQ({ totalIQ }: AggregateIQProps) {
             <span
               className="text-7xl font-bold tracking-tight"
               style={{
-                background: 'linear-gradient(to right, #2C2C2C, #D4A181)',
+                background:
+                  'linear-gradient(to right, var(--gradient-start, #E5E5E5), var(--gradient-end, #B88E6E))',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent',
                 textShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',

--- a/apps/launchpad/app/components/chart.tsx
+++ b/apps/launchpad/app/components/chart.tsx
@@ -1,0 +1,20 @@
+// TODO: This is from shadcn/ui. We should move this to 1ui along with other new components
+
+import * as React from 'react'
+
+interface ChartProps extends React.HTMLAttributes<HTMLDivElement> {
+  config?: Record<string, any>
+}
+
+const ChartContainer = React.forwardRef<HTMLDivElement, ChartProps>(
+  ({ className, children, config, ...props }, ref) => {
+    return (
+      <div ref={ref} className={className} {...props}>
+        {children}
+      </div>
+    )
+  },
+)
+ChartContainer.displayName = 'ChartContainer'
+
+export { ChartContainer }

--- a/apps/launchpad/app/components/chart.tsx
+++ b/apps/launchpad/app/components/chart.tsx
@@ -2,19 +2,365 @@
 
 import * as React from 'react'
 
-interface ChartProps extends React.HTMLAttributes<HTMLDivElement> {
-  config?: Record<string, any>
+import { cn } from '@0xintuition/1ui'
+
+import * as RechartsPrimitive from 'recharts'
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: '', dark: '.dark' } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
 }
 
-const ChartContainer = React.forwardRef<HTMLDivElement, ChartProps>(
-  ({ className, children, config, ...props }, ref) => {
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error('useChart must be used within a <ChartContainer />')
+  }
+
+  return context
+}
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> & {
+    config: ChartConfig
+    children: React.ComponentProps<
+      typeof RechartsPrimitive.ResponsiveContainer
+    >['children']
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+})
+ChartContainer.displayName = 'Chart'
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color,
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join('\n')}
+}
+`,
+          )
+          .join('\n'),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<'div'> & {
+      hideLabel?: boolean
+      hideIndicator?: boolean
+      indicator?: 'line' | 'dot' | 'dashed'
+      nameKey?: string
+      labelKey?: string
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = 'dot',
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref,
+  ) => {
+    const { config } = useChart()
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null
+      }
+
+      const [item] = payload
+      const key = `${labelKey || item.dataKey || item.name || 'value'}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const value =
+        !labelKey && typeof label === 'string'
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label
+
+      if (labelFormatter) {
+        return (
+          <div className={cn('font-medium', labelClassName)}>
+            {labelFormatter(value, payload)}
+          </div>
+        )
+      }
+
+      if (!value) {
+        return null
+      }
+
+      return <div className={cn('font-medium', labelClassName)}>{value}</div>
+    }, [
+      label,
+      labelFormatter,
+      payload,
+      hideLabel,
+      labelClassName,
+      config,
+      labelKey,
+    ])
+
+    if (!active || !payload?.length) {
+      return null
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== 'dot'
+
     return (
-      <div ref={ref} className={className} {...props}>
-        {children}
+      <div
+        ref={ref}
+        className={cn(
+          'grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl',
+          className,
+        )}
+      >
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload.map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || 'value'}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color || item.payload.fill || item.color
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
+                  indicator === 'dot' && 'items-center',
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            'shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]',
+                            {
+                              'h-2.5 w-2.5': indicator === 'dot',
+                              'w-1': indicator === 'line',
+                              'w-0 border-[1.5px] border-dashed bg-transparent':
+                                indicator === 'dashed',
+                              'my-0.5': nestLabel && indicator === 'dashed',
+                            },
+                          )}
+                          style={
+                            {
+                              '--color-bg': indicatorColor,
+                              '--color-border': indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        'flex flex-1 justify-between leading-none',
+                        nestLabel ? 'items-end' : 'items-center',
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+        </div>
       </div>
     )
   },
 )
-ChartContainer.displayName = 'ChartContainer'
+ChartTooltipContent.displayName = 'ChartTooltip'
 
-export { ChartContainer }
+const ChartLegend = RechartsPrimitive.Legend
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> &
+    Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
+      hideIcon?: boolean
+      nameKey?: string
+    }
+>(
+  (
+    { className, hideIcon = false, payload, verticalAlign = 'bottom', nameKey },
+    ref,
+  ) => {
+    const { config } = useChart()
+
+    if (!payload?.length) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex items-center justify-center gap-4',
+          verticalAlign === 'top' ? 'pb-3' : 'pt-3',
+          className,
+        )}
+      >
+        {payload.map((item) => {
+          const key = `${nameKey || item.dataKey || 'value'}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                'flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground',
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+      </div>
+    )
+  },
+)
+ChartLegendContent.displayName = 'ChartLegend'
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string,
+) {
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    'payload' in payload &&
+    typeof payload.payload === 'object' &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === 'string'
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/apps/launchpad/app/components/skill-modal.tsx
+++ b/apps/launchpad/app/components/skill-modal.tsx
@@ -1,0 +1,94 @@
+import { Dialog, DialogContent, Progress } from '@0xintuition/1ui'
+
+import { Skill, SkillLevel } from 'app/types/rewards'
+
+interface SkillModalProps {
+  skill: Skill | null
+  isOpen: boolean
+  onClose: () => void
+  levels: SkillLevel[]
+}
+
+export function SkillModal({
+  skill,
+  isOpen,
+  onClose,
+  levels,
+}: SkillModalProps) {
+  if (!skill) {
+    return null
+  }
+
+  const currentPoints = Math.floor(skill.points || 0)
+  const maxPoints = Math.max(
+    ...(levels?.map((level) => level.pointsThreshold) || [0]),
+  )
+  const progress = (currentPoints / maxPoints) * 100
+
+  const currentLevel = levels
+    ? levels.findIndex((level) => currentPoints < level.pointsThreshold) - 1
+    : -1
+  const nextLevel = Math.min(currentLevel + 1, levels ? levels.length - 1 : 0)
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[600px] bg-black text-white border-gray-800">
+        <div className="space-y-6">
+          {/* Header */}
+          <div className="flex items-center gap-4">
+            <div className="w-12 h-12 rounded-full bg-gray-800" />
+            <div>
+              <h2 className="text-2xl font-bold">{skill.name}</h2>
+              <p className="text-dune-copper">
+                {currentPoints.toLocaleString()} Points
+              </p>
+            </div>
+          </div>
+
+          {/* Progress Bar */}
+          <div className="space-y-2">
+            <Progress value={progress} className="h-2 bg-gray-800" />
+            <div className="flex justify-between text-sm text-gray-400">
+              <span>{currentPoints.toLocaleString()}</span>
+              <span>{maxPoints.toLocaleString()}</span>
+            </div>
+          </div>
+
+          {/* Level Progression */}
+          <div className="flex justify-between items-center pt-4">
+            {levels?.map((level, index) => (
+              <div key={index} className="flex flex-col items-center gap-2">
+                <div
+                  className={`
+                  relative w-16 h-16 rounded-full flex items-center justify-center
+                  ${index <= currentLevel ? 'ring-2 ring-green-500' : ''}
+                  ${index === nextLevel ? 'ring-2 ring-blue-500' : ''}
+                  ${index > nextLevel ? 'bg-gray-800' : 'bg-gray-900'}
+                `}
+                >
+                  {index <= nextLevel ? (
+                    <span className="text-2xl font-bold">{level.asset}</span>
+                  ) : (
+                    <span className="text-gray-600">🔒</span>
+                  )}
+                  {index === nextLevel && (
+                    <div
+                      className="absolute inset-0 rounded-full border-4 border-blue-500"
+                      style={{
+                        clipPath: `polygon(0 0, 100% 0, 100% ${progress}%, 0 ${progress}%)`,
+                      }}
+                    />
+                  )}
+                </div>
+                <span className="text-sm font-medium">{level.name}</span>
+                <span className="text-sm text-dune-copper">
+                  {level.pointsThreshold.toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/launchpad/app/components/skill-modal.tsx
+++ b/apps/launchpad/app/components/skill-modal.tsx
@@ -1,6 +1,15 @@
-import { Dialog, DialogContent, Progress } from '@0xintuition/1ui'
+import { Dialog, DialogContent, DialogTitle, Text } from '@0xintuition/1ui'
 
-import { Skill, SkillLevel } from 'app/types/rewards'
+interface Skill {
+  name: string
+  points: number
+}
+
+interface SkillLevel {
+  name: string
+  pointsThreshold: number
+  asset?: string // Optional asset to show instead of roman numeral
+}
 
 interface SkillModalProps {
   skill: Skill | null
@@ -8,6 +17,26 @@ interface SkillModalProps {
   onClose: () => void
   levels: SkillLevel[]
 }
+
+const LockIcon = () => (
+  <svg
+    width="34"
+    height="42"
+    viewBox="0 0 34 42"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-12 h-12"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M16.9897 0.0743408C11.2367 0.0743408 6.573 4.738 6.573 10.491V14.6577H0.323V41.741H33.6563V14.6577H27.4063V10.491C27.4063 4.738 22.7426 0.0743408 16.9897 0.0743408ZM24.2813 14.6577V10.491C24.2813 6.46391 21.0168 3.19934 16.9897 3.19934C12.9626 3.19934 9.698 6.46391 9.698 10.491V14.6577H24.2813ZM18.5522 23.5118V32.8868H15.4272V23.5118H18.5522Z"
+      fill="#313131"
+    />
+  </svg>
+)
+
+const romanNumerals = ['I', 'II', 'III', 'IV', 'V', 'VI']
 
 export function SkillModal({
   skill,
@@ -20,70 +49,121 @@ export function SkillModal({
   }
 
   const currentPoints = Math.floor(skill.points || 0)
-  const maxPoints = Math.max(
-    ...(levels?.map((level) => level.pointsThreshold) || [0]),
-  )
-  const progress = (currentPoints / maxPoints) * 100
 
-  const currentLevel = levels
-    ? levels.findIndex((level) => currentPoints < level.pointsThreshold) - 1
-    : -1
-  const nextLevel = Math.min(currentLevel + 1, levels ? levels.length - 1 : 0)
+  // Find current level based on points
+  const currentLevel = levels.reduce((acc, level, index) => {
+    if (currentPoints >= level.pointsThreshold) {
+      return index
+    }
+    return acc
+  }, -1)
+
+  // Calculate progress percentage for current level
+  const nextLevelThreshold = levels[currentLevel + 1]?.pointsThreshold
+  const currentLevelThreshold = levels[currentLevel]?.pointsThreshold || 0
+  const progressPercentage = nextLevelThreshold
+    ? ((currentPoints - currentLevelThreshold) /
+        (nextLevelThreshold - currentLevelThreshold)) *
+      100
+    : 100
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[600px] bg-black text-white border-gray-800">
-        <div className="space-y-6">
+      <DialogContent className="sm:max-w-[800px] bg-black text-white border-gray-800">
+        {/* <DialogClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogClose> */}
+        <DialogTitle>Skill Progression</DialogTitle>
+        <div className="space-y-8">
           {/* Header */}
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 rounded-full bg-gray-800" />
-            <div>
-              <h2 className="text-2xl font-bold">{skill.name}</h2>
-              <p className="text-dune-copper">
-                {currentPoints.toLocaleString()} Points
-              </p>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <div className="w-16 h-16 rounded-full bg-gray-800" />
+              <div>
+                <div className="flex items-center gap-2">
+                  <Text
+                    variant="heading4"
+                    weight="normal"
+                    className="text-foreground"
+                  >
+                    {skill.name}: {levels[currentLevel + 1]?.name}
+                  </Text>
+                </div>
+                <Text
+                  variant="headline"
+                  weight="normal"
+                  className="text-amber-500"
+                >
+                  {currentPoints.toLocaleString()} Points
+                </Text>
+              </div>
             </div>
-          </div>
-
-          {/* Progress Bar */}
-          <div className="space-y-2">
-            <Progress value={progress} className="h-2 bg-gray-800" />
-            <div className="flex justify-between text-sm text-gray-400">
-              <span>{currentPoints.toLocaleString()}</span>
-              <span>{maxPoints.toLocaleString()}</span>
+            <div className="flex items-center gap-2">
+              <div className="h-2 w-32 bg-gray-800 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-blue-500 transition-all duration-300"
+                  style={{
+                    width: `${Math.min(Math.max(progressPercentage, 0), 100)}%`,
+                  }}
+                />
+              </div>
+              <Text className="text-gray-400">
+                {(currentPoints - currentLevelThreshold).toLocaleString()} /{' '}
+                {(nextLevelThreshold - currentLevelThreshold).toLocaleString()}
+              </Text>
+              <div className="ml-2 w-8 h-8 rounded-full bg-black border border-gray-800 flex items-center justify-center text-sm font-serif">
+                {romanNumerals[currentLevel + 1]}
+              </div>
             </div>
           </div>
 
           {/* Level Progression */}
-          <div className="flex justify-between items-center pt-4">
+          <div className="flex justify-between items-center gap-4">
             {levels?.map((level, index) => (
-              <div key={index} className="flex flex-col items-center gap-2">
-                <div
-                  className={`
-                  relative w-16 h-16 rounded-full flex items-center justify-center
-                  ${index <= currentLevel ? 'ring-2 ring-green-500' : ''}
-                  ${index === nextLevel ? 'ring-2 ring-blue-500' : ''}
-                  ${index > nextLevel ? 'bg-gray-800' : 'bg-gray-900'}
-                `}
-                >
-                  {index <= nextLevel ? (
-                    <span className="text-2xl font-bold">{level.asset}</span>
-                  ) : (
-                    <span className="text-gray-600">🔒</span>
-                  )}
-                  {index === nextLevel && (
-                    <div
-                      className="absolute inset-0 rounded-full border-4 border-blue-500"
-                      style={{
-                        clipPath: `polygon(0 0, 100% 0, 100% ${progress}%, 0 ${progress}%)`,
-                      }}
-                    />
+              <div key={index} className="flex flex-col items-center gap-3">
+                <div className="relative">
+                  <div
+                    className={`
+                      relative w-20 h-20 rounded-full flex items-center justify-center border-4
+                      ${index <= currentLevel ? 'border-green-500 bg-black' : ''}
+                      ${index === currentLevel + 1 ? 'border-gray-800 bg-black' : ''}
+                      ${index > currentLevel + 1 ? 'border-gray-800 bg-black' : ''}
+                    `}
+                  >
+                    {index <= currentLevel + 1 ? (
+                      <span className="text-4xl font-serif text-center">
+                        {level.asset || romanNumerals[index]}
+                      </span>
+                    ) : (
+                      <div className="flex items-center justify-center w-full h-full">
+                        <LockIcon />
+                      </div>
+                    )}
+                  </div>
+                  {index === currentLevel + 1 && (
+                    <svg
+                      className="absolute inset-0 w-20 h-20 -rotate-90"
+                      viewBox="0 0 100 100"
+                    >
+                      <circle
+                        className="text-blue-500"
+                        strokeWidth="4"
+                        stroke="currentColor"
+                        fill="transparent"
+                        r="48"
+                        cx="50"
+                        cy="50"
+                        strokeDasharray={`${progressPercentage * 3.02} 302`}
+                        strokeLinecap="round"
+                      />
+                    </svg>
                   )}
                 </div>
-                <span className="text-sm font-medium">{level.name}</span>
-                <span className="text-sm text-dune-copper">
+                <Text className="font-medium uppercase">{level.name}</Text>
+                <Text className="text-[#E6A57E]">
                   {level.pointsThreshold.toLocaleString()}
-                </span>
+                </Text>
               </div>
             ))}
           </div>

--- a/apps/launchpad/app/components/skill-radar-chart.tsx
+++ b/apps/launchpad/app/components/skill-radar-chart.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+
+import { ChartContainer } from '@components/chart'
+import { Skill } from 'app/types/rewards'
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+} from 'recharts'
+
+import { SkillModal } from './skill-modal'
+
+interface SkillRadarChartProps {
+  skills: Skill[]
+}
+
+export function SkillRadarChart({ skills }: SkillRadarChartProps) {
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const chartData = skills.map((skill) => ({
+    subject: skill.name,
+    A: skill.points,
+    fullMark: Math.max(...skills.map((s) => s.points)) * 1.2,
+    originalSkill: skill, // Store the original skill data for the click handler
+  }))
+
+  const handleClick = (data: any) => {
+    if (data && data.payload && data.payload.originalSkill) {
+      setSelectedSkill(data.payload.originalSkill)
+      setIsModalOpen(true)
+    }
+  }
+
+  return (
+    <>
+      <ChartContainer
+        config={{
+          A: {
+            label: 'Points',
+            color: 'hsl(var(--chart-1))',
+          },
+        }}
+        className="w-full h-[400px]"
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <RadarChart
+            cx="50%"
+            cy="50%"
+            outerRadius="90%"
+            data={chartData}
+            margin={{ top: 20, right: 30, bottom: 20, left: 30 }}
+          >
+            <PolarGrid />
+            <PolarAngleAxis
+              dataKey="subject"
+              tick={({ x, y, payload }) => (
+                <g transform={`translate(${x},${y})`}>
+                  <text
+                    x={0}
+                    y={0}
+                    dy={3}
+                    textAnchor="middle"
+                    fill="currentColor"
+                    className="cursor-pointer"
+                    onClick={() => {
+                      const skill = skills.find((s) => s.name === payload.value)
+                      if (skill) {
+                        setSelectedSkill(skill)
+                        setIsModalOpen(true)
+                      }
+                    }}
+                  >
+                    {payload.value}
+                  </text>
+                </g>
+              )}
+            />
+            <Radar
+              name="Skills"
+              dataKey="A"
+              stroke="var(--color-A)"
+              fill="pink"
+              fillOpacity={0.6}
+            />
+          </RadarChart>
+        </ResponsiveContainer>
+      </ChartContainer>
+
+      {selectedSkill && (
+        <SkillModal
+          skill={selectedSkill}
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          levels={[
+            { name: 'Novice', asset: '1', pointsThreshold: 1000 },
+            { name: 'Apprentice', asset: '2', pointsThreshold: 5000 },
+            { name: 'Adept', asset: '3', pointsThreshold: 10000 },
+            { name: 'Expert', asset: '4', pointsThreshold: 20000 },
+            { name: 'Master', asset: '5', pointsThreshold: 35000 },
+            { name: 'Grandmaster', asset: '6', pointsThreshold: 50000 },
+          ]}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/launchpad/app/components/skill-radar-chart.tsx
+++ b/apps/launchpad/app/components/skill-radar-chart.tsx
@@ -27,13 +27,6 @@ export function SkillRadarChart({ skills }: SkillRadarChartProps) {
     originalSkill: skill, // Store the original skill data for the click handler
   }))
 
-  const handleClick = (data: any) => {
-    if (data && data.payload && data.payload.originalSkill) {
-      setSelectedSkill(data.payload.originalSkill)
-      setIsModalOpen(true)
-    }
-  }
-
   return (
     <>
       <ChartContainer
@@ -78,13 +71,7 @@ export function SkillRadarChart({ skills }: SkillRadarChartProps) {
                 </g>
               )}
             />
-            <Radar
-              name="Skills"
-              dataKey="A"
-              stroke="var(--color-A)"
-              fill="pink"
-              fillOpacity={0.6}
-            />
+            <Radar name="Skills" dataKey="A" fill="#E6A068" fillOpacity={0.6} />
           </RadarChart>
         </ResponsiveContainer>
       </ChartContainer>

--- a/apps/launchpad/app/components/skill-radar-chart.tsx
+++ b/apps/launchpad/app/components/skill-radar-chart.tsx
@@ -8,12 +8,34 @@ import {
   Radar,
   RadarChart,
   ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
 } from 'recharts'
 
 import { SkillModal } from './skill-modal'
 
 interface SkillRadarChartProps {
   skills: Skill[]
+}
+
+interface ChartData {
+  subject: string
+  A: number
+  fullMark: number
+  originalSkill: Skill
+}
+
+const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
+  if (active && payload && payload.length) {
+    const data = payload[0].payload as ChartData
+    return (
+      <div className="bg-background border rounded-lg p-2 shadow-lg">
+        <p className="font-medium">{data.subject}</p>
+        <p className="text-sm text-muted-foreground">Points: {data.A}</p>
+      </div>
+    )
+  }
+  return null
 }
 
 export function SkillRadarChart({ skills }: SkillRadarChartProps) {
@@ -24,7 +46,7 @@ export function SkillRadarChart({ skills }: SkillRadarChartProps) {
     subject: skill.name,
     A: skill.points,
     fullMark: Math.max(...skills.map((s) => s.points)) * 1.2,
-    originalSkill: skill, // Store the original skill data for the click handler
+    originalSkill: skill,
   }))
 
   return (
@@ -56,8 +78,8 @@ export function SkillRadarChart({ skills }: SkillRadarChartProps) {
                     y={0}
                     dy={3}
                     textAnchor="middle"
-                    fill="currentColor"
-                    className="cursor-pointer"
+                    fill="#BA8461"
+                    className="cursor-pointer text-lg"
                     onClick={() => {
                       const skill = skills.find((s) => s.name === payload.value)
                       if (skill) {
@@ -71,7 +93,18 @@ export function SkillRadarChart({ skills }: SkillRadarChartProps) {
                 </g>
               )}
             />
-            <Radar name="Skills" dataKey="A" fill="#E6A068" fillOpacity={0.6} />
+            <Tooltip content={<CustomTooltip />} />
+            <Radar
+              name="Skills"
+              dataKey="A"
+              fill="#F59E11"
+              fillOpacity={0.6}
+              dot={{
+                r: 4,
+                fillOpacity: 1,
+                fill: '#F59E11',
+              }}
+            />
           </RadarChart>
         </ResponsiveContainer>
       </ChartContainer>

--- a/apps/launchpad/app/data/mock-rewards.ts
+++ b/apps/launchpad/app/data/mock-rewards.ts
@@ -48,4 +48,13 @@ export const skills: Skill[] = [
     description: 'Build and nurture web3 communities and DAOs.',
     recentAchievement: 'Founded a new DAO initiative',
   },
+  {
+    name: 'Analytics',
+    level: 1,
+    progress: 20,
+    pointsToNext: 5,
+    points: 180.0,
+    description: 'Analyze and interpret data from various web3 sources.',
+    recentAchievement: 'Created first data visualization dashboard',
+  },
 ]

--- a/apps/launchpad/app/data/mock-rewards.ts
+++ b/apps/launchpad/app/data/mock-rewards.ts
@@ -1,0 +1,51 @@
+import { Skill } from 'app/types/rewards'
+
+export const skills: Skill[] = [
+  {
+    name: 'Portal',
+    level: 1,
+    progress: 33,
+    pointsToNext: 3,
+    points: 404.18,
+    description:
+      'Master the art of portal creation and interdimensional travel.',
+    recentAchievement: 'Created first stable portal connection',
+  },
+  {
+    name: 'Quests',
+    level: 1,
+    progress: 45,
+    pointsToNext: 4,
+    points: 325.5,
+    description: 'Complete challenges and missions across the metaverse.',
+    recentAchievement: 'Completed a legendary quest chain',
+  },
+  {
+    name: 'Protocol',
+    level: 1,
+    progress: 60,
+    pointsToNext: 2,
+    points: 286.3,
+    description:
+      'Understand and implement blockchain protocols and smart contracts.',
+    recentAchievement: 'Deployed first smart contract',
+  },
+  {
+    name: 'NFT',
+    level: 1,
+    progress: 25,
+    pointsToNext: 5,
+    points: 195.75,
+    description: 'Create and trade unique digital assets and collections.',
+    recentAchievement: 'Minted first NFT collection',
+  },
+  {
+    name: 'Community',
+    level: 1,
+    progress: 15,
+    pointsToNext: 6,
+    points: 150.2,
+    description: 'Build and nurture web3 communities and DAOs.',
+    recentAchievement: 'Founded a new DAO initiative',
+  },
+]

--- a/apps/launchpad/app/routes/_app+/rewards.tsx
+++ b/apps/launchpad/app/routes/_app+/rewards.tsx
@@ -1,20 +1,11 @@
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@0xintuition/1ui'
+import { Avatar, Button } from '@0xintuition/1ui'
 
 import { AggregateIQ } from '@components/aggregate-iq'
 import { ErrorPage } from '@components/ErrorPage'
 import { SkillRadarChart } from '@components/skill-radar-chart'
 import { skills } from 'app/data/mock-rewards'
 import { motion } from 'framer-motion'
-import { ChevronRight, Link, Share2, Users } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 
 export function ErrorBoundary() {
   return <ErrorPage routeName="rewards" />
@@ -30,7 +21,7 @@ export default function Rewards() {
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
-        className="flex justify-between items-center bg-gradient-to-r from-dune-sand to-dune-tan rounded-2xl p-6 text-dune-stone shadow-pop-lg"
+        className="flex justify-between items-center bg-background/95 rounded-2xl p-6 text-palette-neutral-900 shadow-pop-lg"
       >
         <div>
           <motion.h1

--- a/apps/launchpad/app/routes/_app+/rewards.tsx
+++ b/apps/launchpad/app/routes/_app+/rewards.tsx
@@ -21,7 +21,7 @@ export default function Rewards() {
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
-        className="flex justify-between items-center bg-background/95 rounded-2xl p-6 text-palette-neutral-900 shadow-pop-lg"
+        className="flex justify-between items-center bg-background border border-border/10 rounded-lg p-6 text-palette-neutral-900 shadow-pop-lg"
       >
         <div>
           <motion.h1
@@ -51,7 +51,7 @@ export default function Rewards() {
       </motion.div>
       <AggregateIQ totalIQ={totalIQ} />
 
-      <div className="space-y-6">
+      <div className="space-y-6 bg-background border border-border/10 rounded-lg p-6">
         <div className="flex justify-between items-center">
           <h2 className="text-3xl font-bold">Your Skills</h2>
           <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>

--- a/apps/launchpad/app/routes/_app+/rewards.tsx
+++ b/apps/launchpad/app/routes/_app+/rewards.tsx
@@ -11,6 +11,7 @@ import {
 
 import { AggregateIQ } from '@components/aggregate-iq'
 import { ErrorPage } from '@components/ErrorPage'
+import { SkillRadarChart } from '@components/skill-radar-chart'
 import { skills } from 'app/data/mock-rewards'
 import { motion } from 'framer-motion'
 import { ChevronRight, Link, Share2, Users } from 'lucide-react'
@@ -76,8 +77,11 @@ export default function Rewards() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
+          className="flex justify-center items-center"
         >
-          {/* <RadialSkillTree skills={skills} /> */}
+          <div className="w-full max-w-2xl">
+            <SkillRadarChart skills={skills} />
+          </div>
         </motion.div>
       </div>
     </div>

--- a/apps/launchpad/app/routes/_app+/rewards.tsx
+++ b/apps/launchpad/app/routes/_app+/rewards.tsx
@@ -1,0 +1,85 @@
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@0xintuition/1ui'
+
+import { AggregateIQ } from '@components/aggregate-iq'
+import { ErrorPage } from '@components/ErrorPage'
+import { skills } from 'app/data/mock-rewards'
+import { motion } from 'framer-motion'
+import { ChevronRight, Link, Share2, Users } from 'lucide-react'
+
+export function ErrorBoundary() {
+  return <ErrorPage routeName="rewards" />
+}
+
+const totalIQ = skills.reduce((sum, skill) => sum + skill.points, 0)
+const user = { name: 'JP', avatar: '/placeholder.svg?height=40&width=40' }
+
+export default function Rewards() {
+  return (
+    <div className="space-y-8 text-foreground p-8">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="flex justify-between items-center bg-gradient-to-r from-dune-sand to-dune-tan rounded-2xl p-6 text-dune-stone shadow-pop-lg"
+      >
+        <div>
+          <motion.h1
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.2, duration: 0.5 }}
+            className="text-3xl font-bold mb-2"
+          >
+            Welcome back, {user.name}!
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.4, duration: 0.5 }}
+            className="text-lg opacity-90"
+          >
+            Ready to boost your Intuition today?
+          </motion.p>
+        </div>
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+        >
+          <Avatar className="w-24 h-24" src={user.avatar} name={user.name} />
+        </motion.div>
+      </motion.div>
+      <AggregateIQ totalIQ={totalIQ} />
+
+      <div className="space-y-6">
+        <div className="flex justify-between items-center">
+          <h2 className="text-3xl font-bold">Your Skills</h2>
+          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+            <Button variant="primary" size="lg">
+              View All Skills
+              <ChevronRight className="ml-2 h-5 w-5" />
+            </Button>
+          </motion.div>
+        </div>
+        <p className="text-lg">
+          Master your abilities and unlock your full potential
+        </p>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+        >
+          {/* <RadialSkillTree skills={skills} /> */}
+        </motion.div>
+      </div>
+    </div>
+  )
+}

--- a/apps/launchpad/app/routes/_index.tsx
+++ b/apps/launchpad/app/routes/_index.tsx
@@ -1,3 +1,5 @@
-export default function Index() {
-  return <div>Home Page</div>
+import { redirect } from '@remix-run/node'
+
+export async function loader() {
+  throw redirect('/dashboard')
 }

--- a/apps/launchpad/app/types/rewards.ts
+++ b/apps/launchpad/app/types/rewards.ts
@@ -1,0 +1,9 @@
+export interface Skill {
+  name: string
+  level: number
+  progress: number
+  pointsToNext: number
+  points: number
+  description: string
+  recentAchievement: string
+}

--- a/apps/launchpad/app/types/rewards.ts
+++ b/apps/launchpad/app/types/rewards.ts
@@ -6,4 +6,19 @@ export interface Skill {
   points: number
   description: string
   recentAchievement: string
+  currentPoints?: number
+  requiredPoints?: number
+}
+
+export interface SkillLevel {
+  name: string
+  asset: string
+  pointsThreshold: number
+}
+
+export interface SkillModalProps {
+  skill: Skill | null
+  isOpen: boolean
+  onClose: () => void
+  levels: SkillLevel[]
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Updates routing for `/` to redirect to `/dashboard` and updates `AppSidebar` to include the _Rewards_
- Adds `/rewards` route and brings in v0 scaffolding -- iterated on this in v0 and then moved into Launchpad after tweaking things there
- Adds in points data structure and mock data that is then passed into the `<AggregateIQ/>`  and `<SkillRadarChart/>` components
- Adds a tooltip on hover that shows point breakdown for each section of the radar chart
- On clicking the skill name, opens the 'rewards' modal that shows progress (still tweaking this modal a bit to make more reusable)
- _View All Skills_ button is a placeholder -- will add routing and detail pages for those after the preferences work
- Aims for a mid-fi implementation -- pulls in some elements from #1020 to start aligning with our theme and Figma

## Screen Captures

![launchpad-rewards-mid-fi](https://github.com/user-attachments/assets/fdecc608-0ff1-4ad7-9b92-8600eca77d5d)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
