### PR TITLE
ENG-5463 feat(launchpad): detail modal table row click

### DIFF
--- a/apps/launchpad/app/components/atom-details-card.tsx
+++ b/apps/launchpad/app/components/atom-details-card.tsx
@@ -1,0 +1,103 @@
+import { cn, Text } from '@0xintuition/1ui'
+
+import { Coins, Users } from 'lucide-react'
+
+interface AtomDetailsCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  name: string
+  list?: string
+  icon: React.ReactNode
+  atomId: number
+  userCount: number
+  ethStaked: number
+}
+
+export function AtomDetailsCard({
+  name,
+  list,
+  icon,
+  atomId,
+  userCount,
+  ethStaked,
+  className,
+  ...props
+}: AtomDetailsCardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg bg-gradient-to-b from-[#060504] to-[#101010] min-w-[480px]',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4">
+          <div className="flex items-center gap-3">
+            <div className="size-6 rounded flex items-center justify-center">
+              {icon}
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Text
+                variant="body"
+                weight="normal"
+                className="text-foreground/70"
+              >
+                For {list}
+              </Text>
+              <div className="flex items-center gap-3">
+                <Text variant="bodyLarge" className="text-white">
+                  {name}
+                </Text>
+                <Text
+                  variant="caption"
+                  weight="normal"
+                  className="rounded-xl border border-border/10 px-2 py-0.5 text-[#E6B17E]"
+                >
+                  ID: {atomId}
+                </Text>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Middle section with description and stats */}
+        <div>
+          {/* <Text
+            variant="caption"
+            weight="normal"
+            className="text-foreground/90 px-4 pb-4"
+          >
+            This is the atom for this list entry.
+          </Text> */}
+          {/* Dotted line */}
+          <div className="py-4">
+            <div className="border-t border-dashed border-border/10" />
+          </div>
+
+          <div className="flex justify-between items-center px-4 pb-4">
+            <div className="flex items-center gap-2">
+              <Users className="h-4 w-4 text-amber-500" />
+              <Text
+                variant="caption"
+                weight="normal"
+                className="text-foreground/90"
+              >
+                {userCount} user position(s)
+              </Text>
+            </div>
+            <div className="flex items-center gap-2">
+              <Coins className="h-4 w-4 text-green-500" />
+              <Text
+                variant="caption"
+                weight="normal"
+                className="text-foreground/90"
+              >
+                {ethStaked.toFixed(3)} ETH staked
+              </Text>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/launchpad/app/components/atom-details-card.tsx
+++ b/apps/launchpad/app/components/atom-details-card.tsx
@@ -92,7 +92,7 @@ export function AtomDetailsCard({
                 weight="normal"
                 className="text-foreground/90"
               >
-                {ethStaked.toFixed(3)} ETH staked
+                {ethStaked.toFixed(4)} ETH staked
               </Text>
             </div>
           </div>

--- a/apps/launchpad/app/components/atom-details-card.tsx
+++ b/apps/launchpad/app/components/atom-details-card.tsx
@@ -67,7 +67,7 @@ export function AtomDetailsCard({
             weight="normal"
             className="text-foreground/90 px-4 pb-4"
           >
-            This is the atom for this list entry.
+            Created by {creator}
           </Text> */}
           {/* Dotted line */}
           <div className="py-4">

--- a/apps/launchpad/app/components/atom-details-modal.tsx
+++ b/apps/launchpad/app/components/atom-details-modal.tsx
@@ -13,7 +13,7 @@ interface AtomDetailsModalProps {
   onClose: () => void
   atomId: number
   data?: {
-    id: number
+    id: string
     image: string
     name: string
     list: string

--- a/apps/launchpad/app/components/atom-details-modal.tsx
+++ b/apps/launchpad/app/components/atom-details-modal.tsx
@@ -1,22 +1,59 @@
-import { Dialog, DialogContent, DialogTitle, Text } from '@0xintuition/1ui'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Icon,
+  Text,
+} from '@0xintuition/1ui'
+
+import { AtomDetailsCard } from './atom-details-card'
 
 interface AtomDetailsModalProps {
   isOpen: boolean
   onClose: () => void
   atomId: number
+  data?: {
+    id: number
+    image: string
+    name: string
+    list: string
+    users: number
+    assets: number
+  }
 }
 
 export function AtomDetailsModal({
   isOpen,
   onClose,
   atomId,
+  data,
 }: AtomDetailsModalProps) {
+  const cardData = {
+    name: data?.name ?? `Atom ${atomId}`,
+    list: data?.list ?? 'Intuition',
+    description: 'A detailed description of this atom will be added soon.',
+    icon: data?.image ? (
+      <img src={data.image} alt={data.name} className="h-6 w-6 rounded-full" />
+    ) : (
+      <Icon name="circles-three" className="h-6 w-6" />
+    ),
+    atomId,
+    userCount: data?.users ?? 0,
+    ethStaked: data?.assets ?? 0,
+    mutualConnections: 0, // Placeholder for now
+    onStake: () => console.log('Stake clicked'),
+    onChat: () => console.log('Chat clicked'),
+  }
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent>
-        <DialogTitle>
-          <Text>Atom Details - {atomId}</Text>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogTitle className="px-8">
+          <Text className="text-neutral-400 text-lg">Atom {atomId}</Text>
         </DialogTitle>
+        <div className="px-6 py-6">
+          <AtomDetailsCard {...cardData} />
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/apps/launchpad/app/components/atom-details-modal.tsx
+++ b/apps/launchpad/app/components/atom-details-modal.tsx
@@ -1,0 +1,23 @@
+import { Dialog, DialogContent, DialogTitle, Text } from '@0xintuition/1ui'
+
+interface AtomDetailsModalProps {
+  isOpen: boolean
+  onClose: () => void
+  atomId: number
+}
+
+export function AtomDetailsModal({
+  isOpen,
+  onClose,
+  atomId,
+}: AtomDetailsModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogTitle>
+          <Text>Atom Details - {atomId}</Text>
+        </DialogTitle>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/launchpad/app/components/ui/table/columns.tsx
+++ b/apps/launchpad/app/components/ui/table/columns.tsx
@@ -10,6 +10,7 @@ type TableItem = {
   id: string
   image: string
   name: string
+  list?: string
   users: number
   assets: number
 }

--- a/apps/launchpad/app/components/ui/table/data-table.tsx
+++ b/apps/launchpad/app/components/ui/table/data-table.tsx
@@ -26,9 +26,10 @@ import {
 
 import { DataTablePagination } from './data-table-pagination'
 
-interface DataTableProps<TData, TValue> {
+interface DataTableProps<TData extends { id: string | number }, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
+  onRowClick?: (id: number) => void
 }
 
 const getCommonPinningStyles = <T,>(
@@ -54,9 +55,10 @@ const getCommonPinningStyles = <T,>(
   }
 }
 
-export function DataTable<TData, TValue>({
+export function DataTable<TData extends { id: string | number }, TValue>({
   columns,
   data,
+  onRowClick,
 }: DataTableProps<TData, TValue>) {
   const [columnResizeMode] = React.useState<ColumnResizeMode>('onChange')
   const [sorting, setSorting] = React.useState<SortingState>([
@@ -148,8 +150,9 @@ export function DataTable<TData, TValue>({
                 table.getRowModel().rows.map((row) => (
                   <TableRow
                     key={row.id}
-                    className="border-b border-border/10 hover:bg-[#101010] transition-colors"
+                    className="border-b border-border/10 hover:bg-[#101010] transition-colors cursor-pointer"
                     data-state={row.getIsSelected() && 'selected'}
+                    onClick={() => onRowClick?.(Number(row.original.id))}
                   >
                     {row.getVisibleCells().map((cell) => (
                       <TableCell

--- a/apps/launchpad/app/lib/state/store.ts
+++ b/apps/launchpad/app/lib/state/store.ts
@@ -44,7 +44,7 @@ export const atomDetailsModalAtom = atom<{
   isOpen: boolean
   atomId: number
   data?: {
-    id: number
+    id: string
     image: string
     name: string
     list: string

--- a/apps/launchpad/app/lib/state/store.ts
+++ b/apps/launchpad/app/lib/state/store.ts
@@ -43,7 +43,16 @@ export const shareModalAtom = atom<{
 export const atomDetailsModalAtom = atom<{
   isOpen: boolean
   atomId: number
+  data?: {
+    id: number
+    image: string
+    name: string
+    list: string
+    users: number
+    assets: number
+  }
 }>({
   isOpen: false,
   atomId: 0,
+  data: undefined,
 })

--- a/apps/launchpad/app/lib/state/store.ts
+++ b/apps/launchpad/app/lib/state/store.ts
@@ -39,3 +39,11 @@ export const shareModalAtom = atom<{
   title: '',
   tvl: 0,
 })
+
+export const atomDetailsModalAtom = atom<{
+  isOpen: boolean
+  atomId: number
+}>({
+  isOpen: false,
+  atomId: 0,
+})

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -109,7 +109,7 @@ export default function MiniGameOne() {
   logger(listData?.globalTriples)
 
   interface TableRowData {
-    id: number
+    id: string
     image: string
     name: string
     list: string
@@ -123,8 +123,8 @@ export default function MiniGameOne() {
       // Debug log to see the image data
       console.log('Triple data:', triple)
 
-      const rowData: TableRowData = {
-        id: Number(triple.id),
+      const tableRow: TableRowData = {
+        id: String(triple.id),
         image: triple.subject.image || '',
         name: triple.subject.label || 'Untitled Entry',
         list: triple.object.label || 'Untitled List',
@@ -135,8 +135,8 @@ export default function MiniGameOne() {
         ),
       }
 
-      console.log('Row data:', rowData)
-      return rowData
+      console.log('Row data:', tableRow)
+      return tableRow
     }) || []
 
   // Log each triple's shares for debugging
@@ -160,7 +160,7 @@ export default function MiniGameOne() {
   }
 
   const handleRowClick = (id: number) => {
-    const rowData = tableData.find((row) => Number(row.id) === id)
+    const rowData = tableData.find((row) => row.id === String(id))
     console.log('Clicked row data:', rowData)
 
     if (rowData) {

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -107,26 +107,36 @@ export default function MiniGameOne() {
   )
 
   logger(listData?.globalTriples)
+
+  interface TableRowData {
+    id: number
+    image: string
+    name: string
+    list: string
+    users: number
+    assets: number
+  }
+
   // Transform the data for the table
-  const tableData =
+  const tableData: TableRowData[] =
     listData?.globalTriples?.map((triple) => {
       // Debug log to see the image data
-      logger('Triple data:', {
-        id: triple.id,
-        subject: triple.subject,
-        image: triple.subject.image,
-      })
+      console.log('Triple data:', triple)
 
-      return {
-        id: triple.id,
+      const rowData: TableRowData = {
+        id: Number(triple.id),
         image: triple.subject.image || '',
         name: triple.subject.label || 'Untitled Entry',
+        list: triple.object.label || 'Untitled List',
         users: Number(triple.vault?.positions_aggregate?.aggregate?.count ?? 0),
         assets: +formatUnits(
           triple.vault?.positions_aggregate?.aggregate?.sum?.shares ?? 0,
           18,
         ),
       }
+
+      console.log('Row data:', rowData)
+      return rowData
     }) || []
 
   // Log each triple's shares for debugging
@@ -150,7 +160,16 @@ export default function MiniGameOne() {
   }
 
   const handleRowClick = (id: number) => {
-    setAtomDetailsModal({ isOpen: true, atomId: id })
+    const rowData = tableData.find((row) => Number(row.id) === id)
+    console.log('Clicked row data:', rowData)
+
+    if (rowData) {
+      setAtomDetailsModal({
+        isOpen: true,
+        atomId: id,
+        data: rowData,
+      })
+    }
   }
 
   return (
@@ -239,8 +258,11 @@ export default function MiniGameOne() {
       />
       <AtomDetailsModal
         isOpen={atomDetailsModal.isOpen}
-        onClose={() => setAtomDetailsModal({ isOpen: false, atomId: 0 })}
+        onClose={() =>
+          setAtomDetailsModal({ isOpen: false, atomId: 0, data: undefined })
+        }
         atomId={atomDetailsModal.atomId}
+        data={atomDetailsModal.data}
       />
     </>
   )

--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -14,13 +14,18 @@ import {
   useGetListDetailsQuery,
 } from '@0xintuition/graphql'
 
+import { AtomDetailsModal } from '@components/atom-details-modal'
 import { OnboardingModal } from '@components/onboarding-modal/onboarding-modal'
 import ShareModal from '@components/share-modal'
 import { columns } from '@components/ui/table/columns'
 import { DataTable } from '@components/ui/table/data-table'
 import { mockMinigames } from '@lib/data/mock-minigames'
 import { useGoBack } from '@lib/hooks/useGoBack'
-import { onboardingModalAtom, shareModalAtom } from '@lib/state/store'
+import {
+  atomDetailsModalAtom,
+  onboardingModalAtom,
+  shareModalAtom,
+} from '@lib/state/store'
 import logger from '@lib/utils/logger'
 import { useLoaderData } from '@remix-run/react'
 // import { requireUser } from '@server/auth'
@@ -77,6 +82,7 @@ export default function MiniGameOne() {
   useLoaderData<typeof loader>()
   const [shareModalActive, setShareModalActive] = useAtom(shareModalAtom)
   const [onboardingModal, setOnboardingModal] = useAtom(onboardingModalAtom)
+  const [atomDetailsModal, setAtomDetailsModal] = useAtom(atomDetailsModalAtom)
 
   const hasUserParam = location.search.includes('user=')
   const fullPath = hasUserParam
@@ -143,6 +149,10 @@ export default function MiniGameOne() {
     setOnboardingModal({ isOpen: false, gameId: null })
   }
 
+  const handleRowClick = (id: number) => {
+    setAtomDetailsModal({ isOpen: true, atomId: id })
+  }
+
   return (
     <>
       <div className="flex items-center gap-4 mb-6">
@@ -206,7 +216,11 @@ export default function MiniGameOne() {
 
       {/* Space for table */}
       <div className="mt-6">
-        <DataTable columns={columns} data={tableData} />
+        <DataTable
+          columns={columns}
+          data={tableData}
+          onRowClick={handleRowClick}
+        />
       </div>
       <ShareModal
         open={shareModalActive.isOpen}
@@ -222,6 +236,11 @@ export default function MiniGameOne() {
       <OnboardingModal
         isOpen={onboardingModal.isOpen}
         onClose={handleCloseOnboarding}
+      />
+      <AtomDetailsModal
+        isOpen={atomDetailsModal.isOpen}
+        onClose={() => setAtomDetailsModal({ isOpen: false, atomId: 0 })}
+        atomId={atomDetailsModal.atomId}
       />
     </>
   )


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds in a basic AtomDetailCard that shows in a modal upon clicking the table row
- We can always add additional information to this modal, but this adds in the basic pattern/state/UI and data passing from table row to modal

## Screen Captures

![atom-detail-card-modal](https://github.com/user-attachments/assets/c3714c42-dd9a-489f-9494-838bc0fba384)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
