### PR TITLE
ENG-5428 ENG-5429 feat(launchpad): sharing modal flow

### DIFF
--- a/apps/launchpad/app/components/share-modal.tsx
+++ b/apps/launchpad/app/components/share-modal.tsx
@@ -1,0 +1,99 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTitle,
+  Icon,
+  IconName,
+  Text,
+} from '@0xintuition/1ui'
+
+import { useCopy } from '@lib/hooks/useCopy'
+
+export interface ShareModalProps {
+  currentPath: string
+  open?: boolean
+  onClose: () => void
+}
+
+function ShareModalContent({ currentPath }: ShareModalProps) {
+  const { copy } = useCopy()
+
+  return (
+    <DialogContent className="bg-background backdrop-blur-sm rounded-3xl shadow-2xl border border-neutral-800 flex flex-col px-0 pb-0">
+      <div className="flex flex-col gap-4">
+        <div className="flex justify-between items-start">
+          <DialogTitle className='px-8'>
+            <Text className="text-neutral-400 text-lg">
+              Best Crypto Wallets
+            </Text>
+          </DialogTitle>
+        </div>
+
+        <div className="flex justify-between items-center px-8">
+          <div className="flex items-baseline gap-2">
+            <Text className="text-4xl font-bold text-white">$178.52</Text>
+            <Text className="text-emerald-400 text-lg">
+              +176.10 (+7,272.66%)
+            </Text>
+          </div>
+          <div className="w-12 h-12 rounded-full bg-neutral-800 overflow-hidden">
+            {/* Avatar placeholder */}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-4 grid-rows-2 gap-4 px-8">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="aspect-square rounded-2xl bg-neutral-800/50"
+            />
+          ))}
+        </div>
+
+        <div className="flex justify-end pr-8">
+          <Text className="text-neutral-500 text-sm">Powered by Intuition</Text>
+        </div>
+
+        <div className="flex justify-between items-center  bg-[#0F0F0F] p-8">
+          <button
+            onClick={() => copy(currentPath)}
+            className="bg-neutral-950 rounded-full border border-emerald-500/20 px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-neutral-900 transition-colors"
+          >
+            <Icon
+              name={IconName.checkmark}
+              className="h-5 w-5 text-emerald-500"
+            />
+            <Text className="text-emerald-500">Copied!</Text>
+          </button>
+
+          <div className="flex gap-4">
+            <button className="p-3 rounded-full bg-neutral-950 border border-neutral-800 hover:border-neutral-700 transition-colors">
+              <Icon name={IconName.twitter} className="h-5 w-5" />
+            </button>
+            <button className="p-3 rounded-full bg-neutral-950 border border-neutral-800 hover:border-neutral-700 transition-colors">
+              <Icon name={IconName.twitter} className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  )
+}
+
+export default function ShareModal({
+  currentPath,
+  open,
+  onClose,
+}: ShareModalProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={() => {
+        onClose?.()
+      }}
+    >
+      <ShareModalContent currentPath={currentPath} onClose={onClose} />
+    </Dialog>
+  )
+}

--- a/apps/launchpad/app/components/share-modal.tsx
+++ b/apps/launchpad/app/components/share-modal.tsx
@@ -1,29 +1,41 @@
+import { useEffect } from 'react'
+
 import {
   Dialog,
   DialogContent,
   DialogTitle,
-  DialogTitle,
   Icon,
   IconName,
   Text,
+  toast,
 } from '@0xintuition/1ui'
 
 import { useCopy } from '@lib/hooks/useCopy'
 
 export interface ShareModalProps {
-  currentPath: string
   open?: boolean
   onClose: () => void
 }
 
