### PR TITLE
ENG-5589 feat(launchpad): link to portal in atom details modal

### DIFF
--- a/apps/launchpad/app/components/atom-details-card.tsx
+++ b/apps/launchpad/app/components/atom-details-card.tsx
@@ -1,12 +1,14 @@
-import { cn, Text } from '@0xintuition/1ui'
+import { Button, ButtonVariant, cn, Text } from '@0xintuition/1ui'
 
-import { Coins, Users } from 'lucide-react'
+import { PORTAL_URL } from '@consts/general'
+import { Coins, ExternalLink, Users } from 'lucide-react'
 
 interface AtomDetailsCardProps extends React.HTMLAttributes<HTMLDivElement> {
   name: string
   list?: string
   icon: React.ReactNode
   atomId: number
+  listClaim: boolean
   userCount: number
   ethStaked: number
 }
@@ -16,6 +18,7 @@ export function AtomDetailsCard({
   list,
   icon,
   atomId,
+  listClaim = true, // TODO: Add handling for regular atoms (not in a list)
   userCount,
   ethStaked,
   className,
@@ -58,6 +61,16 @@ export function AtomDetailsCard({
               </div>
             </div>
           </div>
+          <a
+            href={`${PORTAL_URL}/${listClaim ? 'claim' : 'identity'}/${atomId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button variant={ButtonVariant.secondary}>
+              <ExternalLink className="h-4 w-4" />
+              View on Portal
+            </Button>
+          </a>
         </div>
 
         {/* Middle section with description and stats */}

--- a/apps/launchpad/app/components/atom-details-modal.tsx
+++ b/apps/launchpad/app/components/atom-details-modal.tsx
@@ -32,6 +32,7 @@ export function AtomDetailsModal({
       <Icon name="circles-three" className="h-6 w-6" />
     ),
     atomId,
+    listClaim: true, // TODO: Add handling for regular atoms (not in a list)
     userCount: data?.users ?? 0,
     ethStaked: data?.assets ?? 0,
     mutualConnections: 0, // Placeholder for now

--- a/apps/launchpad/app/consts/general.ts
+++ b/apps/launchpad/app/consts/general.ts
@@ -45,6 +45,11 @@ export const BLOCK_EXPLORER_URL =
     ? 'https://sepolia.basescan.org'
     : 'https://basescan.org'
 
+export const PORTAL_URL =
+  CURRENT_ENV === 'development'
+    ? 'https://dev.portal.intuition.systems/readonly'
+    : 'https://beta.portal.intuition.systems/readonly'
+
 export const IPFS_GATEWAY_URL = 'https://ipfs.io/ipfs'
 
 // Routes


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Adds a button that links to Portal to view the details of the triple/atom associated with the list item. Links to readonly route. 

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
