### PR TITLE
ENG-5565 feat(launchpad): manage api url providers environment

### DIFF
--- a/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
+++ b/apps/launchpad/app/components/onboarding-modal/onboarding-modal.tsx
@@ -65,6 +65,10 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
   const objectId =
     getSpecialPredicate(CURRENT_ENV).web3Wallet.vaultId.toString()
 
+  logger('current env', CURRENT_ENV)
+  logger('predicateId', predicateId)
+  logger('objectId', objectId)
+
   const { data: listData, isLoading: isLoadingList } = useGetListDetailsQuery(
     {
       tagPredicateId: predicateId,

--- a/apps/launchpad/app/lib/hooks/useQuestionData.ts
+++ b/apps/launchpad/app/lib/hooks/useQuestionData.ts
@@ -1,5 +1,7 @@
 import { useGetListDetailsQuery } from '@0xintuition/graphql'
 
+import { CURRENT_ENV } from '@consts/general'
+import { getSpecialPredicate } from '@lib/utils/app'
 import logger from '@lib/utils/logger'
 import { useQuery } from '@tanstack/react-query'
 
@@ -7,21 +9,24 @@ interface UseQuestionDataProps {
   questionId: number
 }
 
+const predicateId = getSpecialPredicate(CURRENT_ENV).tagPredicate.id.toString()
+const objectId = getSpecialPredicate(CURRENT_ENV).web3Wallet.vaultId.toString()
+
 export function useQuestionData({ questionId }: UseQuestionDataProps) {
   const { data: listData, isLoading: isLoadingList } = useGetListDetailsQuery(
     {
-      tagPredicateId: 3,
+      tagPredicateId: predicateId,
       globalWhere: {
         predicate_id: {
-          _eq: 3,
+          _eq: predicateId,
         },
         object_id: {
-          _eq: 620,
+          _eq: objectId,
         },
       },
     },
     {
-      queryKey: ['get-list-details', { predicateId: 3, objectId: 620 }],
+      queryKey: ['get-list-details', { predicateId, objectId }],
     },
   )
 

--- a/apps/launchpad/app/lib/providers/index.tsx
+++ b/apps/launchpad/app/lib/providers/index.tsx
@@ -1,5 +1,9 @@
 import { WagmiProvider } from '@privy-io/wagmi'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  HydrationBoundary,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query'
 
 import { wagmiConfig } from '../utils/wagmi'
 import { AuthProvider } from './auth-provider'
@@ -18,14 +22,19 @@ interface ProvidersProps {
   env?: {
     PRIVY_APP_ID: string
   }
+  dehydratedState?: unknown
 }
 
-export function Providers({ children, env }: ProvidersProps) {
+export function Providers({ children, env, dehydratedState }: ProvidersProps) {
   return (
     <PrivyConfig env={env}>
       <QueryClientProvider client={queryClient}>
         <WagmiProvider config={wagmiConfig}>
-          <AuthProvider>{children}</AuthProvider>
+          <AuthProvider>
+            <HydrationBoundary state={dehydratedState}>
+              {children}
+            </HydrationBoundary>
+          </AuthProvider>
         </WagmiProvider>
       </QueryClientProvider>
     </PrivyConfig>

--- a/apps/launchpad/app/root.tsx
+++ b/apps/launchpad/app/root.tsx
@@ -13,8 +13,13 @@ import { Providers } from './lib/providers'
 import './styles/globals.css'
 
 import { Toaster } from '@0xintuition/1ui'
-import { API_URL_DEV, configureClient } from '@0xintuition/graphql'
+import {
+  API_URL_DEV,
+  API_URL_PROD,
+  configureClient,
+} from '@0xintuition/graphql'
 
+import { CURRENT_ENV } from '@consts/general'
 import { json } from '@remix-run/node'
 import { setupAPI } from '@server/auth'
 import { getEnv } from '@server/env'
@@ -22,7 +27,7 @@ import { getEnv } from '@server/env'
 // Configure GraphQL client at module initialization using the URLs from the package. For now, we should use the local URL for development
 // This can be updated to use the same environment approach that we use in Portal in the future, or leave up to the template user to configure however makes sense for their use case
 configureClient({
-  apiUrl: API_URL_DEV,
+  apiUrl: CURRENT_ENV === 'development' ? API_URL_DEV : API_URL_PROD,
 })
 
 export async function loader() {

--- a/apps/launchpad/app/routes/_app+/dashboard.tsx
+++ b/apps/launchpad/app/routes/_app+/dashboard.tsx
@@ -43,9 +43,9 @@ function MinigameSkeleton() {
 export default function Index() {
   const [onboardingModal, setOnboardingModal] = useAtom(onboardingModalAtom)
 
-  const handleStartOnboarding = (gameId: string) => {
-    setOnboardingModal({ isOpen: true, gameId })
-  }
+  // const handleStartOnboarding = (gameId: string) => {
+  //   setOnboardingModal({ isOpen: true, gameId })
+  // }
 
   const handleCloseOnboarding = () => {
     setOnboardingModal({ isOpen: false, gameId: null })
@@ -54,12 +54,12 @@ export default function Index() {
   return (
     <>
       <div className="grid gap-6 md:grid-cols-2">
-        <Suspense fallback={<MinigameSkeleton />}>
+        {/* <Suspense fallback={<MinigameSkeleton />}>
           <MinigameCardWrapper
             questionId={1}
             onStart={() => handleStartOnboarding(mockMinigames[0].id)}
           />
-        </Suspense>
+        </Suspense> */}
 
         <div className="relative">
           <Card className="h-[400px] rounded-lg border-none bg-gradient-to-br from-[#060504] to-[#101010] min-w-[480px] blur-sm brightness-50">

--- a/apps/launchpad/app/routes/_app+/dashboard.tsx
+++ b/apps/launchpad/app/routes/_app+/dashboard.tsx
@@ -43,9 +43,9 @@ function MinigameSkeleton() {
 export default function Index() {
   const [onboardingModal, setOnboardingModal] = useAtom(onboardingModalAtom)
 
-  // const handleStartOnboarding = (gameId: string) => {
-  //   setOnboardingModal({ isOpen: true, gameId })
-  // }
+  const handleStartOnboarding = (gameId: string) => {
+    setOnboardingModal({ isOpen: true, gameId })
+  }
 
   const handleCloseOnboarding = () => {
     setOnboardingModal({ isOpen: false, gameId: null })
@@ -54,12 +54,12 @@ export default function Index() {
   return (
     <>
       <div className="grid gap-6 md:grid-cols-2">
-        {/* <Suspense fallback={<MinigameSkeleton />}>
+        <Suspense fallback={<MinigameSkeleton />}>
           <MinigameCardWrapper
             questionId={1}
             onStart={() => handleStartOnboarding(mockMinigames[0].id)}
           />
-        </Suspense> */}
+        </Suspense>
 
         <div className="relative">
           <Card className="h-[400px] rounded-lg border-none bg-gradient-to-br from-[#060504] to-[#101010] min-w-[480px] blur-sm brightness-50">

--- a/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
@@ -22,6 +22,7 @@ import { OnboardingModal } from '@components/onboarding-modal/onboarding-modal'
 import ShareModal from '@components/share-modal'
 import { columns } from '@components/ui/table/columns'
 import { DataTable } from '@components/ui/table/data-table'
+import { CURRENT_ENV } from '@consts/general'
 import { useGoBack } from '@lib/hooks/useGoBack'
 import { usePoints } from '@lib/hooks/usePoints'
 import { useQuestionData } from '@lib/hooks/useQuestionData'
@@ -30,6 +31,7 @@ import {
   onboardingModalAtom,
   shareModalAtom,
 } from '@lib/state/store'
+import { getSpecialPredicate } from '@lib/utils/app'
 import logger from '@lib/utils/logger'
 import { usePrivy } from '@privy-io/react-auth'
 import { useLoaderData, useParams } from '@remix-run/react'
@@ -98,15 +100,20 @@ export default function MiniGameOne() {
     ? `${location.pathname}${location.search}`
     : `${location.pathname}${location.search}${location.search ? '&' : '?'}`
 
+  const predicateId =
+    getSpecialPredicate(CURRENT_ENV).tagPredicate.id.toString()
+  const objectId =
+    getSpecialPredicate(CURRENT_ENV).web3Wallet.vaultId.toString()
+
   const { data: listData } = useGetListDetailsQuery(
     {
-      tagPredicateId: 3,
+      tagPredicateId: predicateId,
       globalWhere: {
         predicate_id: {
-          _eq: 3,
+          _eq: predicateId,
         },
         object_id: {
-          _eq: 620,
+          _eq: objectId,
         },
       },
     },


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Changes the `API_URL` used in `configureClient` to be environment based
- Ensures that we're using `getSpecialPredicate` throughout, and that it respects current environment
- Also closes ENG-5583

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
