### PR TITLE
Fix visual bug : Allow the switch knob to go all the way to the left when the switch button is off

### DIFF
--- a/packages/1ui/src/components/Switch/Switch.tsx
+++ b/packages/1ui/src/components/Switch/Switch.tsx
@@ -10,7 +10,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 p-[0.5px] cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-primary/40',
+      'peer inline-flex h-6 w-11 shrink-0 p-[0.5px] cursor-pointer items-center rounded-full border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-primary/40',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [x] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools


## Screen Captures
-before : 
![image](https://github.com/user-attachments/assets/2868be05-e09e-4ae7-97db-2ae8e70a8fe0)

-after : 
![image](https://github.com/user-attachments/assets/dcaf7333-3861-4c62-8300-6cfd5baa44e2)


## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
