### PR TITLE
ENG-5433 ENG-5473 feat(launchpad): tcr table list with results, adds ctas to each page

### DIFF
--- a/apps/launchpad/app/components/layouts/app-shell-context.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell-context.tsx
@@ -37,8 +37,8 @@ export function AppShellProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (isMobile) {
       setIsSidebarOpen(false)
-      setLayoutVariant('wide')
-      setPaddingVariant('compact')
+      setLayoutVariant('narrow')
+      setPaddingVariant('default')
     } else {
       setIsSidebarOpen(true)
       setLayoutVariant('default')

--- a/apps/launchpad/app/components/layouts/app-shell.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell.tsx
@@ -23,7 +23,7 @@ function AppShellContent({ children, suspense = true }: AppShellContentProps) {
   const { layoutVariant, paddingVariant } = useAppShell()
 
   const content = (
-    <div className="flex justify-center w-full">
+    <div className="flex justify-center w-full max-w-screen-xl mx-auto">
       <div
         className={cn(
           'flex flex-col w-full space-y-6',

--- a/apps/launchpad/app/components/layouts/app-shell.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell.tsx
@@ -23,14 +23,16 @@ function AppShellContent({ children, suspense = true }: AppShellContentProps) {
   const { layoutVariant, paddingVariant } = useAppShell()
 
   const content = (
-    <div
-      className={cn(
-        'flex flex-col w-full mx-auto space-y-6',
-        layoutConfig.maxWidth[layoutVariant],
-        layoutConfig.padding[paddingVariant],
-      )}
-    >
-      {children}
+    <div className="flex justify-center w-full">
+      <div
+        className={cn(
+          'flex flex-col w-full space-y-6',
+          layoutConfig.maxWidth[layoutVariant],
+          layoutConfig.padding[paddingVariant],
+        )}
+      >
+        {children}
+      </div>
     </div>
   )
 

--- a/apps/launchpad/app/components/layouts/types.ts
+++ b/apps/launchpad/app/components/layouts/types.ts
@@ -5,31 +5,27 @@ export interface BaseLayoutProps {
   fillWidth?: boolean
 }
 
-export type LayoutVariant = 'default' | 'narrow' | 'wide'
-export type PaddingVariant = 'default' | 'none' | 'compact'
+export type LayoutVariant = 'default' | 'narrow'
+export type PaddingVariant = 'default' | 'narrow'
 
 export interface LayoutConfig {
   maxWidth: {
     default: string
     narrow: string
-    wide: string
   }
   padding: {
     default: string
-    none: string
-    compact: string
+    narrow: string
   }
 }
 
-export const layoutConfig: LayoutConfig = {
+export const layoutConfig = {
   maxWidth: {
-    default: 'max-w-[1280px]',
-    narrow: 'max-w-md',
-    wide: 'max-w-[1440px]',
+    default: 'max-w-[1200px]',
+    narrow: 'max-w-5xl',
   },
   padding: {
-    default: 'px-4 sm:px-6 lg:px-8 py-6',
-    none: 'p-0',
-    compact: 'p-4',
+    default: 'px-8 py-6',
+    narrow: 'px-4 py-4',
   },
-}
+} as const

--- a/apps/launchpad/app/components/minigame-card.tsx
+++ b/apps/launchpad/app/components/minigame-card.tsx
@@ -1,6 +1,7 @@
 import { Button, Card, Text } from '@0xintuition/1ui'
 
 import type { Minigame } from '@lib/types/minigame'
+import { useNavigate } from '@remix-run/react'
 
 interface MinigameCardProps {
   className?: string
@@ -15,6 +16,8 @@ export function MinigameCard({
   game,
   hideCTA = false,
 }: MinigameCardProps) {
+  const navigate = useNavigate()
+
   return (
     <Card
       className={`relative h-[400px] rounded-lg border-none bg-gradient-to-br from-[#060504] to-[#101010] min-w-[480px] ${className}`}
@@ -38,7 +41,7 @@ export function MinigameCard({
           </div>
         )}
 
-        <div className="flex justify-start">
+        <div className="flex justify-between">
           <Text
             variant="heading5"
             weight="semibold"
@@ -46,6 +49,12 @@ export function MinigameCard({
           >
             ${game.totalEarned.toFixed(1)}
           </Text>
+          <Button
+            variant="secondary"
+            onClick={() => navigate('/minigames/game-1')}
+          >
+            View Game List
+          </Button>
         </div>
       </div>
     </Card>

--- a/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
@@ -244,6 +244,9 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
     }))
     updateStepStatus(STEPS.STAKE, 'completed')
     updateStepStatus(STEPS.REWARD, 'current')
+    queryClient.invalidateQueries({
+      queryKey: ['get-list-details', { predicateId: 3, objectId: 620 }],
+    })
   }
 
   console.log('listData', listData)

--- a/apps/launchpad/app/components/ui/table/columns.tsx
+++ b/apps/launchpad/app/components/ui/table/columns.tsx
@@ -1,6 +1,7 @@
-import { Button, Icon } from '@0xintuition/1ui'
+import { Icon } from '@0xintuition/1ui'
 
 import { ColumnDef } from '@tanstack/react-table'
+import { ArrowUpDown, X as CloseX } from 'lucide-react'
 
 import { DataTableColumnHeader } from './data-table-column-header'
 
@@ -40,10 +41,7 @@ export const columns: ColumnDef<TableItem>[] = [
           }}
         >
           <span>Entries</span>
-          <div className="flex flex-col -space-y-1">
-            <Icon name="arrow-up" className="h-3 w-3" />
-            <Icon name="arrow-down" className="h-3 w-3" />
-          </div>
+          <ArrowUpDown className="h-4 w-4" />
         </button>
       </div>
     ),
@@ -101,16 +99,11 @@ export const columns: ColumnDef<TableItem>[] = [
       return (
         <div className="flex items-center justify-end gap-2 pr-6">
           <div className="flex items-center gap-2 px-3 py-1.5 bg-[#1C1C1C] rounded-lg">
-            <Icon name="arrow-up" className="h-4 w-4" />
+            <Icon name="arrow-up" className="h-5 w-5" />
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            disabled
-            className="h-8 w-8 rounded-lg bg-[#E11D48] hover:bg-[#E11D48]"
-          >
-            <Icon name="x" className="h-4 w-4 text-white" />
-          </Button>
+          <div className="flex items-center justify-center h-8 w-8 rounded-lg bg-destructive">
+            <CloseX className="h-5 w-5 text-white" />
+          </div>
         </div>
       )
     },

--- a/apps/launchpad/app/components/ui/table/columns.tsx
+++ b/apps/launchpad/app/components/ui/table/columns.tsx
@@ -18,9 +18,11 @@ export const columns: ColumnDef<TableItem>[] = [
   {
     id: 'position',
     header: '',
-    cell: ({ row }) => {
+    cell: ({ table, row }) => {
       return (
-        <div className="w-12 pl-6 text-muted-foreground">{row.index + 1}</div>
+        <div className="w-12 pl-6 text-muted-foreground">
+          {table.getSortedRowModel().rows.findIndex((r) => r.id === row.id) + 1}
+        </div>
       )
     },
     size: 48,
@@ -75,16 +77,17 @@ export const columns: ColumnDef<TableItem>[] = [
       return <div className="text-right pr-12">{row.getValue('users')}</div>
     },
     size: 120,
+    sortDescFirst: true,
   },
   {
     accessorKey: 'assets',
     header: ({ column }) => (
-      <div className="flex justify-end">
+      <div className="flex justify-end pr-6">
         <DataTableColumnHeader column={column} title="Assets" />
       </div>
     ),
     cell: ({ row }) => {
-      return <div className="text-right pr-12">${row.getValue('assets')}</div>
+      return <div className="text-right pr-6">{row.getValue('assets')} ETH</div>
     },
     size: 120,
   },

--- a/apps/launchpad/app/components/ui/table/columns.tsx
+++ b/apps/launchpad/app/components/ui/table/columns.tsx
@@ -1,0 +1,120 @@
+import { Button, Icon } from '@0xintuition/1ui'
+
+import { ColumnDef } from '@tanstack/react-table'
+
+import { DataTableColumnHeader } from './data-table-column-header'
+
+// Define the type for our data
+type TableItem = {
+  id: string
+  image: string
+  name: string
+  users: number
+  assets: number
+}
+
+export const columns: ColumnDef<TableItem>[] = [
+  {
+    id: 'position',
+    header: '',
+    cell: ({ row }) => {
+      return (
+        <div className="w-12 pl-6 text-muted-foreground">{row.index + 1}</div>
+      )
+    },
+    size: 48,
+    enableSorting: false,
+  },
+  {
+    accessorKey: 'name',
+    header: ({ column }) => (
+      <div className="flex items-center gap-3 pl-6">
+        <button
+          className="flex items-center gap-2"
+          onClick={() => column.toggleSorting()}
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              column.toggleSorting()
+            }
+          }}
+        >
+          <span>Entries</span>
+          <div className="flex flex-col -space-y-1">
+            <Icon name="arrow-up" className="h-3 w-3" />
+            <Icon name="arrow-down" className="h-3 w-3" />
+          </div>
+        </button>
+      </div>
+    ),
+    cell: ({ row }) => {
+      const image = row.original.image
+      return (
+        <div className="flex items-center gap-3 pl-6">
+          {image ? (
+            <img
+              src={image}
+              alt={row.getValue('name')}
+              className="w-8 h-8 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-8 h-8 rounded-full bg-background-muted" />
+          )}
+          <span className="font-medium">{row.getValue('name')}</span>
+        </div>
+      )
+    },
+    size: 480,
+  },
+  {
+    accessorKey: 'users',
+    header: ({ column }) => (
+      <div className="flex justify-end">
+        <DataTableColumnHeader column={column} title="Users" />
+      </div>
+    ),
+    cell: ({ row }) => {
+      return <div className="text-right pr-12">{row.getValue('users')}</div>
+    },
+    size: 120,
+  },
+  {
+    accessorKey: 'assets',
+    header: ({ column }) => (
+      <div className="flex justify-end">
+        <DataTableColumnHeader column={column} title="Assets" />
+      </div>
+    ),
+    cell: ({ row }) => {
+      return <div className="text-right pr-12">${row.getValue('assets')}</div>
+    },
+    size: 120,
+  },
+  {
+    id: 'signal',
+    header: ({ column }) => (
+      <div className="flex justify-end pr-6">
+        <DataTableColumnHeader column={column} title="Signal" />
+      </div>
+    ),
+    cell: () => {
+      return (
+        <div className="flex items-center justify-end gap-2 pr-6">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-[#1C1C1C] rounded-lg">
+            <Icon name="arrow-up" className="h-4 w-4" />
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled
+            className="h-8 w-8 rounded-lg bg-[#E11D48] hover:bg-[#E11D48]"
+          >
+            <Icon name="x" className="h-4 w-4 text-white" />
+          </Button>
+        </div>
+      )
+    },
+    enableSorting: false,
+    size: 180,
+  },
+]

--- a/apps/launchpad/app/components/ui/table/data-table-column-header.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table-column-header.tsx
@@ -1,0 +1,91 @@
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@0xintuition/1ui'
+
+import { Column } from '@tanstack/react-table'
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ChevronsUpDown,
+  EyeOff,
+  PinIcon,
+} from 'lucide-react'
+
+interface DataTableColumnHeaderProps<TData, TValue>
+  extends React.HTMLAttributes<HTMLDivElement> {
+  column: Column<TData, TValue>
+  title: string
+}
+
+export function DataTableColumnHeader<TData, TValue>({
+  column,
+  title,
+  className,
+}: DataTableColumnHeaderProps<TData, TValue>) {
+  if (!column.getCanSort()) {
+    return <div className={cn(className)}>{title}</div>
+  }
+
+  return (
+    <div className={cn('flex items-center space-x-2', className)}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant={ButtonVariant.text}
+            size={ButtonSize.md}
+            className="px-0"
+          >
+            <span>{title}</span>
+            {column.getIsSorted() === 'desc' ? (
+              <ArrowDownIcon className="h-4 w-4" />
+            ) : column.getIsSorted() === 'asc' ? (
+              <ArrowUpIcon className="h-4 w-4" />
+            ) : (
+              <ChevronsUpDown className="h-4 w-4" />
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem onClick={() => column.toggleSorting(false)}>
+            <ArrowUpIcon className="h-3.5 w-3.5 text-muted-foreground/70" />
+            Asc
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => column.toggleSorting(true)}>
+            <ArrowDownIcon className="h-3.5 w-3.5 text-muted-foreground/70" />
+            Desc
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
+            <EyeOff className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+            Hide
+          </DropdownMenuItem>
+          {column.getCanPin() && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => column.pin('left')}>
+                <PinIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+                Pin Left
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => column.pin('right')}>
+                <PinIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+                Pin Right
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => column.pin(false)}>
+                <PinIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+                Unpin
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/apps/launchpad/app/components/ui/table/data-table-pagination.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table-pagination.tsx
@@ -1,0 +1,105 @@
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@0xintuition/1ui'
+
+import { Table } from '@tanstack/react-table'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronsLeft,
+  ChevronsRight,
+} from 'lucide-react'
+
+interface DataTablePaginationProps<TData> {
+  table: Table<TData>
+}
+
+export function DataTablePagination<TData>({
+  table,
+}: DataTablePaginationProps<TData>) {
+  return (
+    <div className="flex items-center justify-between px-2">
+      <div className="flex-1 text-sm text-muted-foreground">
+        {table.getFilteredSelectedRowModel().rows.length} of{' '}
+        {table.getFilteredRowModel().rows.length} row(s) selected.
+      </div>
+      <div className="flex items-center space-x-6 lg:space-x-8">
+        <div className="flex items-center space-x-2">
+          <p className="text-sm font-medium text-foreground/70">
+            Rows per page
+          </p>
+          <Select
+            value={`${table.getState().pagination.pageSize}`}
+            onValueChange={(value) => {
+              table.setPageSize(Number(value))
+            }}
+          >
+            <SelectTrigger className="h-8 w-[70px]">
+              <SelectValue placeholder={table.getState().pagination.pageSize} />
+            </SelectTrigger>
+            <SelectContent side="top">
+              {[10, 20, 30, 40, 50].map((pageSize) => (
+                <SelectItem key={pageSize} value={`${pageSize}`}>
+                  {pageSize}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex w-[100px] items-center justify-center text-sm font-medium text-foreground/70">
+          Page {table.getState().pagination.pageIndex + 1} of{' '}
+          {table.getPageCount()}
+        </div>
+        <div className="flex items-center space-x-2">
+          <Button
+            variant={ButtonVariant.secondary}
+            size={ButtonSize.icon}
+            className="hidden h-8 w-8 p-0 lg:flex"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">Go to first page</span>
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={ButtonVariant.secondary}
+            size={ButtonSize.icon}
+            className="h-8 w-8 p-0"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">Go to previous page</span>
+            <ChevronLeftIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={ButtonVariant.secondary}
+            size={ButtonSize.icon}
+            className="h-8 w-8 p-0"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">Go to next page</span>
+            <ChevronRightIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={ButtonVariant.secondary}
+            size={ButtonSize.icon}
+            className="hidden h-8 w-8 p-0 lg:flex"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">Go to last page</span>
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/launchpad/app/components/ui/table/data-table-row-actions.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table-row-actions.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  ButtonVariant,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@0xintuition/1ui'
+
+import { Row } from '@tanstack/react-table'
+import { MoreHorizontal } from 'lucide-react'
+
+import { thingSchema } from './schema/thing'
+
+interface DataTableRowActionsProps<TData> {
+  row: Row<TData>
+}
+
+export function DataTableRowActions<TData>({
+  row,
+}: DataTableRowActionsProps<TData>) {
+  const thing = thingSchema.parse(row.original)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant={ButtonVariant.navigation}
+          className="flex h-8 w-8 p-0 data-[state=open]:bg-muted"
+        >
+          <MoreHorizontal className="h-4 w-4" />
+          <span className="sr-only">Open menu</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[160px]">
+        <DropdownMenuItem>Edit</DropdownMenuItem>
+        <DropdownMenuItem>Make a copy</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          Delete
+          <DropdownMenuShortcut>⌘⌫</DropdownMenuShortcut>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/launchpad/app/components/ui/table/data-table-row-actions.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table-row-actions.tsx
@@ -4,30 +4,14 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@0xintuition/1ui'
 
-import { Row } from '@tanstack/react-table'
 import { MoreHorizontal } from 'lucide-react'
 
-import { thingSchema } from './schema/thing'
-
-interface DataTableRowActionsProps<TData> {
-  row: Row<TData>
-}
-
-export function DataTableRowActions<TData>({
-  row,
-}: DataTableRowActionsProps<TData>) {
-  const thing = thingSchema.parse(row.original)
-
+export function DataTableRowActions() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/apps/launchpad/app/components/ui/table/data-table-toolbar.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table-toolbar.tsx
@@ -1,0 +1,42 @@
+import { Button, Input } from '@0xintuition/1ui'
+
+import { Table } from '@tanstack/react-table'
+import { CrossIcon } from 'lucide-react'
+
+import { DataTableViewOptions } from './data-table-view-options'
+
+interface DataTableToolbarProps<TData> {
+  table: Table<TData>
+}
+
+export function DataTableToolbar<TData>({
+  table,
+}: DataTableToolbarProps<TData>) {
+  const isFiltered = table.getState().columnFilters.length > 0
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex flex-1 items-center space-x-2">
+        <Input
+          placeholder="Filter by name..."
+          value={(table.getColumn('name')?.getFilterValue() as string) ?? ''}
+          onChange={(event) =>
+            table.getColumn('name')?.setFilterValue(event.target.value)
+          }
+          className="h-8 w-[150px] lg:w-[250px]"
+        />
+        {isFiltered && (
+          <Button
+            variant="ghost"
+            onClick={() => table.resetColumnFilters()}
+            className="h-8 px-2 lg:px-3"
+          >
+            Reset
+            <CrossIcon className="ml-2 h-4 w-4" />
+          </Button>
+        )}
+      </div>
+      <DataTableViewOptions table={table} />
+    </div>
+  )
+}

--- a/apps/launchpad/app/components/ui/table/data-table-view-options.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table-view-options.tsx
@@ -1,0 +1,59 @@
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@0xintuition/1ui'
+
+import { Table } from '@tanstack/react-table'
+import { SlidersHorizontal } from 'lucide-react'
+
+interface DataTableViewOptionsProps<TData> {
+  table: Table<TData>
+}
+
+export function DataTableViewOptions<TData>({
+  table,
+}: DataTableViewOptionsProps<TData>) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant={ButtonVariant.secondary}
+          size={ButtonSize.md}
+          className="ml-auto hidden h-8 lg:flex"
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+          View
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[150px]">
+        <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {table
+          .getAllColumns()
+          .filter(
+            (column) =>
+              typeof column.accessorFn !== 'undefined' && column.getCanHide(),
+          )
+          .map((column) => {
+            return (
+              <DropdownMenuCheckboxItem
+                key={column.id}
+                className="capitalize"
+                checked={column.getIsVisible()}
+                onCheckedChange={(value) => column.toggleVisibility(!!value)}
+              >
+                {column.id}
+              </DropdownMenuCheckboxItem>
+            )
+          })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/launchpad/app/components/ui/table/data-table.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table.tsx
@@ -1,0 +1,185 @@
+import React, { CSSProperties } from 'react'
+
+import {
+  Button,
+  Icon,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@0xintuition/1ui'
+
+import {
+  Column,
+  ColumnDef,
+  ColumnResizeMode,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table'
+
+import { DataTablePagination } from './data-table-pagination'
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+}
+
+const getCommonPinningStyles = <T,>(
+  column: Column<T, unknown>,
+): CSSProperties => {
+  const isPinned = column.getIsPinned()
+  const isLastLeftPinnedColumn =
+    isPinned === 'left' && column.getIsLastColumn('left')
+  const isFirstRightPinnedColumn =
+    isPinned === 'right' && column.getIsFirstColumn('right')
+
+  return {
+    boxShadow: isLastLeftPinnedColumn
+      ? '4px 0 4px -4px rgba(0, 0, 0, 0.1)'
+      : isFirstRightPinnedColumn
+        ? '-4px 0 4px -4px rgba(0, 0, 0, 0.1)'
+        : undefined,
+    left: isPinned === 'left' ? `${column.getStart('left')}px` : undefined,
+    right: isPinned === 'right' ? `${column.getAfter('right')}px` : undefined,
+    position: isPinned ? 'sticky' : 'relative',
+    zIndex: isPinned ? 2 : 1,
+    backgroundColor: isPinned ? 'var(--background)' : undefined,
+  }
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) {
+  const [columnResizeMode] = React.useState<ColumnResizeMode>('onChange')
+  const [sorting, setSorting] = React.useState<SortingState>([])
+
+  const table = useReactTable({
+    data,
+    columns,
+    columnResizeMode,
+    enableColumnPinning: true,
+    enableColumnResizing: true,
+    onSortingChange: setSorting,
+    state: {
+      sorting,
+    },
+    initialState: {
+      pagination: {
+        pageIndex: 0,
+        pageSize: 50,
+      },
+      columnPinning: {
+        left: ['index'],
+        right: ['actions'],
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        {/* <Button variant="ghost" size="sm" className="ml-auto">
+          <Icon name="filter-1" className="h-4 w-4 mr-2" />
+          Filter
+        </Button> */}
+      </div>
+      <div className="rounded-md border border-border/10 bg-[#060504] overflow-hidden">
+        <div className="overflow-x-auto w-full">
+          <Table className="w-full" style={{ minWidth: table.getTotalSize() }}>
+            <TableHeader className="bg-[#101010]">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow
+                  key={headerGroup.id}
+                  className="border-b border-border/10"
+                >
+                  {headerGroup.headers.map((header) => (
+                    <TableHead
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      className="text-sm font-medium text-muted-foreground h-12"
+                      style={{
+                        width: header.getSize(),
+                        ...getCommonPinningStyles(header.column),
+                      }}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {header.column.getCanResize() && (
+                        <div
+                          role="presentation"
+                          aria-hidden="true"
+                          onMouseDown={header.getResizeHandler()}
+                          onTouchStart={header.getResizeHandler()}
+                          className={`resizer ${
+                            header.column.getIsResizing() ? 'isResizing' : ''
+                          }`}
+                        />
+                      )}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows?.length ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="border-b border-border/10 hover:bg-[#101010] transition-colors"
+                    data-state={row.getIsSelected() && 'selected'}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell
+                        key={cell.id}
+                        className="h-[72px] text-sm"
+                        style={{
+                          width: cell.column.getSize(),
+                          ...getCommonPinningStyles(cell.column),
+                        }}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length}
+                    className="h-24 text-center text-muted-foreground"
+                  >
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+      <DataTablePagination table={table} />
+    </div>
+  )
+}

--- a/apps/launchpad/app/components/ui/table/data-table.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table.tsx
@@ -1,8 +1,6 @@
 import React, { CSSProperties } from 'react'
 
 import {
-  Button,
-  Icon,
   Table,
   TableBody,
   TableCell,
@@ -61,7 +59,12 @@ export function DataTable<TData, TValue>({
   data,
 }: DataTableProps<TData, TValue>) {
   const [columnResizeMode] = React.useState<ColumnResizeMode>('onChange')
-  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [sorting, setSorting] = React.useState<SortingState>([
+    {
+      id: 'users',
+      desc: true,
+    },
+  ])
 
   const table = useReactTable({
     data,

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -131,6 +131,10 @@ export default function MiniGameOne() {
     )
   })
 
+  // Calculate total users and TVL
+  const totalUsers = tableData.reduce((sum, item) => sum + item.users, 0)
+  const totalTVL = tableData.reduce((sum, item) => sum + item.assets, 0)
+
   const handleStartOnboarding = (gameId: string) => {
     setOnboardingModal({ isOpen: true, gameId })
   }
@@ -167,7 +171,7 @@ export default function MiniGameOne() {
                   isOpen: true,
                   currentPath: fullPath,
                   title: listData?.globalTriples[0].object.label ?? '',
-                  tvl: 0,
+                  tvl: totalTVL,
                 })
               }
             >
@@ -184,7 +188,7 @@ export default function MiniGameOne() {
           metrics={[
             {
               label: 'TVL',
-              value: 0,
+              value: totalTVL,
               suffix: 'ETH',
             },
             {
@@ -193,7 +197,7 @@ export default function MiniGameOne() {
             },
             {
               label: 'Users',
-              value: 0,
+              value: totalUsers,
             },
           ]}
           className="[&>div]:after:hidden sm:[&>div]:after:block"

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -16,6 +16,8 @@ import {
 
 import { OnboardingModal } from '@components/onboarding-modal/onboarding-modal'
 import ShareModal from '@components/share-modal'
+import { columns } from '@components/ui/table/columns'
+import { DataTable } from '@components/ui/table/data-table'
 import { mockMinigames } from '@lib/data/mock-minigames'
 import { useGoBack } from '@lib/hooks/useGoBack'
 import { onboardingModalAtom, shareModalAtom } from '@lib/state/store'
@@ -97,6 +99,26 @@ export default function MiniGameOne() {
     },
   )
 
+  logger(listData?.globalTriples)
+  // Transform the data for the table
+  const tableData =
+    listData?.globalTriples?.map((triple) => {
+      // Debug log to see the image data
+      logger('Triple data:', {
+        id: triple.id,
+        subject: triple.subject,
+        image: triple.subject.image,
+      })
+
+      return {
+        id: triple.id,
+        image: triple.subject.image || '',
+        name: triple.subject.label || 'Untitled Entry',
+        users: 25, // Placeholder for now
+        assets: 3.73, // Placeholder for now
+      }
+    }) || []
+
   // Log each triple's shares for debugging
   listData?.globalTriples?.forEach((triple, index) => {
     logger(
@@ -175,7 +197,9 @@ export default function MiniGameOne() {
       </div>
 
       {/* Space for table */}
-      <div className="mt-6">{/* Table will go here */}</div>
+      <div className="mt-6">
+        <DataTable columns={columns} data={tableData} />
+      </div>
       <ShareModal
         open={shareModalActive.isOpen}
         onClose={() =>

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -14,9 +14,11 @@ import {
   useGetListDetailsQuery,
 } from '@0xintuition/graphql'
 
+import { OnboardingModal } from '@components/onboarding-modal/onboarding-modal'
 import ShareModal from '@components/share-modal'
+import { mockMinigames } from '@lib/data/mock-minigames'
 import { useGoBack } from '@lib/hooks/useGoBack'
-import { shareModalAtom } from '@lib/state/store'
+import { onboardingModalAtom, shareModalAtom } from '@lib/state/store'
 import logger from '@lib/utils/logger'
 import { useLoaderData } from '@remix-run/react'
 // import { requireUser } from '@server/auth'
@@ -71,6 +73,7 @@ export default function MiniGameOne() {
   const goBack = useGoBack({ fallbackRoute: '/minigames' })
   useLoaderData<typeof loader>()
   const [shareModalActive, setShareModalActive] = useAtom(shareModalAtom)
+  const [onboardingModal, setOnboardingModal] = useAtom(onboardingModalAtom)
 
   const hasUserParam = location.search.includes('user=')
   const fullPath = hasUserParam
@@ -102,6 +105,14 @@ export default function MiniGameOne() {
     )
   })
 
+  const handleStartOnboarding = (gameId: string) => {
+    setOnboardingModal({ isOpen: true, gameId })
+  }
+
+  const handleCloseOnboarding = () => {
+    setOnboardingModal({ isOpen: false, gameId: null })
+  }
+
   return (
     <>
       <div className="flex items-center gap-4 mb-6">
@@ -115,21 +126,29 @@ export default function MiniGameOne() {
         </Button>
         <div className="flex flex-1 justify-between items-center">
           <PageHeader title={listData?.globalTriples[0].object.label ?? ''} />
-          <Button
-            variant="secondary"
-            className="border border-border/10"
-            onClick={() =>
-              setShareModalActive({
-                isOpen: true,
-                currentPath: fullPath,
-                title: listData?.globalTriples[0].object.label ?? '',
-                tvl: 0,
-              })
-            }
-          >
-            <Icon name="square-arrow-top-right" className="h-4 w-4" />
-            Share
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="primary"
+              onClick={() => handleStartOnboarding(mockMinigames[0].id)}
+            >
+              Play Again
+            </Button>
+            <Button
+              variant="secondary"
+              className="border border-border/10"
+              onClick={() =>
+                setShareModalActive({
+                  isOpen: true,
+                  currentPath: fullPath,
+                  title: listData?.globalTriples[0].object.label ?? '',
+                  tvl: 0,
+                })
+              }
+            >
+              <Icon name="square-arrow-top-right" className="h-4 w-4" />
+              Share
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -167,6 +186,10 @@ export default function MiniGameOne() {
         }
         title={shareModalActive.title}
         tvl={shareModalActive.tvl}
+      />
+      <OnboardingModal
+        isOpen={onboardingModal.isOpen}
+        onClose={handleCloseOnboarding}
       />
     </>
   )

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -26,6 +26,7 @@ import { useLoaderData } from '@remix-run/react'
 // import { requireUser } from '@server/auth'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { useAtom } from 'jotai'
+import { formatUnits } from 'viem'
 
 export async function loader() {
   const queryClient = new QueryClient()
@@ -114,8 +115,11 @@ export default function MiniGameOne() {
         id: triple.id,
         image: triple.subject.image || '',
         name: triple.subject.label || 'Untitled Entry',
-        users: 25, // Placeholder for now
-        assets: 3.73, // Placeholder for now
+        users: Number(triple.vault?.positions_aggregate?.aggregate?.count ?? 0),
+        assets: +formatUnits(
+          triple.vault?.positions_aggregate?.aggregate?.sum?.shares ?? 0,
+          18,
+        ),
       }
     }) || []
 

--- a/apps/launchpad/package.json
+++ b/apps/launchpad/package.json
@@ -28,6 +28,7 @@
     "@remix-run/react": "^2.15.1",
     "@remix-run/serve": "^2.15.1",
     "@tanstack/react-query": "^5.32.0",
+    "@tanstack/react-table": "^8.20.6",
     "@types/cookie": "^0.6.0",
     "@types/cytoscape": "^3.21.8",
     "@vidstack/react": "^1.10.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,6 +475,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.32.0
         version: 5.45.0(react@18.3.1)
+      '@tanstack/react-table':
+        specifier: ^8.20.6
+        version: 8.20.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -6640,6 +6643,13 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@tanstack/react-table@8.20.6':
+    resolution: {integrity: sha512-w0jluT718MrOKthRcr2xsjqzx+oEM7B7s/XXyfs19ll++hlId3fjTm+B2zrR3ijpANpkzBAr15j1XGVOMxpggQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
   '@tanstack/react-virtual@3.11.2':
     resolution: {integrity: sha512-OuFzMXPF4+xZgx8UzJha0AieuMihhhaWG0tCqpp6tDzlFwOmNBPYMuLOtMJ1Tr4pXLHmgjcWhG6RlknY2oNTdQ==}
     peerDependencies:
@@ -6651,6 +6661,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@tanstack/table-core@8.20.5':
+    resolution: {integrity: sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==}
+    engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.11.2':
     resolution: {integrity: sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==}
@@ -24340,6 +24354,12 @@ snapshots:
       '@tanstack/query-core': 5.45.0
       react: 18.3.1
 
+  '@tanstack/react-table@8.20.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/table-core': 8.20.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@tanstack/react-virtual@3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/virtual-core': 3.11.2
@@ -24351,6 +24371,8 @@ snapshots:
       '@tanstack/virtual-core': 3.5.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/table-core@8.20.5': {}
 
   '@tanstack/virtual-core@3.11.2': {}
 


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Brings in `@tanstack/react-table` and connects to the game-1 wallet list data. Adds a lot of sorting functionality, and ensures that the values are based on the list. A lot of powerful scaffolding is added with this, but we'll need to enhance the composability a bit to allow for more adjustable columns. We'll do this as an enhancement as this scaffolding gives us the power of React Table with our 1ui components.
- Updates the `AggregatedMetrics` component logic to calculate users and tvl
- Adds CTAs to Play Again and View List
- Adds invalidation so the table automatically updates after users complete the survey game

## Screen Captures

![table-flow-demo](https://github.com/user-attachments/assets/7bc756f9-931e-40d7-9b2f-748f7b63669d)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
