### PR TITLE
ENG-5644 feat(launchpad): qa pass for questions, sidebar, ctas, and other items

### DIFF
--- a/apps/launchpad/app/components/app-sidebar.tsx
+++ b/apps/launchpad/app/components/app-sidebar.tsx
@@ -11,7 +11,6 @@ import {
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -66,10 +65,16 @@ export function AppSidebar({
 
   const mainNavItems: NavItem[] = [
     {
-      iconName: 'home-door',
-      label: 'Home',
-      href: '/',
-      isAccent: location.pathname === '/' || location.pathname === '/dashboard',
+      iconName: 'crystal-ball',
+      label: 'Quests',
+      href: '/quests/',
+      isAccent: location.pathname === '/quests/',
+    },
+    {
+      iconName: 'book',
+      label: 'Questions',
+      href: '/quests/questions',
+      isAccent: location.pathname.startsWith('/quests/questions'),
     },
     {
       iconName: 'circle-arrow',
@@ -122,11 +127,6 @@ export function AppSidebar({
       </Link>
     )
   }
-
-  const isQuestionsActive = location.pathname.startsWith('/quests/questions')
-  const isPreferencesActive = location.pathname.startsWith(
-    '/quests/preferences',
-  )
 
   const sidebarContent = (
     <>
@@ -291,62 +291,6 @@ export function AppSidebar({
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>Quests</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={location.pathname === '/quests'}
-                  className={cn(
-                    'w-full gap-3 py-0',
-                    location.pathname === '/quests' ? 'text-accent' : undefined,
-                  )}
-                >
-                  <Link to="/quests" className="flex items-center gap-3">
-                    <Icon name="crystal-ball" className="h-4 w-4" />
-                    {!isMinimal && <span>Overview</span>}
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isQuestionsActive}
-                  className={cn(
-                    'w-full gap-3 py-0',
-                    isQuestionsActive ? 'text-accent' : undefined,
-                  )}
-                >
-                  <Link
-                    to="/quests/questions"
-                    className="flex items-center gap-3"
-                  >
-                    <Icon name="book" className="h-4 w-4" />
-                    {!isMinimal && <span>Questions</span>}
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  disabled
-                  isActive={isPreferencesActive}
-                  className={cn(
-                    'w-full gap-3 py-0 opacity-50',
-                    isPreferencesActive ? 'text-accent' : undefined,
-                  )}
-                >
-                  <div className="flex items-center gap-3">
-                    <Icon name="settings-gear" className="h-4 w-4" />
-                    {!isMinimal && <span>Preferences (Coming Soon)</span>}
-                  </div>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/apps/launchpad/app/components/minigame-card-wrapper.tsx
+++ b/apps/launchpad/app/components/minigame-card-wrapper.tsx
@@ -37,6 +37,7 @@ export function MinigameCardWrapper({
       questionId,
     },
   )
+  logger('questionData', questionData)
   const userWallet = user?.wallet?.address?.toLowerCase()
   const { data: points, isLoading: isPointsLoading } = usePoints(userWallet)
 
@@ -58,6 +59,7 @@ export function MinigameCardWrapper({
         title={questionData.title}
         description={`${questionData.atoms.toLocaleString()} atoms • ${questionData.totalUsers.toLocaleString()} users`}
         points={gamePoints}
+        pointAwardAmount={questionData.pointAwardAmount}
         onStart={onStart}
         className="w-full"
         hideCTA={!authenticated}

--- a/apps/launchpad/app/components/minigame-card.tsx
+++ b/apps/launchpad/app/components/minigame-card.tsx
@@ -8,6 +8,7 @@ interface MinigameCardProps {
   title: string
   description: string
   points: number
+  pointAwardAmount: number
   hideCTA?: boolean
   isLoading?: boolean
   resultsLink?: string
@@ -19,6 +20,7 @@ export function MinigameCard({
   title,
   description,
   points,
+  pointAwardAmount,
   hideCTA = false,
   isLoading = false,
   resultsLink,
@@ -40,31 +42,50 @@ export function MinigameCard({
         </div>
 
         {!hideCTA && (
-          <div className="flex flex-col items-center">
+          <div className="flex flex-col gap-4 items-center justify-between">
+            {points <= 0 && (
+              <Button
+                onClick={() => onStart()}
+                variant="primary"
+                size="lg"
+                className="min-w-[200px]"
+                disabled={isLoading}
+              >
+                {isLoading ? 'Loading...' : 'Answer Question'}
+              </Button>
+            )}
             <Button
-              onClick={points > 0 ? () => navigate(resultsLink || '') : onStart}
-              variant="primary"
+              onClick={() => navigate(resultsLink || '')}
+              variant="secondary"
               size="lg"
-              className="min-w-[200px]"
+              className="min-w-[200px] rounded-full"
               disabled={isLoading}
             >
-              {isLoading
-                ? 'Loading...'
-                : points > 0
-                  ? 'View Results'
-                  : 'Earn 200 IQ Points'}
+              See Results
             </Button>
           </div>
         )}
 
         <div className="flex justify-end items-center">
-          {points > 0 && (
+          {points > 0 ? (
             <div className="flex items-baseline gap-2">
               <span className="text-xl font-bold bg-gradient-to-r from-[#34C578] to-[#00FF94] bg-clip-text text-transparent">
                 {points}
               </span>
               <span className="text-md font-semibold text-muted-foreground">
                 IQ Earned
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-baseline gap-2">
+              <span className="text-md font-semibold text-muted-foreground">
+                Earn
+              </span>
+              <span className="text-xl font-bold bg-gradient-to-r from-[#34C578] to-[#00FF94] bg-clip-text text-transparent">
+                {pointAwardAmount}
+              </span>
+              <span className="text-md font-semibold text-muted-foreground">
+                IQ Points
               </span>
             </div>
           )}

--- a/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
@@ -258,7 +258,7 @@ export default function MiniGameOne() {
             <Icon name="chevron-left" className="h-4 w-4" />
           </Button>
           <div className="flex flex-1 justify-between items-center">
-            <PageHeader title={`Quest: ${title}`} />
+            <PageHeader title={`Intuition Questions Module: Question ${id}`} />
           </div>
         </div>
         <div className="flex items-center justify-center h-[400px]">
@@ -280,7 +280,7 @@ export default function MiniGameOne() {
           <Icon name="chevron-left" className="h-4 w-4" />
         </Button>
         <div className="flex flex-1 justify-between items-center">
-          <PageHeader title={`Quest: ${title}`} />
+          <PageHeader title={`Intuition Questions Module: Question ${id}`} />
           <div className="flex items-center gap-2">
             <Button
               variant="secondary"

--- a/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/questions+/question+/$id.tsx
@@ -303,7 +303,7 @@ export default function MiniGameOne() {
 
       <div className="py-4 bg-gradient-to-b from-[#060504] to-[#101010] rounded-xl">
         <div className="relative">
-          <Card className="h-[400px] border-none bg-gradient-to-br from-[#060504] to-[#101010] min-w-[480px]">
+          <Card className="border-none bg-gradient-to-br from-[#060504] to-[#101010] min-w-[480px] min-h-80">
             <div className="absolute inset-0 flex flex-col justify-center items-center">
               <div className="space-y-2 items-center pb-8">
                 <Text variant="heading3" className="text-foreground">

--- a/apps/launchpad/app/routes/_index.tsx
+++ b/apps/launchpad/app/routes/_index.tsx
@@ -1,5 +1,5 @@
 import { redirect } from '@remix-run/node'
 
 export async function loader() {
-  throw redirect('/dashboard')
+  throw redirect('/quests')
 }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Addresses feedback and closes ENG-5621, ENG-5618, ENG-5616, ENG-5649, and ENG-5651
- Summary: Streamlines the AppSidebar, changes the card CTA and adds in the See Results button, changes the app entry point, changes some copy, and tightens up the results page header

## Screen Captures

![questions-ux-pass-1-28-25](https://github.com/user-attachments/assets/b6544b92-6c46-4058-84b4-5b635fc6e847)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
