### PR TITLE
ENG-5678 fix(launchpad): hide image upload from create form temporarily

### DIFF
--- a/apps/launchpad/app/components/atom-forms/forms/thing-form.tsx
+++ b/apps/launchpad/app/components/atom-forms/forms/thing-form.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { FormProvider, useForm } from 'react-hook-form'
 
-import { FormImageUpload, FormInput, FormTextarea } from '../form-fields'
+import { FormInput, FormTextarea } from '../form-fields'
 import { ThingAtom, thingAtomSchema } from '../types'
 
 interface ThingFormProps {
@@ -26,7 +26,7 @@ export function ThingForm({ onSubmit, defaultValues }: ThingFormProps) {
         className="space-y-2.5"
       >
         <FormInput name="name" label="Name" placeholder="Enter name" />
-        <FormImageUpload name="image" label="Image" control={form.control} />
+        {/* <FormImageUpload name="image" label="Image" control={form.control} /> */}
         <FormTextarea
           name="description"
           label="Description"


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Temporarily hides image upload from create form until upload issue is resolved.

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
