### PR TITLE
ENG-5614 feat(launchpad): streamline account dropdown menu

### DIFF
--- a/apps/launchpad/app/components/account-button.tsx
+++ b/apps/launchpad/app/components/account-button.tsx
@@ -63,9 +63,6 @@ export function AccountButton({
         align="start"
         className="w-[--radix-dropdown-menu-trigger-width] bg-[#131313]"
       >
-        <DropdownMenuItem>Profile</DropdownMenuItem>
-        <DropdownMenuItem>Preferences</DropdownMenuItem>
-        <DropdownMenuItem>Settings</DropdownMenuItem>
         <DropdownMenuItem onClick={disconnect}>Disconnect</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Small QoL change from QA that removes the unused links from the account dropdown when a user is connected. We can always add these back in. Leaves in `Disconnect` since it has a specific purpose.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
