### PR TITLE
ENG-5478 feat(launchpad,1ui): adjust the aggregatedmetrics component to allow optional precision

### DIFF
--- a/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
+++ b/apps/launchpad/app/routes/_app+/minigames+/game-1.tsx
@@ -219,6 +219,7 @@ export default function MiniGameOne() {
               label: 'TVL',
               value: totalTVL,
               suffix: 'ETH',
+              precision: 2,
             },
             {
               label: 'Atoms',

--- a/apps/launchpad/app/routes/_app+/network.tsx
+++ b/apps/launchpad/app/routes/_app+/network.tsx
@@ -150,6 +150,7 @@ export default function Network() {
                 label: 'TVL',
                 value: +formatUnits(stats?.contract_balance ?? 0, 18),
                 suffix: 'ETH',
+                precision: 2,
               },
               { label: 'Atoms', value: stats?.total_atoms ?? 0 },
               { label: 'Triples', value: stats?.total_triples ?? 0 },

--- a/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.spec.tsx
+++ b/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.spec.tsx
@@ -47,7 +47,7 @@ describe('AggregatedMetrics', () => {
             <div
               class="text-2xl font-medium text-foreground"
             >
-              4.20k
+              4.20K
             </div>
           </div>
           <div
@@ -61,7 +61,7 @@ describe('AggregatedMetrics', () => {
             <div
               class="text-2xl font-medium text-foreground"
             >
-              4.20k
+              4.20K
             </div>
           </div>
           <div
@@ -75,7 +75,7 @@ describe('AggregatedMetrics', () => {
             <div
               class="text-2xl font-medium text-foreground"
             >
-              4.20k
+              4.20K
             </div>
           </div>
           <div
@@ -89,7 +89,7 @@ describe('AggregatedMetrics', () => {
             <div
               class="text-2xl font-medium text-foreground"
             >
-              4.20k
+              4.20K
             </div>
           </div>
         </div>

--- a/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.tsx
+++ b/packages/1ui/src/components/AggregatedMetrics/AggregatedMetrics.tsx
@@ -6,6 +6,7 @@ interface Metric {
   value: number | string
   hideOnMobile?: boolean
   suffix?: string
+  precision?: number
 }
 
 interface AggregatedMetricsProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -25,26 +26,32 @@ export function AggregatedMetrics({
       )}
       {...props}
     >
-      {metrics.map(({ label, value, hideOnMobile, suffix }, index) => {
-        const formattedValue = typeof value === 'string' ? Number(value) : value
-        return (
-          <div
-            key={label}
-            className={cn(
-              'relative text-center px-12',
-              hideOnMobile && 'hidden lg:block',
-              index !== metrics.length - 1 &&
-                'after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20',
-            )}
-          >
-            <div className="text-sm text-foreground/70">{label}</div>
-            <div className="text-2xl font-medium text-foreground">
-              {formatNumber(formattedValue, 2)}
-              {suffix ? ` ${suffix}` : ''}
+      {metrics.map(
+        ({ label, value, hideOnMobile, suffix, precision }, index) => {
+          const formattedValue =
+            typeof value === 'string' ? Number(value) : value
+          const shouldForceDecimals = formattedValue >= 1000
+          const effectivePrecision = shouldForceDecimals ? 2 : precision ?? 0
+
+          return (
+            <div
+              key={label}
+              className={cn(
+                'relative text-center px-12',
+                hideOnMobile && 'hidden lg:block',
+                index !== metrics.length - 1 &&
+                  'after:absolute after:right-0 after:inset-y-0 after:w-px after:bg-border/20',
+              )}
+            >
+              <div className="text-sm text-foreground/70">{label}</div>
+              <div className="text-2xl font-medium text-foreground">
+                {formatNumber(formattedValue, effectivePrecision)}
+                {suffix ? ` ${suffix}` : ''}
+              </div>
             </div>
-          </div>
-        )
-      })}
+          )
+        },
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [x] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

* Allows optional precision prop in AggregatedMetrics component.
* Still takes into account formatted values (i.e. 1.25k) and forces the 2 precision
* ETH values should have precision set otherwise could render all 18 decimals
* Whole numbers will render without .00 that was previously a problem

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
