### PR TITLE
ENG-5457 feat(graphql): package parity with main

### DIFF
--- a/packages/graphql/codegen.ts
+++ b/packages/graphql/codegen.ts
@@ -36,7 +36,18 @@ const commonGenerateOptions: Types.ConfiguredOutput = {
 const config: CodegenConfig = {
   overwrite: true,
   hooks: { afterAllFileWrite: ['prettier --write'] },
-  schema: process.env.HASURA_PROJECT_ENDPOINT || API_URL_DEV,
+  // Try local schema first, fall back to remote if needed
+  schema: [
+    './schema.graphql',
+    {
+      [API_URL_DEV]: {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    },
+  ],
   ignoreNoDocuments: true,
   documents: ['**/*.graphql'],
   generates: {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xintuition/graphql",
   "description": "GraphQL",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -41,7 +41,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@0xintuition/api": "workspace:^",
     "@graphql-codegen/typescript-document-nodes": "^4.0.11",
     "@tanstack/react-query": "^5.32.0",
     "graphql": "^16.9.0",

--- a/packages/graphql/src/client.ts
+++ b/packages/graphql/src/client.ts
@@ -1,13 +1,13 @@
 import { GraphQLClient } from 'graphql-request'
 
-import { API_URL_DEV } from './constants'
+import { API_URL_PROD } from './constants'
 
 export interface ClientConfig {
   headers: HeadersInit
   apiUrl?: string
 }
 
-const DEFAULT_API_URL = API_URL_DEV
+const DEFAULT_API_URL = API_URL_PROD
 
 let globalConfig: { apiUrl?: string } = {
   apiUrl: DEFAULT_API_URL,

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -1,4 +1,4 @@
-// dev and prod api url is currently the same
 export const API_URL_LOCAL = 'http://localhost:8080/v1/graphql'
-export const API_URL_DEV = 'https://dev.base.intuition-api.com/v1/graphql'
+export const API_URL_DEV =
+  'https://dev.base-sepolia.intuition-api.com/v1/graphql'
 export const API_URL_PROD = 'https://dev.base.intuition-api.com/v1/graphql'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,9 +1163,6 @@ importers:
 
   packages/graphql:
     dependencies:
-      '@0xintuition/api':
-        specifier: workspace:^
-        version: link:../api
       '@graphql-codegen/typescript-document-nodes':
         specifier: ^4.0.11
         version: 4.0.11(encoding@0.1.13)(graphql@16.9.0)


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- We had some drift where the most recent changes from the GraphQL package on `main` weren't brought in
- This brings these updates in. Most notably the `codegen.ts` process and the `constants.ts` with the updated API URLs. 
- Tested the `configureClient` in Launchpad after this change and it works -- the `getStats` query returned two different sets of results based on the configured override.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