-function ShareModalContent({ currentPath }: ShareModalProps) {
+function ShareModalContent({ onClose, open }: ShareModalProps) {
   const { copy } = useCopy()
+
+  useEffect(() => {
+    if (open && typeof window !== 'undefined') {
+      copy(window.location.href)
+    }
+  }, [open])
+
+  const handleManualCopy = () => {
+    copy(window.location.href)
+    toast.success('Link copied to clipboard!')
+  }
 
   return (
     <DialogContent className="bg-background backdrop-blur-sm rounded-3xl shadow-2xl border border-neutral-800 flex flex-col px-0 pb-0">
       <div className="flex flex-col gap-4">
         <div className="flex justify-between items-start">
-          <DialogTitle className='px-8'>
+          <DialogTitle className="px-8">
             <Text className="text-neutral-400 text-lg">
               Best Crypto Wallets
             </Text>
@@ -55,9 +67,9 @@ function ShareModalContent({ currentPath }: ShareModalProps) {
           <Text className="text-neutral-500 text-sm">Powered by Intuition</Text>
         </div>
 
-        <div className="flex justify-between items-center  bg-[#0F0F0F] p-8">
+        <div className="flex justify-between items-center bg-[#0F0F0F] p-8">
           <button
-            onClick={() => copy(currentPath)}
+            onClick={handleManualCopy}
             className="bg-neutral-950 rounded-full border border-emerald-500/20 px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-neutral-900 transition-colors"
           >
             <Icon
@@ -72,7 +84,7 @@ function ShareModalContent({ currentPath }: ShareModalProps) {
               <Icon name={IconName.twitter} className="h-5 w-5" />
             </button>
             <button className="p-3 rounded-full bg-neutral-950 border border-neutral-800 hover:border-neutral-700 transition-colors">
-              <Icon name={IconName.twitter} className="h-5 w-5" />
+              <Icon name={IconName.farcaster} className="h-5 w-5" />
             </button>
           </div>
         </div>
@@ -81,11 +93,7 @@ function ShareModalContent({ currentPath }: ShareModalProps) {
   )
 }
 
-export default function ShareModal({
-  currentPath,
-  open,
-  onClose,
-}: ShareModalProps) {
+export default function ShareModal({ open, onClose }: ShareModalProps) {
   return (
     <Dialog
       open={open}
@@ -93,7 +101,7 @@ export default function ShareModal({
         onClose?.()
       }}
     >
-      <ShareModalContent currentPath={currentPath} onClose={onClose} />
+      <ShareModalContent onClose={onClose} open={open} />
     </Dialog>
   )
 }

--- a/apps/launchpad/app/components/share-modal.tsx
+++ b/apps/launchpad/app/components/share-modal.tsx
@@ -8,6 +8,10 @@ import {
   IconName,
   Text,
   toast,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@0xintuition/1ui'
 
 import { useCopy } from '@lib/hooks/useCopy'
@@ -15,9 +19,19 @@ import { useCopy } from '@lib/hooks/useCopy'
 export interface ShareModalProps {
   open?: boolean
   onClose: () => void
+  title: string
+  tvl: number
+  percentageChange?: number
+  valueChange?: number
 }
 
-function ShareModalContent({ onClose, open }: ShareModalProps) {
+function ShareModalContent({
+  open,
+  title,
+  tvl,
+  percentageChange = 0,
+  valueChange = 0,
+}: ShareModalProps) {
   const { copy } = useCopy()
 
   useEffect(() => {
@@ -31,23 +45,39 @@ function ShareModalContent({ onClose, open }: ShareModalProps) {
     toast.success('Link copied to clipboard!')
   }
 
+  const handleTwitterShare = () => {
+    const text = `Check out my ${title.toLowerCase()} performance!`
+    const url = encodeURIComponent(window.location.href)
+    const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${url}`
+    window.open(twitterUrl, '_blank')
+  }
+
+  const handleFarcasterShare = () => {
+    const text = `Check out my ${title.toLowerCase()} performance!`
+    const url = encodeURIComponent(window.location.href)
+    const farcasterUrl = `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}&embeds[]=${url}`
+    window.open(farcasterUrl, '_blank')
+  }
+
   return (
     <DialogContent className="bg-background backdrop-blur-sm rounded-3xl shadow-2xl border border-neutral-800 flex flex-col px-0 pb-0">
       <div className="flex flex-col gap-4">
         <div className="flex justify-between items-start">
           <DialogTitle className="px-8">
-            <Text className="text-neutral-400 text-lg">
-              Best Crypto Wallets
-            </Text>
+            <Text className="text-neutral-400 text-lg">{title}</Text>
           </DialogTitle>
         </div>
 
         <div className="flex justify-between items-center px-8">
           <div className="flex items-baseline gap-2">
-            <Text className="text-4xl font-bold text-white">$178.52</Text>
-            <Text className="text-emerald-400 text-lg">
-              +176.10 (+7,272.66%)
+            <Text className="text-4xl font-bold text-white">
+              ${tvl.toFixed(2)}
             </Text>
+            {(percentageChange !== 0 || valueChange !== 0) && (
+              <Text className="text-emerald-400 text-lg">
+                +{valueChange.toFixed(2)} (+{percentageChange.toFixed(2)}%)
+              </Text>
+            )}
           </div>
           <div className="w-12 h-12 rounded-full bg-neutral-800 overflow-hidden">
             {/* Avatar placeholder */}
@@ -68,22 +98,37 @@ function ShareModalContent({ onClose, open }: ShareModalProps) {
         </div>
 
         <div className="flex justify-between items-center bg-[#0F0F0F] p-8">
-          <button
-            onClick={handleManualCopy}
-            className="bg-neutral-950 rounded-full border border-emerald-500/20 px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-neutral-900 transition-colors"
-          >
-            <Icon
-              name={IconName.checkmark}
-              className="h-5 w-5 text-emerald-500"
-            />
-            <Text className="text-emerald-500">Copied!</Text>
-          </button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleManualCopy}
+                  className="bg-neutral-950 rounded-full border border-emerald-500/20 px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-neutral-900 transition-colors"
+                >
+                  <Icon
+                    name={IconName.checkmark}
+                    className="h-5 w-5 text-emerald-500"
+                  />
+                  <Text className="text-emerald-500">Copied!</Text>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <Text className="text-sm">{window.location.href}</Text>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
           <div className="flex gap-4">
-            <button className="p-3 rounded-full bg-neutral-950 border border-neutral-800 hover:border-neutral-700 transition-colors">
+            <button
+              onClick={handleTwitterShare}
+              className="p-3 rounded-full bg-neutral-950 border border-neutral-800 hover:border-neutral-700 transition-colors"
+            >
               <Icon name={IconName.twitter} className="h-5 w-5" />
             </button>
-            <button className="p-3 rounded-full bg-neutral-950 border border-neutral-800 hover:border-neutral-700 transition-colors">
+            <button
+              onClick={handleFarcasterShare}
+              className="p-3 rounded-full bg-neutral-950 border border-neutral-800 hover:border-neutral-700 transition-colors"
+            >
               <Icon name={IconName.farcaster} className="h-5 w-5" />
             </button>
           </div>
@@ -93,7 +138,14 @@ function ShareModalContent({ onClose, open }: ShareModalProps) {
   )
 }
 
-export default function ShareModal({ open, onClose }: ShareModalProps) {
+export default function ShareModal({
+  open,
+  onClose,
+  title,
+  tvl,
+  percentageChange,
+  valueChange,
+}: ShareModalProps) {
   return (
     <Dialog
       open={open}
@@ -101,7 +153,14 @@ export default function ShareModal({ open, onClose }: ShareModalProps) {
         onClose?.()
       }}
     >
-      <ShareModalContent onClose={onClose} open={open} />
+      <ShareModalContent
+        onClose={onClose}
+        open={open}
+        title={title}
+        tvl={tvl}
+        percentageChange={percentageChange}
+        valueChange={valueChange}
+      />
     </Dialog>
   )
 }

--- a/apps/launchpad/app/lib/state/store.ts
+++ b/apps/launchpad/app/lib/state/store.ts
@@ -1,0 +1,27 @@
+import type { WritableAtom } from 'jotai'
+import { atom, createStore } from 'jotai'
+
+export const GlobalStore = createStore()
+
+export function atomWithToggle(
+  initialValue: boolean,
+): WritableAtom<boolean, [boolean | undefined], void> {
+  const anAtom = atom<boolean, [boolean | undefined], void>(
+    // read function
+    initialValue,
+    // write function
+    (get, set, nextValue?: boolean) => {
+      const update = nextValue ?? !get(anAtom)
+      set(anAtom, update)
+    },
+  )
+  return anAtom
+}
+
+export const shareModalAtom = atom<{
+  isOpen: boolean
+  currentPath: string | null
+}>({
+  isOpen: false,
+  currentPath: null,
+})

--- a/apps/launchpad/app/lib/state/store.ts
+++ b/apps/launchpad/app/lib/state/store.ts
@@ -21,7 +21,13 @@ export function atomWithToggle(
 export const shareModalAtom = atom<{
   isOpen: boolean
   currentPath: string | null
+  title: string
+  tvl: number
+  percentageChange?: number
+  valueChange?: number
 }>({
   isOpen: false,
   currentPath: null,
+  title: '',
+  tvl: 0,
 })

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -14,13 +14,20 @@ import {
   useGetListDetailsQuery,
 } from '@0xintuition/graphql'
 
+import ShareModal from '@components/share-modal'
 import { useGoBack } from '@lib/hooks/useGoBack'
+import { shareModalAtom } from '@lib/state/store'
 import logger from '@lib/utils/logger'
+import { LoaderFunctionArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
+// import { requireUser } from '@server/auth'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { useAtom } from 'jotai'
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
   const queryClient = new QueryClient()
+  // const user = await requireUser(request)
+  // const wallet = user?.wallet?.address
 
   await queryClient.prefetchQuery({
     queryKey: ['get-list-details', { predicateId: 3, objectId: 620 }],
@@ -42,6 +49,7 @@ export async function loader() {
   })
 
   return {
+    // wallet,
     dehydratedState: dehydrate(queryClient),
   }
 }
@@ -63,6 +71,12 @@ export function ErrorBoundary() {
 export default function MiniGameOne() {
   const goBack = useGoBack({ fallbackRoute: '/minigames' })
   useLoaderData<typeof loader>()
+  const [shareModalActive, setShareModalActive] = useAtom(shareModalAtom)
+
+  const hasUserParam = location.search.includes('user=')
+  const fullPath = hasUserParam
+    ? `${location.pathname}${location.search}`
+    : `${location.pathname}${location.search}${location.search ? '&' : '?'}`
 
   const { data: listData } = useGetListDetailsQuery(
     {
@@ -102,7 +116,16 @@ export default function MiniGameOne() {
         </Button>
         <div className="flex flex-1 justify-between items-center">
           <PageHeader title={listData?.globalTriples[0].object.label ?? ''} />
-          <Button variant="secondary" className="border border-border/10">
+          <Button
+            variant="secondary"
+            className="border border-border/10"
+            onClick={() =>
+              setShareModalActive({
+                isOpen: true,
+                currentPath: fullPath,
+              })
+            }
+          >
             <Icon name="square-arrow-top-right" className="h-4 w-4" />
             Share
           </Button>
@@ -133,6 +156,16 @@ export default function MiniGameOne() {
 
       {/* Space for table */}
       <div className="mt-6">{/* Table will go here */}</div>
+      <ShareModal
+        currentPath={fullPath}
+        open={shareModalActive.isOpen}
+        onClose={() =>
+          setShareModalActive({
+            ...shareModalActive,
+            isOpen: false,
+          })
+        }
+      />
     </>
   )
 }

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -18,13 +18,12 @@ import ShareModal from '@components/share-modal'
 import { useGoBack } from '@lib/hooks/useGoBack'
 import { shareModalAtom } from '@lib/state/store'
 import logger from '@lib/utils/logger'
-import { LoaderFunctionArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 // import { requireUser } from '@server/auth'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { useAtom } from 'jotai'
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader() {
   const queryClient = new QueryClient()
   // const user = await requireUser(request)
   // const wallet = user?.wallet?.address

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -122,6 +122,8 @@ export default function MiniGameOne() {
               setShareModalActive({
                 isOpen: true,
                 currentPath: fullPath,
+                title: listData?.globalTriples[0].object.label ?? '',
+                tvl: 0,
               })
             }
           >
@@ -156,7 +158,6 @@ export default function MiniGameOne() {
       {/* Space for table */}
       <div className="mt-6">{/* Table will go here */}</div>
       <ShareModal
-        currentPath={fullPath}
         open={shareModalActive.isOpen}
         onClose={() =>
           setShareModalActive({
@@ -164,6 +165,8 @@ export default function MiniGameOne() {
             isOpen: false,
           })
         }
+        title={shareModalActive.title}
+        tvl={shareModalActive.tvl}
       />
     </>
   )

--- a/apps/launchpad/package.json
+++ b/apps/launchpad/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^3.6.0",
     "framer-motion": "^11.2.10",
     "isbot": "^4.1.0",
+    "jotai": "^2.8.3",
     "lucide-react": "^0.441.0",
     "react": "^18.2.0",
     "react-cytoscapejs": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,6 +511,9 @@ importers:
       isbot:
         specifier: ^4.1.0
         version: 4.4.0
+      jotai:
+        specifier: ^2.8.3
+        version: 2.8.3(@types/react@18.3.1)(react@18.3.1)
       lucide-react:
         specifier: ^0.441.0
         version: 0.441.0(react@18.3.1)
@@ -19335,8 +19338,8 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.0.0
-      '@noble/hashes': 1.5.0
-      '@scure/base': 1.1.9
+      '@noble/hashes': 1.6.1
+      '@scure/base': 1.2.1
       '@types/debug': 4.1.12
       debug: 4.3.5(supports-color@5.5.0)
       pony-cause: 2.1.11
@@ -29108,7 +29111,7 @@ snapshots:
 
   ethereum-bloom-filters@1.1.0:
     dependencies:
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.6.1
 
   ethereum-cryptography@2.2.0:
     dependencies:


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds the state and flow for the share modal from the details page (no link to this yet in app, but it's `/minigames/game-1`
- Automatically copies the link upon opening modal and shows it on hover
- Made slight modifications to see if we want to make the query support user perspective, but now planning for global list
- Scaffolds out the share to Twitter/Farcaster buttons (we'll need the copy)
- Modal takes in the title and tvl and optional props to match the Figma
- Will update the modal UI as we lock it in

## Screen Captures

![launchpad-share-modal](https://github.com/user-attachments/assets/d217312c-67f0-439e-b46d-ba27613375c1)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
