### PR TITLE
ENG-5492 fix(launchpad): update metadata to remove intuition explorer label

### DIFF
--- a/apps/launchpad/app/root.tsx
+++ b/apps/launchpad/app/root.tsx
@@ -53,7 +53,7 @@ export const meta: MetaFunction = () => {
     },
     {
       name: 'twitter:title',
-      content: 'Intuition Explorer',
+      content: 'Intuition Launchpad',
     },
     {
       name: 'twitter:description',


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Removes any mention of Explorer and replaces it with Launchpad.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
