### PR TITLE
ENG-5469 feat(launchpad): wire up points to home page and success handler

### DIFF
--- a/apps/launchpad/app/components/minigame-card-wrapper.tsx
+++ b/apps/launchpad/app/components/minigame-card-wrapper.tsx
@@ -1,7 +1,9 @@
 import { useMinigameData } from '@lib/hooks/useMinigameData'
 import type { Minigame } from '@lib/types/minigame'
+import logger from '@lib/utils/logger'
 import { usePrivy } from '@privy-io/react-auth'
 
+import { usePoints } from '../lib/hooks/usePoints'
 import { AuthCover } from './auth-cover'
 import { MinigameCard } from './minigame-card'
 
@@ -16,13 +18,17 @@ export function MinigameCardWrapper({
   onStart,
   className,
 }: MinigameCardWrapperProps) {
-  const { authenticated } = usePrivy()
+  const { authenticated, user } = usePrivy()
   const gameData = useMinigameData(gameId)
+  const userWallet = user?.wallet?.address?.toLowerCase()
+  const { data: points } = usePoints(userWallet)
+
+  logger('Points data:', points)
 
   const game: Minigame = {
     id: gameId,
     title: gameData.title,
-    points: gameData.points,
+    points: points?.minigame1 || 0,
     totalAtoms: gameData.atoms,
     totalUsers: gameData.users,
     totalEarned: gameData.totalEarned,

--- a/apps/launchpad/app/components/minigame-card.tsx
+++ b/apps/launchpad/app/components/minigame-card.tsx
@@ -36,19 +36,19 @@ export function MinigameCard({
         {!hideCTA && (
           <div className="flex flex-col items-center">
             <Button onClick={onStart} variant="primary" size="lg">
-              Earn {game.points} Points
+              Earn Points
             </Button>
           </div>
         )}
 
-        <div className="flex justify-between">
-          <Text
-            variant="heading5"
-            weight="semibold"
-            className="text-foreground"
-          >
-            ${game.totalEarned.toFixed(1)}
-          </Text>
+        <div className="flex justify-between items-center">
+          {game.points > 0 ? (
+            <Text variant="body" weight="semibold" className="text-green-500">
+              {game.points} points earned!
+            </Text>
+          ) : (
+            <div />
+          )}
           <Button
             variant="secondary"
             onClick={() => navigate('/minigames/game-1')}

--- a/apps/launchpad/app/components/minigame-card.tsx
+++ b/apps/launchpad/app/components/minigame-card.tsx
@@ -8,6 +8,7 @@ interface MinigameCardProps {
   onStart: () => void
   game: Minigame
   hideCTA?: boolean
+  isLoading?: boolean
 }
 
 export function MinigameCard({
@@ -15,6 +16,7 @@ export function MinigameCard({
   onStart,
   game,
   hideCTA = false,
+  isLoading = false,
 }: MinigameCardProps) {
   const navigate = useNavigate()
 
@@ -35,8 +37,18 @@ export function MinigameCard({
 
         {!hideCTA && (
           <div className="flex flex-col items-center">
-            <Button onClick={onStart} variant="primary" size="lg">
-              Earn 200 IQ Points
+            <Button
+              onClick={onStart}
+              variant="primary"
+              size="lg"
+              className="min-w-[200px]"
+              disabled={isLoading}
+            >
+              {isLoading
+                ? 'Loading...'
+                : game.points > 0
+                  ? 'Play Again'
+                  : 'Earn 200 IQ Points'}
             </Button>
           </div>
         )}

--- a/apps/launchpad/app/components/minigame-card.tsx
+++ b/apps/launchpad/app/components/minigame-card.tsx
@@ -36,16 +36,21 @@ export function MinigameCard({
         {!hideCTA && (
           <div className="flex flex-col items-center">
             <Button onClick={onStart} variant="primary" size="lg">
-              Earn Points
+              Earn 200 IQ Points
             </Button>
           </div>
         )}
 
         <div className="flex justify-between items-center">
           {game.points > 0 ? (
-            <Text variant="body" weight="semibold" className="text-green-500">
-              {game.points} points earned!
-            </Text>
+            <div className="flex items-baseline gap-2">
+              <span className="text-xl font-bold bg-gradient-to-r from-[#34C578] to-[#00FF94] bg-clip-text text-transparent">
+                {game.points}
+              </span>
+              <span className="text-md font-semibold text-muted-foreground">
+                IQ Earned
+              </span>
+            </div>
           ) : (
             <div />
           )}

--- a/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
@@ -12,7 +12,6 @@ import { CURRENT_ENV } from '@consts/general'
 import { getSpecialPredicate } from '@lib/utils/app'
 import logger from '@lib/utils/logger'
 import { usePrivy } from '@privy-io/react-auth'
-import { Form, useNavigate } from '@remix-run/react'
 import { useQueryClient } from '@tanstack/react-query'
 import { ClientOnly } from 'remix-utils/client-only'
 
@@ -30,15 +29,6 @@ import {
   STEPS,
   Topic,
 } from './types'
-
-interface PointsResponse {
-  success: boolean
-  data?: {
-    account_id: string
-    minigame1: number
-  }
-  error?: string
-}
 
 const STORAGE_KEY = 'onboarding-progress'
 
@@ -59,7 +49,6 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
   const queryClient = useQueryClient()
   const { user: privyUser } = usePrivy()
   const userWallet = privyUser?.wallet?.address
-  const navigate = useNavigate()
 
   const [state, setState] = useState<OnboardingState>(INITIAL_STATE)
   const [topics, setTopics] = useState<Topic[]>([])

--- a/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
@@ -278,23 +278,18 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
     [steps, state.currentStep, handleTransition],
   )
 
-  const awardPoints = useCallback(
-    (accountId: string, redirectUrl?: string) => {
-      logger('Submitting points update...')
-      const formData = new FormData()
-      formData.append('accountId', accountId)
-      formData.append('type', 'minigame1')
-      if (redirectUrl) {
-        formData.append('redirectUrl', redirectUrl)
-      }
-
-      fetcher.submit(formData, {
-        method: 'post',
-        action: '/actions/reward-points',
-      })
-    },
-    [fetcher],
-  )
+  const awardPoints = (accountId: string, redirectUrl?: string) => {
+    const formData = new FormData()
+    formData.append('accountId', accountId)
+    formData.append('type', 'minigame1')
+    if (redirectUrl) {
+      formData.append('redirectUrl', redirectUrl)
+    }
+    fetcher.submit(formData, {
+      method: 'post',
+      action: '/actions/reward-points',
+    })
+  }
 
   useEffect(() => {
     logger('Fetcher state:', fetcher.state)
@@ -302,10 +297,7 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
 
     if (fetcher.state === 'idle' && fetcher.data?.success) {
       logger('Points updated successfully')
-      // Don't invalidate queries here since we don't need to refresh the list
-      // queryClient.invalidateQueries({
-      //   queryKey: ['get-list-details', { predicateId, objectId }],
-      // })
+      // Redirect will be handled by the action response
     }
   }, [fetcher.state, fetcher.data])
 
@@ -415,6 +407,7 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
                     txHash={txState.txHash}
                     userWallet={userWallet}
                     awardPoints={awardPoints}
+                    redirectUrl="/minigames/game-1"
                   />
                 )}
             </div>

--- a/apps/launchpad/app/components/onboarding-modal/reward-step.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/reward-step.tsx
@@ -10,9 +10,19 @@ interface RewardStepProps {
   selectedTopic: Topic
   newAtomMetadata?: NewAtomMetadata
   txHash?: string
+  userWallet?: string
+  awardPoints?: (accountId: string, redirectUrl?: string) => void
+  redirectUrl?: string
 }
 
-export function RewardStep({ isOpen, selectedTopic, txHash }: RewardStepProps) {
+export function RewardStep({
+  isOpen,
+  selectedTopic,
+  txHash,
+  userWallet,
+  awardPoints,
+  redirectUrl,
+}: RewardStepProps) {
   const { reward } = useReward('rewardId', 'confetti', {
     lifetime: 1000,
     elementCount: 100,
@@ -26,12 +36,17 @@ export function RewardStep({ isOpen, selectedTopic, txHash }: RewardStepProps) {
     },
   })
   const [hasRewardAnimated, setHasRewardAnimated] = useState(false)
+  const [hasAwardedPoints, setHasAwardedPoints] = useState(false)
 
   useEffect(() => {
     if (isOpen && !hasRewardAnimated) {
       const timer = setTimeout(() => {
         reward()
-        setHasRewardAnimated(true)
+        // Award points when animation starts if we haven't already
+        if (!hasAwardedPoints && userWallet && awardPoints) {
+          awardPoints(userWallet.toLowerCase(), redirectUrl)
+          setHasAwardedPoints(true)
+        }
       }, 500)
 
       return () => clearTimeout(timer)
@@ -39,8 +54,17 @@ export function RewardStep({ isOpen, selectedTopic, txHash }: RewardStepProps) {
 
     if (!isOpen) {
       setHasRewardAnimated(false)
+      setHasAwardedPoints(false)
     }
-  }, [isOpen, hasRewardAnimated, reward])
+  }, [
+    isOpen,
+    hasRewardAnimated,
+    hasAwardedPoints,
+    reward,
+    userWallet,
+    awardPoints,
+    redirectUrl,
+  ])
 
   return (
     <div className="p-8">

--- a/apps/launchpad/app/components/onboarding-modal/reward-step.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/reward-step.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { BLOCK_EXPLORER_URL } from '@consts/general'
+import { useQueryClient } from '@tanstack/react-query'
 import { useReward } from 'react-rewards'
 
 import { NewAtomMetadata, Topic } from './types'
@@ -23,6 +24,7 @@ export function RewardStep({
   awardPoints,
   redirectUrl,
 }: RewardStepProps) {
+  const queryClient = useQueryClient()
   const { reward } = useReward('rewardId', 'confetti', {
     lifetime: 1000,
     elementCount: 100,
@@ -45,6 +47,10 @@ export function RewardStep({
         // Award points when animation starts if we haven't already
         if (!hasAwardedPoints && userWallet && awardPoints) {
           awardPoints(userWallet.toLowerCase(), redirectUrl)
+          // Invalidate points query to force a refresh
+          queryClient.invalidateQueries({
+            queryKey: ['account-points', userWallet.toLowerCase()],
+          })
           setHasAwardedPoints(true)
         }
       }, 500)
@@ -64,6 +70,7 @@ export function RewardStep({
     userWallet,
     awardPoints,
     redirectUrl,
+    queryClient,
   ])
 
   return (

--- a/apps/launchpad/app/lib/hooks/usePoints.ts
+++ b/apps/launchpad/app/lib/hooks/usePoints.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+export function usePoints(accountId?: string) {
+  return useQuery({
+    queryKey: ['account-points', accountId],
+    queryFn: async () => {
+      if (!accountId) {
+        return null
+      }
+      const response = await fetch(
+        `/resources/get-points?accountId=${accountId}`,
+      )
+      const data = await response.json()
+      return data.points
+    },
+    enabled: !!accountId,
+  })
+}

--- a/apps/launchpad/app/routes/actions+/reward-points.ts
+++ b/apps/launchpad/app/routes/actions+/reward-points.ts
@@ -142,10 +142,9 @@ export async function action({ request }: ActionFunctionArgs) {
     const result = await upsertPoints(accountId.toString(), pointsAllocation)
     logger('upsert result:', result)
 
-    // If redirectUrl is provided, redirect after successful points update
+    // If redirectUrl is provided, redirect to it
     if (redirectUrl && typeof redirectUrl === 'string') {
-      logger('redirecting to:', redirectUrl)
-      throw redirect(redirectUrl)
+      return redirect(redirectUrl)
     }
 
     return { success: true, data: result }

--- a/apps/launchpad/app/routes/actions+/reward-points.ts
+++ b/apps/launchpad/app/routes/actions+/reward-points.ts
@@ -144,7 +144,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
     // If redirectUrl is provided, redirect after successful points update
     if (redirectUrl && typeof redirectUrl === 'string') {
-      return redirect(redirectUrl)
+      logger('redirecting to:', redirectUrl)
+      throw redirect(redirectUrl)
     }
 
     return { success: true, data: result }

--- a/apps/launchpad/app/routes/actions+/reward-points.ts
+++ b/apps/launchpad/app/routes/actions+/reward-points.ts
@@ -1,0 +1,158 @@
+import logger from '@lib/utils/logger'
+import { invariant } from '@lib/utils/misc'
+import type { ActionFunctionArgs } from '@remix-run/node'
+import { redirect } from '@remix-run/node'
+import { gql, GraphQLClient } from 'graphql-request'
+
+interface PointsRecord {
+  account_id: string
+  community: number
+  minigame1: number
+  portal_quests: number
+  referral: number
+  social: number
+}
+
+interface GetAccountPointsResponse {
+  points_by_pk: PointsRecord | null
+}
+
+interface InsertPointsResponse {
+  insert_points_one: {
+    account_id: string
+  }
+}
+
+interface UpdatePointsResponse {
+  update_points_by_pk: {
+    account_id: string
+  }
+}
+
+const api_url = process.env.HASURA_POINTS_ENDPOINT
+const client = new GraphQLClient(api_url!, {
+  headers: {
+    'x-hasura-admin-secret': process.env.HASURA_POINTS_SECRET as string,
+  },
+})
+
+const GetAccountPointsQuery = gql`
+  query GetAccountPoints($account_id: String!) {
+    points_by_pk(account_id: $account_id) {
+      account_id
+      community
+      minigame1
+      portal_quests
+      referral
+      social
+    }
+  }
+`
+
+const InsertPointsMutation = gql`
+  mutation InsertPoints($object: points_insert_input = {}) {
+    insert_points_one(object: $object) {
+      account_id
+      minigame1
+    }
+  }
+`
+
+const UpdatePointsMutation = gql`
+  mutation UpdatePoints(
+    $account_id: String = ""
+    $points: points_set_input = {}
+  ) {
+    update_points_by_pk(
+      pk_columns: { account_id: $account_id }
+      _set: $points
+    ) {
+      account_id
+      minigame1
+    }
+  }
+`
+
+export const getAccountPoints = async (account_id: string) => {
+  const data = await client.request<GetAccountPointsResponse>(
+    GetAccountPointsQuery,
+    {
+      account_id,
+    },
+  )
+  return data.points_by_pk
+}
+
+export const insertPoints = async (points: Partial<PointsRecord>) => {
+  const data = await client.request<InsertPointsResponse>(
+    InsertPointsMutation,
+    {
+      object: points,
+    },
+  )
+  return data.insert_points_one
+}
+
+export const updatePoints = async (
+  account_id: string,
+  points: Partial<PointsRecord>,
+) => {
+  const data = await client.request<UpdatePointsResponse>(
+    UpdatePointsMutation,
+    {
+      account_id,
+      points,
+    },
+  )
+  return data.update_points_by_pk
+}
+
+export const upsertPoints = async (
+  account_id: string,
+  points: Partial<PointsRecord>,
+) => {
+  const existing = await getAccountPoints(account_id)
+  if (existing) {
+    return updatePoints(account_id, points)
+  }
+  return insertPoints({ account_id, ...points })
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
+  const formData = await request.formData()
+  const accountId = formData.get('accountId')
+  const type = formData.get('type')
+  const redirectUrl = formData.get('redirectUrl')
+
+  invariant(accountId, 'accountId is required')
+  invariant(type, 'type is required')
+  invariant(typeof type === 'string', 'type must be a string')
+
+  // Only update minigame1 points, leave other fields untouched
+  const pointsAllocation: Partial<PointsRecord> = {
+    minigame1: type === 'minigame1' ? 200 : 0,
+  }
+
+  try {
+    logger('upserting points for account', accountId)
+    const result = await upsertPoints(accountId.toString(), pointsAllocation)
+    logger('upsert result:', result)
+
+    // If redirectUrl is provided, redirect after successful points update
+    if (redirectUrl && typeof redirectUrl === 'string') {
+      return redirect(redirectUrl)
+    }
+
+    return { success: true, data: result }
+  } catch (error) {
+    if (error instanceof Response) {
+      throw error
+    }
+    console.error('Error updating points:', error)
+    return { success: false, error: 'Failed to update points' }
+  }
+}

--- a/apps/launchpad/app/routes/resources+/get-points.ts
+++ b/apps/launchpad/app/routes/resources+/get-points.ts
@@ -1,0 +1,55 @@
+import { error } from 'console'
+import process from 'process'
+
+import { type LoaderFunctionArgs } from '@remix-run/node'
+import { gql, GraphQLClient } from 'graphql-request'
+
+interface PointsRecord {
+  account_id: string
+  community: number
+  minigame1: number
+  portal_quests: number
+  referral: number
+  social: number
+}
+
+interface GetAccountPointsResponse {
+  points_by_pk: PointsRecord | null
+}
+
+const GetAccountPointsQuery = gql`
+  query GetAccountPoints($account_id: String!) {
+    points_by_pk(account_id: $account_id) {
+      account_id
+      community
+      minigame1
+      portal_quests
+      referral
+      social
+    }
+  }
+`
+
+if (process.env.HASURA_POINTS_ENDPOINT === undefined) {
+  throw error('Endpoint not defined')
+}
+
+const client = new GraphQLClient(process.env.HASURA_POINTS_ENDPOINT)
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url)
+  const accountId = url.searchParams.get('accountId')
+
+  if (!accountId) {
+    return { points: null }
+  }
+
+  const data = await client.request<GetAccountPointsResponse>(
+    GetAccountPointsQuery,
+    {
+      account_id: accountId,
+    },
+  )
+
+  return { points: data.points_by_pk }
+}

--- a/apps/launchpad/package.json
+++ b/apps/launchpad/package.json
@@ -41,6 +41,7 @@
     "cytoscape-popper": "^4.0.1",
     "date-fns": "^3.6.0",
     "framer-motion": "^11.2.10",
+    "graphql-request": "^7.1.0",
     "isbot": "^4.1.0",
     "jotai": "^2.8.3",
     "lucide-react": "^0.441.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       framer-motion:
         specifier: ^11.2.10
         version: 11.2.10(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      graphql-request:
+        specifier: ^7.1.0
+        version: 7.1.0(graphql@16.9.0)
       isbot:
         specifier: ^4.1.0
         version: 4.4.0


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds in server actions / resources for setting and getting points
- Adds in the awarding of points on success for first time completing minigame one
- Creates a usePoints hook to query the points from the resource route and display in the minigame card

## Screen Captures

<img width="1439" alt="points-card" src="https://github.com/user-attachments/assets/8fe52560-3973-4c65-a088-70602f8912b3" />

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
