### PR TITLE
ENG-5682 feat(launchpad): temporarily removes network page

### DIFF
--- a/apps/launchpad/app/components/app-sidebar.tsx
+++ b/apps/launchpad/app/components/app-sidebar.tsx
@@ -76,12 +76,13 @@ export function AppSidebar({
       href: '/quests/questions',
       isAccent: location.pathname.startsWith('/quests/questions'),
     },
-    {
-      iconName: 'circle-arrow',
-      label: 'Network',
-      href: '/network',
-      isAccent: location.pathname === '/network',
-    },
+    // TODO: Add this back in once we resolve query questions
+    // {
+    //   iconName: 'circle-arrow',
+    //   label: 'Network',
+    //   href: '/network',
+    //   isAccent: location.pathname === '/network',
+    // },
   ]
 
   const footerNavItems: NavItem[] = [


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Temporarily removes the network page until we lock in some of the data questions
- We can decide if we want to merge this in and remove or hold off -- can quickly add back in once things are locked

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
