### PR TITLE
ENG-5556 feat(launchpad): ux second pass

### DIFF
--- a/apps/launchpad/app/components/auth-cover.tsx
+++ b/apps/launchpad/app/components/auth-cover.tsx
@@ -43,7 +43,7 @@ export function AuthCover({
             variant="primary"
             size="lg"
             onClick={login}
-            className="pointer-events-auto shadow-2xl"
+            className="pointer-events-auto shadow-2xl min-w-[200px]"
           >
             Connect Wallet
           </Button>

--- a/apps/launchpad/app/components/layouts/app-shell.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell.tsx
@@ -28,7 +28,7 @@ function AppShellContent({ children }: AppShellContentProps) {
 
 function AppShellInner({ children }: BaseLayoutProps) {
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen overflow-y-scroll">
       <SidebarProvider
         style={
           {

--- a/apps/launchpad/app/components/layouts/app-shell.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell.tsx
@@ -6,22 +6,12 @@ import { AppSidebar } from '../app-sidebar'
 import { AppShellProvider, useAppShell } from './app-shell-context'
 import { BaseLayoutProps, layoutConfig } from './types'
 
-function LoadingSpinner() {
-  return (
-    <div className="flex h-screen items-center justify-center">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-accent border-t-transparent" />
-    </div>
-  )
-}
+interface AppShellContentProps extends BaseLayoutProps {}
 
-interface AppShellContentProps extends BaseLayoutProps {
-  suspense?: boolean
-}
-
-function AppShellContent({ children, suspense = true }: AppShellContentProps) {
+function AppShellContent({ children }: AppShellContentProps) {
   const { layoutVariant, paddingVariant } = useAppShell()
 
-  const content = (
+  return (
     <div className="flex justify-center w-full max-w-screen-xl mx-auto">
       <div
         className={cn(
@@ -34,14 +24,6 @@ function AppShellContent({ children, suspense = true }: AppShellContentProps) {
       </div>
     </div>
   )
-
-  if (suspense) {
-    return (
-      <React.Suspense fallback={<LoadingSpinner />}>{content}</React.Suspense>
-    )
-  }
-
-  return content
 }
 
 function AppShellInner({ children }: BaseLayoutProps) {

--- a/apps/launchpad/app/components/layouts/app-shell.tsx
+++ b/apps/launchpad/app/components/layouts/app-shell.tsx
@@ -28,7 +28,7 @@ function AppShellContent({ children }: AppShellContentProps) {
 
 function AppShellInner({ children }: BaseLayoutProps) {
   return (
-    <div className="flex flex-col min-h-screen overflow-y-scroll">
+    <div className="flex flex-col min-h-screen">
       <SidebarProvider
         style={
           {

--- a/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
@@ -179,6 +179,16 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
     }
   }, [isOpen, queryClient])
 
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.paddingRight = 'var(--removed-body-scroll-bar-size)'
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.paddingRight = ''
+      document.body.style.overflow = ''
+    }
+  }, [isOpen])
+
   const handleNext = useCallback(() => {
     if (state.currentStep === STEPS.TOPICS) {
       const selectedTopic = topics.find((topic) => topic.selected)
@@ -405,7 +415,6 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
                     txHash={txState.txHash}
                     userWallet={userWallet}
                     awardPoints={awardPoints}
-                    redirectUrl="/minigames/game-1"
                   />
                 )}
             </div>

--- a/apps/launchpad/app/components/onboarding-modal/topics-step.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/topics-step.tsx
@@ -9,6 +9,7 @@ import {
 
 import LoadingLogo from '@components/loading-logo'
 import { Search } from '@components/search'
+import { QUESTIONS_METADATA } from '@lib/utils/constants'
 import { Book } from 'lucide-react'
 
 import { Topic } from './types'
@@ -34,14 +35,14 @@ export function TopicsStep({
         <div className="flex items-start justify-between gap-4 pb-5">
           <div className="space-y-1">
             <Text variant="headline" className="font-semibold">
-              What is your preferred Web3 Wallet?
+              {QUESTIONS_METADATA.ONE.title}
             </Text>
             <Text
               variant={TextVariant.footnote}
               className="text-primary/70 flex flex-row gap-1 items-center"
             >
               <Book className="h-4 w-4 text-primary/70" />
-              Select your preferred wallet from the list below.
+              {QUESTIONS_METADATA.ONE.description}
             </Text>
           </div>
         </div>

--- a/apps/launchpad/app/lib/hooks/usePoints.ts
+++ b/apps/launchpad/app/lib/hooks/usePoints.ts
@@ -2,17 +2,19 @@ import { useQuery } from '@tanstack/react-query'
 
 export function usePoints(accountId?: string) {
   return useQuery({
-    queryKey: ['account-points', accountId],
+    queryKey: ['account-points', accountId?.toLowerCase()],
     queryFn: async () => {
       if (!accountId) {
         return null
       }
       const response = await fetch(
-        `/resources/get-points?accountId=${accountId}`,
+        `/resources/get-points?accountId=${accountId.toLowerCase()}`,
       )
       const data = await response.json()
       return data.points
     },
     enabled: !!accountId,
+    // This ensures we don't refetch on mount if we already have the data
+    staleTime: 30000, // Consider data fresh for 30 seconds
   })
 }

--- a/apps/launchpad/app/lib/utils/constants.ts
+++ b/apps/launchpad/app/lib/utils/constants.ts
@@ -1,0 +1,27 @@
+export const QUESTIONS_METADATA = {
+  ONE: {
+    title: 'What is your preferred Web3 Wallet?',
+    description: 'Select your preferred wallet from the list below.',
+  },
+  TWO: {
+    title: 'Coming Soon',
+    description: 'More questions are on the way!',
+  },
+} as const
+
+export const QUESTS = [
+  {
+    title: 'What are your preferences?',
+    description: 'Answer questions about your preferences to earn IQ!',
+    link: '/quests/questions',
+    enabled: true,
+    index: 1,
+  },
+  {
+    title: 'What are your preferences?',
+    description: 'Answer questions about your preferences to earn IQ!',
+    link: '/quests/preferences',
+    enabled: false,
+    index: 2,
+  },
+]

--- a/apps/launchpad/app/routes/_app+/quests+/index.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/index.tsx
@@ -2,27 +2,11 @@ import { PageHeader } from '@0xintuition/1ui'
 
 import { ErrorPage } from '@components/error-page'
 import { QuestCard } from '@components/quest-card'
+import { QUESTS } from '@lib/utils/constants'
 
 export function ErrorBoundary() {
   return <ErrorPage routeName="dashboard" />
 }
-
-const QUESTS = [
-  {
-    title: 'What are your preferences?',
-    description: 'Answer questions about your preferences to earn IQ!',
-    link: '/quests/questions',
-    enabled: true,
-    index: 1,
-  },
-  {
-    title: 'What are your preferences?',
-    description: 'Answer questions about your preferences to earn IQ!',
-    link: '/quests/preferences',
-    enabled: false,
-    index: 2,
-  },
-]
 
 export default function Quests() {
   return (

--- a/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
@@ -89,7 +89,7 @@ export default function MiniGameOne() {
   const [onboardingModal, setOnboardingModal] = useAtom(onboardingModalAtom)
   const [atomDetailsModal, setAtomDetailsModal] = useAtom(atomDetailsModalAtom)
 
-  const { user: privyUser } = usePrivy()
+  const { user: privyUser, authenticated } = usePrivy()
   const userWallet = privyUser?.wallet?.address?.toLowerCase()
   const { data: points, isLoading: isPointsLoading } = usePoints(userWallet)
 
@@ -173,7 +173,6 @@ export default function MiniGameOne() {
 
   const handleRowClick = (id: number) => {
     const rowData = tableData.find((row) => row.id === String(id))
-    console.log('Clicked row data:', rowData)
 
     if (rowData) {
       setAtomDetailsModal({
@@ -252,7 +251,7 @@ export default function MiniGameOne() {
                   {questionData.title}
                 </Text>
               </div>
-              <AuthCover>
+              <AuthCover buttonContainerClassName="h-full flex items-center justify-center w-full">
                 {gamePoints > 0 ? (
                   <div className="flex items-baseline gap-2">
                     <span className="text-xl font-bold bg-gradient-to-r from-[#34C578] to-[#00FF94] bg-clip-text text-transparent">
@@ -263,13 +262,15 @@ export default function MiniGameOne() {
                     </span>
                   </div>
                 ) : (
-                  <Button
-                    variant="primary"
-                    size="lg"
-                    onClick={handleStartOnboarding}
-                  >
-                    Earn 200 IQ Points
-                  </Button>
+                  authenticated && (
+                    <Button
+                      variant="primary"
+                      size="lg"
+                      onClick={handleStartOnboarding}
+                    >
+                      Earn 200 IQ Points
+                    </Button>
+                  )
                 )}
               </AuthCover>
             </div>

--- a/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Icon,
   PageHeader,
+  Text,
 } from '@0xintuition/1ui'
 import {
   fetcher,
@@ -28,9 +29,10 @@ import {
   onboardingModalAtom,
   shareModalAtom,
 } from '@lib/state/store'
+import { QUESTIONS_METADATA } from '@lib/utils/constants'
 import logger from '@lib/utils/logger'
 import { usePrivy } from '@privy-io/react-auth'
-import { useLoaderData } from '@remix-run/react'
+import { useLoaderData, useParams } from '@remix-run/react'
 // import { requireUser } from '@server/auth'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { useAtom } from 'jotai'
@@ -115,6 +117,11 @@ export default function MiniGameOne() {
 
   logger(listData?.globalTriples)
 
+  const { id } = useParams()
+  const questionData =
+    QUESTIONS_METADATA[id?.toUpperCase() as keyof typeof QUESTIONS_METADATA] ||
+    QUESTIONS_METADATA.ONE
+
   interface TableRowData {
     id: string
     image: string
@@ -128,7 +135,6 @@ export default function MiniGameOne() {
   const tableData: TableRowData[] =
     listData?.globalTriples?.map((triple) => {
       // Debug log to see the image data
-      console.log('Triple data:', triple)
 
       const tableRow: TableRowData = {
         id: String(triple.id),
@@ -142,7 +148,6 @@ export default function MiniGameOne() {
         ),
       }
 
-      console.log('Row data:', tableRow)
       return tableRow
     }) || []
 
@@ -194,7 +199,9 @@ export default function MiniGameOne() {
           >
             <Icon name="chevron-left" className="h-4 w-4" />
           </Button>
-          <PageHeader title="Quest: Questions -- Crypto Wallets - Results" />
+          <div className="flex flex-1 justify-between items-center">
+            <PageHeader title="Quest: Question One" />
+          </div>
         </div>
         <div className="flex items-center justify-center h-[400px]">
           <LoadingLogo size={100} />
@@ -215,8 +222,7 @@ export default function MiniGameOne() {
           <Icon name="chevron-left" className="h-4 w-4" />
         </Button>
         <div className="flex flex-1 justify-between items-center">
-          {/* <PageHeader title={listData?.globalTriples[0].object.label ?? ''} /> */}
-          <PageHeader title="Quest: Questions -- Crypto Wallets - Results" />
+          <PageHeader title="Quest: Question One" />
           <div className="flex items-center gap-2">
             <Button
               variant="secondary"
@@ -241,13 +247,18 @@ export default function MiniGameOne() {
         <div className="relative">
           <Card className="h-[400px] border-none bg-gradient-to-br from-[#060504] to-[#101010] min-w-[480px]">
             <div className="absolute inset-0 flex flex-col justify-center items-center">
+              <div className="space-y-2 items-center pb-8">
+                <Text variant="heading3" className="text-foreground">
+                  {questionData.title}
+                </Text>
+              </div>
               <AuthCover>
                 <Button
                   variant="primary"
                   size="lg"
                   onClick={gamePoints > 0 ? undefined : handleStartOnboarding}
                 >
-                  {gamePoints > 0 ? 'Already Completed' : 'Earn 200 IQ Points'}
+                  {gamePoints > 0 ? '200 IQ Earned' : 'Earn 200 IQ Points'}
                 </Button>
               </AuthCover>
             </div>

--- a/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
@@ -253,13 +253,24 @@ export default function MiniGameOne() {
                 </Text>
               </div>
               <AuthCover>
-                <Button
-                  variant="primary"
-                  size="lg"
-                  onClick={gamePoints > 0 ? undefined : handleStartOnboarding}
-                >
-                  {gamePoints > 0 ? '200 IQ Earned' : 'Earn 200 IQ Points'}
-                </Button>
+                {gamePoints > 0 ? (
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-xl font-bold bg-gradient-to-r from-[#34C578] to-[#00FF94] bg-clip-text text-transparent">
+                      200
+                    </span>
+                    <span className="text-md font-semibold text-muted-foreground">
+                      IQ Earned
+                    </span>
+                  </div>
+                ) : (
+                  <Button
+                    variant="primary"
+                    size="lg"
+                    onClick={handleStartOnboarding}
+                  >
+                    Earn 200 IQ Points
+                  </Button>
+                )}
               </AuthCover>
             </div>
           </Card>

--- a/apps/launchpad/app/styles/globals.css
+++ b/apps/launchpad/app/styles/globals.css
@@ -6,6 +6,7 @@
   :root {
     --accent: #ba8461 !important;
     --green-500: #34c578 !important;
+    --removed-body-scroll-bar-size: 15px;
   }
 
   .dark {


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Adds query to more pages and changes the CTAs based on state
- Modifies the results page to be based on state of completion
- Refines other loading states and general states in flow
- Pulls quest data into a constants file and makes more reusable

## Screen Captures

![results-page-cta-ux](https://github.com/user-attachments/assets/205357ea-d764-411b-8556-8c9a4eb0fd61)

<img width="1438" alt="results-page-cta-not-complete" src="https://github.com/user-attachments/assets/167181ab-89c4-43d7-9593-9f4d3c37b357" />

<img width="1438" alt="results-page-not-connected" src="https://github.com/user-attachments/assets/24511997-7df4-4251-a427-2f926add18ef" />

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
