### PR TITLE
ENG-5432 ENG-5466 feat(launchpad): detail page routing layout and appshell update with statsbar

### DIFF
--- a/apps/launchpad/app/components/layouts/app-shell.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell.tsx
@@ -46,7 +46,7 @@ function AppShellContent({ children, suspense = true }: AppShellContentProps) {
 function AppShellInner({ children }: BaseLayoutProps) {
   return (
     <div className="flex flex-col min-h-screen">
-      <StatsBar chapter="Chapter I: Genesis" remainingTime="1d 23h 56m 56s" />
+      <StatsBar />
       <div className="flex-1 pt-[52px]">
         <SidebarProvider
           style={

--- a/apps/launchpad/app/components/layouts/app-shell.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { cn, SidebarInset, SidebarProvider } from '@0xintuition/1ui'
 
 import { AppSidebar } from '../app-sidebar'
+import { StatsBar } from '../stats-bar'
 import { AppShellProvider, useAppShell } from './app-shell-context'
 import { BaseLayoutProps, layoutConfig } from './types'
 
@@ -44,18 +45,23 @@ function AppShellContent({ children, suspense = true }: AppShellContentProps) {
 
 function AppShellInner({ children }: BaseLayoutProps) {
   return (
-    <SidebarProvider
-      style={
-        {
-          '--sidebar-width': '16rem',
-        } as React.CSSProperties
-      }
-    >
-      <AppSidebar />
-      <SidebarInset className="bg-[#131313]">
-        <AppShellContent>{children}</AppShellContent>
-      </SidebarInset>
-    </SidebarProvider>
+    <div className="flex flex-col min-h-screen">
+      <StatsBar chapter="Chapter I: Genesis" remainingTime="1d 23h 56m 56s" />
+      <div className="flex-1 pt-[52px]">
+        <SidebarProvider
+          style={
+            {
+              '--sidebar-width': '16rem',
+            } as React.CSSProperties
+          }
+        >
+          <AppSidebar />
+          <SidebarInset className="bg-[#131313]">
+            <AppShellContent>{children}</AppShellContent>
+          </SidebarInset>
+        </SidebarProvider>
+      </div>
+    </div>
   )
 }
 

--- a/apps/launchpad/app/components/stats-bar.tsx
+++ b/apps/launchpad/app/components/stats-bar.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+
+import { Button, Icon, Text } from '@0xintuition/1ui'
+
+import { Link } from '@remix-run/react'
+
+interface StatsBarProps {
+  chapter: string
+  remainingTime: string
+}
+
+export function StatsBar({ chapter, remainingTime }: StatsBarProps) {
+  return (
+    <div className="fixed top-0 left-[16rem] right-0 flex items-center justify-between w-[calc(100%-16rem)] bg-black/40 px-6 py-3 z-50">
+      <div className="flex items-center gap-2">
+        <Link to="/chapter-1">
+          <Button
+            variant="ghost"
+            className="text-[#BA8461] hover:text-[#BA8461] hover:bg-[#BA8461]/10 border border-border/10"
+          >
+            {chapter}
+            <Icon name="arrow-up-right" className="w-4 h-4" />
+          </Button>
+        </Link>
+      </div>
+      <div className="flex items-center gap-4">
+        <Text variant="body" weight="medium" className="text-[#BA8461]">
+          {remainingTime}
+        </Text>
+        <Button
+          variant="ghost"
+          className="text-[#BA8461] hover:text-[#BA8461] hover:bg-[#BA8461]/10 border border-border/10"
+        >
+          <Icon name="map" className="w-4 h-4" />
+          Roadmap
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/launchpad/app/components/stats-bar.tsx
+++ b/apps/launchpad/app/components/stats-bar.tsx
@@ -1,15 +1,39 @@
 import * as React from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button, Icon, Text } from '@0xintuition/1ui'
 
 import { Link } from '@remix-run/react'
 
-interface StatsBarProps {
-  chapter: string
-  remainingTime: string
-}
+export function StatsBar() {
+  const currentChapter = 'CHAPTER I: GENESIS'
+  const endTime = new Date(Date.now() + 172800000) // 2 days from now
+  const [timeLeft, setTimeLeft] = useState('')
 
-export function StatsBar({ chapter, remainingTime }: StatsBarProps) {
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const now = new Date()
+      const difference = endTime.getTime() - now.getTime()
+
+      if (difference <= 0) {
+        setTimeLeft('Completed')
+        clearInterval(timer)
+        return
+      }
+
+      const days = Math.floor(difference / (1000 * 60 * 60 * 24))
+      const hours = Math.floor(
+        (difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+      )
+      const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60))
+      const seconds = Math.floor((difference % (1000 * 60)) / 1000)
+
+      setTimeLeft(`${days}d ${hours}h ${minutes}m ${seconds}s`)
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [endTime])
+
   return (
     <div className="fixed top-0 left-[16rem] right-0 flex items-center justify-between w-[calc(100%-16rem)] bg-black/40 px-6 py-3 z-50">
       <div className="flex items-center gap-2">
@@ -18,14 +42,14 @@ export function StatsBar({ chapter, remainingTime }: StatsBarProps) {
             variant="ghost"
             className="text-[#BA8461] hover:text-[#BA8461] hover:bg-[#BA8461]/10 border border-border/10"
           >
-            {chapter}
+            {currentChapter}
             <Icon name="arrow-up-right" className="w-4 h-4" />
           </Button>
         </Link>
       </div>
       <div className="flex items-center gap-4">
         <Text variant="body" weight="medium" className="text-[#BA8461]">
-          {remainingTime}
+          {timeLeft}
         </Text>
         <Button
           variant="ghost"

--- a/apps/launchpad/app/lib/hooks/useGoBack.tsx
+++ b/apps/launchpad/app/lib/hooks/useGoBack.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+
+import { useLocation, useNavigate } from '@remix-run/react'
+
+export function useGoBack({ fallbackRoute }: { fallbackRoute: string }) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const hasNavigated = useRef(false)
+
+  useEffect(() => {
+    hasNavigated.current = true
+  }, [location])
+
+  return () => {
+    if (hasNavigated.current && window.history.length > 2) {
+      navigate(-1)
+    } else {
+      window.location.href = fallbackRoute
+    }
+  }
+}

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -1,3 +1,138 @@
-export default function GameOne() {
-  return <div>Minigame One Page</div>
+import {
+  AggregatedMetrics,
+  Banner,
+  Button,
+  Card,
+  Icon,
+  PageHeader,
+} from '@0xintuition/1ui'
+import {
+  fetcher,
+  GetListDetailsDocument,
+  GetListDetailsQuery,
+  GetListDetailsQueryVariables,
+  useGetListDetailsQuery,
+} from '@0xintuition/graphql'
+
+import { useGoBack } from '@lib/hooks/useGoBack'
+import logger from '@lib/utils/logger'
+import { useLoaderData } from '@remix-run/react'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
+
+export async function loader() {
+  const queryClient = new QueryClient()
+
+  await queryClient.prefetchQuery({
+    queryKey: ['get-list-details', { predicateId: 3, objectId: 620 }],
+    queryFn: () =>
+      fetcher<GetListDetailsQuery, GetListDetailsQueryVariables>(
+        GetListDetailsDocument,
+        {
+          tagPredicateId: 3,
+          globalWhere: {
+            predicate_id: {
+              _eq: 3,
+            },
+            object_id: {
+              _eq: 620,
+            },
+          },
+        },
+      ),
+  })
+
+  return {
+    dehydratedState: dehydrate(queryClient),
+  }
+}
+
+export function ErrorBoundary() {
+  return (
+    <Banner
+      variant="error"
+      title="Error Loading Game"
+      message="There was an error loading the game data. Please try again."
+    >
+      <Button variant="secondary" onClick={() => window.location.reload()}>
+        Refresh
+      </Button>
+    </Banner>
+  )
+}
+
+export default function MiniGameOne() {
+  const goBack = useGoBack({ fallbackRoute: '/minigames' })
+  useLoaderData<typeof loader>()
+
+  const { data: listData } = useGetListDetailsQuery(
+    {
+      tagPredicateId: 3,
+      globalWhere: {
+        predicate_id: {
+          _eq: 3,
+        },
+        object_id: {
+          _eq: 620,
+        },
+      },
+    },
+    {
+      queryKey: ['get-list-details', { predicateId: 3, objectId: 620 }],
+    },
+  )
+
+  // Log each triple's shares for debugging
+  listData?.globalTriples?.forEach((triple, index) => {
+    logger(
+      `Triple ${index} shares:`,
+      triple.vault?.positions_aggregate?.aggregate?.sum?.shares,
+    )
+  })
+
+  return (
+    <>
+      <div className="flex items-center gap-4 mb-6">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="border-none text-foreground-muted"
+          onClick={goBack}
+        >
+          <Icon name="chevron-left" className="h-4 w-4" />
+        </Button>
+        <div className="flex flex-1 justify-between items-center">
+          <PageHeader title="Best Web3 Wallets" />
+          <Button variant="secondary" className="border border-border/10">
+            <Icon name="square-arrow-top-right" className="h-4 w-4" />
+            Share
+          </Button>
+        </div>
+      </div>
+
+      <div className="py-4 bg-gradient-to-b from-[#060504] to-[#101010] rounded-xl">
+        <Card className="h-[400px] border-none bg-gradient-to-br from-[#060504] to-[#101010] min-w-[480px]" />
+        <AggregatedMetrics
+          metrics={[
+            {
+              label: 'TVL',
+              value: 0,
+              suffix: 'ETH',
+            },
+            {
+              label: 'Atoms',
+              value: listData?.globalTriplesAggregate?.aggregate?.count ?? 0,
+            },
+            {
+              label: 'Users',
+              value: 0,
+            },
+          ]}
+          className="[&>div]:after:hidden sm:[&>div]:after:block"
+        />
+      </div>
+
+      {/* Space for table */}
+      <div className="mt-6">{/* Table will go here */}</div>
+    </>
+  )
 }

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -1,0 +1,3 @@
+export default function GameOne() {
+  return <div>Minigame One Page</div>
+}

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -101,7 +101,7 @@ export default function MiniGameOne() {
           <Icon name="chevron-left" className="h-4 w-4" />
         </Button>
         <div className="flex flex-1 justify-between items-center">
-          <PageHeader title="Best Web3 Wallets" />
+          <PageHeader title={listData?.globalTriples[0].object.label ?? ''} />
           <Button variant="secondary" className="border border-border/10">
             <Icon name="square-arrow-top-right" className="h-4 w-4" />
             Share

--- a/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.tsx
+++ b/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.tsx
@@ -4,6 +4,7 @@ import { formatNumber } from 'utils'
 interface Metric {
   label: string
   value: number | string
+  precision?: number
   hideOnMobile?: boolean
   suffix?: string
 }
@@ -25,26 +26,29 @@ export function AggregatedMetrics({
       )}
       {...props}
     >
-      {metrics.map(({ label, value, hideOnMobile, suffix }, index) => {
-        const formattedValue = typeof value === 'string' ? Number(value) : value
-        return (
-          <div
-            key={label}
-            className={cn(
-              'relative text-center px-12',
-              hideOnMobile && 'hidden lg:block',
-              index !== metrics.length - 1 &&
-                'after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20',
-            )}
-          >
-            <div className="text-sm text-foreground/70">{label}</div>
-            <div className="text-2xl font-medium text-foreground">
-              {formatNumber(formattedValue, 2)}
-              {suffix ? ` ${suffix}` : ''}
+      {metrics.map(
+        ({ label, value, hideOnMobile, suffix, precision }, index) => {
+          const formattedValue =
+            typeof value === 'string' ? Number(value) : value
+          return (
+            <div
+              key={label}
+              className={cn(
+                'relative text-center px-12',
+                hideOnMobile && 'hidden lg:block',
+                index !== metrics.length - 1 &&
+                  'after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20',
+              )}
+            >
+              <div className="text-sm text-foreground/70">{label}</div>
+              <div className="text-2xl font-medium text-foreground">
+                {formatNumber(formattedValue, precision)}
+                {suffix ? ` ${suffix}` : ''}
+              </div>
             </div>
-          </div>
-        )
-      })}
+          )
+        },
+      )}
     </div>
   )
 }

--- a/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.tsx
+++ b/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.tsx
@@ -4,7 +4,6 @@ import { formatNumber } from 'utils'
 interface Metric {
   label: string
   value: number | string
-  precision?: number
   hideOnMobile?: boolean
   suffix?: string
 }
@@ -26,29 +25,26 @@ export function AggregatedMetrics({
       )}
       {...props}
     >
-      {metrics.map(
-        ({ label, value, hideOnMobile, suffix, precision }, index) => {
-          const formattedValue =
-            typeof value === 'string' ? Number(value) : value
-          return (
-            <div
-              key={label}
-              className={cn(
-                'relative text-center px-12',
-                hideOnMobile && 'hidden lg:block',
-                index !== metrics.length - 1 &&
-                  'after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20',
-              )}
-            >
-              <div className="text-sm text-foreground/70">{label}</div>
-              <div className="text-2xl font-medium text-foreground">
-                {formatNumber(formattedValue, precision)}
-                {suffix ? ` ${suffix}` : ''}
-              </div>
+      {metrics.map(({ label, value, hideOnMobile, suffix }, index) => {
+        const formattedValue = typeof value === 'string' ? Number(value) : value
+        return (
+          <div
+            key={label}
+            className={cn(
+              'relative text-center px-12',
+              hideOnMobile && 'hidden lg:block',
+              index !== metrics.length - 1 &&
+                'after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20',
+            )}
+          >
+            <div className="text-sm text-foreground/70">{label}</div>
+            <div className="text-2xl font-medium text-foreground">
+              {formatNumber(formattedValue, 2)}
+              {suffix ? ` ${suffix}` : ''}
             </div>
-          )
-        },
-      )}
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds in the minigame routing and layout (we can adjust the routing)
- Adds a `StatsBar` and includes this in the `AppShell` -- the data is the same query used in `ChapterProgress`
- Builds initial layout for the detail page with the following notes: query is in, but need to calculate TVL and also update the `AggregatedMetrics` to have optional precision so we can adjust these values on the fly / based on context
- Will return to these issues after rounding out other pages

## Screen Captures

![image](https://github.com/user-attachments/assets/62c6f7e4-d93f-4733-9868-ddb352f29192)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
