### PR TITLE
ENG-5679 fix(launchpad): fix creator field of events in activity feed

### DIFF
--- a/apps/launchpad/app/components/activity-feed.tsx
+++ b/apps/launchpad/app/components/activity-feed.tsx
@@ -66,7 +66,16 @@ function ActivityRow({ activity }: { activity: Events }) {
     ? new Date(parseInt(activity.block_timestamp.toString()) * 1000)
     : new Date()
 
-  const creator = activity.atom?.creator || activity.triple?.creator
+  let creator
+  if (activity.type === 'Deposited') {
+    creator = activity.deposit?.receiver?.label
+  } else if (activity.type === 'Redeemed') {
+    creator = activity.redemption?.receiver?.label
+  } else if (activity.type === 'AtomCreated') {
+    creator = activity.atom?.creator?.label
+  } else if (activity.type === 'TripleCreated') {
+    creator = activity.triple?.creator?.label
+  }
 
   const dataType = activity.atom
     ? 'atom'
@@ -95,8 +104,8 @@ function ActivityRow({ activity }: { activity: Events }) {
 
       <div className="flex-1 min-w-0">
         <div className="flex flex-wrap items-center gap-2 text-sm">
-          <IdentityTag variant={Identity.user} imgSrc={creator?.image}>
-            {creator?.label}
+          <IdentityTag variant={Identity.user} imgSrc={''}>
+            {creator}
           </IdentityTag>
           <span className="text-muted-foreground">
             {activity.type.toLowerCase()}
@@ -119,7 +128,8 @@ function ActivityRow({ activity }: { activity: Events }) {
             variant={
               dataType === 'triple'
                 ? Identity.user
-                : activity.atom?.type === ('Default' || 'Account')
+                : activity.atom?.type === 'Default' ||
+                    activity.atom?.type === 'Account'
                   ? Identity.user
                   : Identity.nonUser
             }

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -10993,9 +10993,11 @@ export type GetEventsQuery = {
     deposit?: {
       __typename?: 'deposits'
       sender_id: string
+      receiver_id: string
       shares_for_receiver: any
       sender_assets_after_total_fees: any
-      sender?: { __typename?: 'accounts'; id: string } | null
+      sender?: { __typename?: 'accounts'; id: string; label: string } | null
+      receiver: { __typename?: 'accounts'; id: string; label: string }
       vault: {
         __typename?: 'vaults'
         total_shares: any
@@ -11016,7 +11018,9 @@ export type GetEventsQuery = {
     redemption?: {
       __typename?: 'redemptions'
       sender_id: string
-      sender?: { __typename?: 'accounts'; id: string } | null
+      receiver_id: string
+      sender?: { __typename?: 'accounts'; id: string; label: string } | null
+      receiver: { __typename?: 'accounts'; id: string; label: string }
     } | null
   }>
 }
@@ -18164,6 +18168,12 @@ export const GetEventsDocument = `
       sender_id
       sender {
         id
+        label
+      }
+      receiver_id
+      receiver {
+        id
+        label
       }
       shares_for_receiver
       sender_assets_after_total_fees
@@ -18185,6 +18195,12 @@ export const GetEventsDocument = `
       sender_id
       sender {
         id
+        label
+      }
+      receiver_id
+      receiver {
+        id
+        label
       }
     }
   }
@@ -33911,6 +33927,31 @@ export const GetEvents = {
                               kind: 'Field',
                               name: { kind: 'Name', value: 'id' },
                             },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'receiver_id' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'receiver' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
                           ],
                         },
                       },
@@ -34057,6 +34098,31 @@ export const GetEvents = {
                             {
                               kind: 'Field',
                               name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'receiver_id' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'receiver' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'label' },
                             },
                           ],
                         },

--- a/packages/graphql/src/queries/events.graphql
+++ b/packages/graphql/src/queries/events.graphql
@@ -109,6 +109,12 @@ query GetEvents(
       sender_id
       sender {
         id
+        label
+      }
+      receiver_id
+      receiver {
+        id
+        label
       }
       shares_for_receiver
       sender_assets_after_total_fees
@@ -130,6 +136,12 @@ query GetEvents(
       sender_id
       sender {
         id
+        label
+      }
+      receiver_id
+      receiver {
+        id
+        label
       }
     }
   }


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Fixes the creator for deposit and redeem events in the activity feed

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
