### PR TITLE
ENG-5675 feat(launchpad): qa pass fixes

### DIFF
--- a/apps/launchpad/app/components/app-sidebar.tsx
+++ b/apps/launchpad/app/components/app-sidebar.tsx
@@ -285,6 +285,7 @@ export function AppSidebar({
                     className={cn(
                       'w-full gap-3',
                       item.isAccent ? 'text-accent' : undefined,
+                      item.label === 'Questions' ? 'pl-9' : undefined,
                     )}
                   >
                     {renderNavLink(item)}

--- a/apps/launchpad/app/lib/utils/constants.ts
+++ b/apps/launchpad/app/lib/utils/constants.ts
@@ -11,8 +11,9 @@ export const QUESTIONS_METADATA = {
 
 export const QUESTS = [
   {
-    title: 'What are your preferences?',
-    description: 'Answer questions about your preferences to earn IQ!',
+    title: 'Questions',
+    description:
+      'Answer questions and stake to earn IQ and see how others voted!',
     link: '/quests/questions',
     enabled: true,
     index: 1,


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Minor changes in response to QA feedback: indent on `AppSidebar`, `/quests` route copy.

## Screen Captures

![image](https://github.com/user-attachments/assets/71388524-d1a3-4f88-aeba-6b22d90ffc23)

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
