### PR TITLE
ENG-5698 chore(portal,graphql): update relic points to use new points api

### DIFF
--- a/apps/portal/app/lib/graphql/client.ts
+++ b/apps/portal/app/lib/graphql/client.ts
@@ -1,0 +1,9 @@
+import { GraphQLClient } from 'graphql-request'
+
+if (process.env.POINTS_GRAPHQL_ENDPOINT === undefined) {
+  throw new Error('Points API endpoint not defined')
+}
+
+export const pointsClient = new GraphQLClient(
+  process.env.POINTS_GRAPHQL_ENDPOINT,
+)

--- a/apps/portal/app/lib/services/points.ts
+++ b/apps/portal/app/lib/services/points.ts
@@ -1,0 +1,137 @@
+import { pointsClient } from '@lib/graphql/client'
+
+export const GetRelicPointsDocument = {
+  query: `
+    query GetRelicPoints($address: String!) {
+      relic_points(where: {address: {_eq: $address}}) {
+        address
+        genesis_minter_points
+        snapshot_1_holder_points
+        snapshot_2_holder_points
+        total_relic_points
+      }
+    }
+  `,
+} as const
+
+export interface GetRelicPointsQuery {
+  relic_points: Array<{
+    address: string
+    genesis_minter_points: number
+    snapshot_1_holder_points: number
+    snapshot_2_holder_points: number
+    total_relic_points: number
+  }>
+}
+
+export interface GetRelicPointsQueryVariables {
+  address: string
+}
+
+export interface RelicPoints {
+  totalPoints: number
+  genesisPoints: number
+  snapshot1Points: number
+  snapshot2Points: number
+}
+
+export async function fetchRelicPoints(address: string): Promise<RelicPoints> {
+  console.log('fetchRelicPoints called with address:', address)
+
+  const data = await pointsClient.request<
+    GetRelicPointsQuery,
+    GetRelicPointsQueryVariables
+  >(GetRelicPointsDocument.query, {
+    address,
+  })
+
+  const points = data?.relic_points[0] ?? {
+    genesis_minter_points: 0,
+    snapshot_1_holder_points: 0,
+    snapshot_2_holder_points: 0,
+    total_relic_points: 0,
+  }
+
+  const result = {
+    totalPoints: points.total_relic_points,
+    genesisPoints: points.genesis_minter_points,
+    snapshot1Points: points.snapshot_1_holder_points,
+    snapshot2Points: points.snapshot_2_holder_points,
+  }
+
+  return result
+}
+
+export const GetPointsDocument = {
+  query: `
+    query GetPoints($address: String!) {
+      points(where: {account_id: {_eq: $address}}) {
+        account_id
+        social
+        portal_quests
+        referral
+        community
+        minigame1
+      }
+    }
+  `,
+} as const
+
+export interface GetPointsQuery {
+  points: Array<{
+    account_id: string
+    social: number
+    portal_quests: number
+    referral: number
+    community: number
+    minigame1: number
+  }>
+}
+
+export interface GetPointsQueryVariables {
+  address: string
+}
+
+export interface Points {
+  social: number
+  portalQuests: number
+  referral: number
+  community: number
+  minigame: number
+  totalPoints: number
+}
+
+export async function fetchPoints(address: string): Promise<Points> {
+  console.log('fetchPoints called with address:', address)
+
+  const data = await pointsClient.request<
+    GetPointsQuery,
+    GetPointsQueryVariables
+  >(GetPointsDocument.query, {
+    address,
+  })
+
+  const points = data?.points[0] ?? {
+    social: 0,
+    portal_quests: 0,
+    referral: 0,
+    community: 0,
+    minigame1: 0,
+  }
+
+  const result = {
+    social: points.social,
+    portalQuests: points.portal_quests,
+    referral: points.referral,
+    community: points.community,
+    minigame: points.minigame1,
+    totalPoints:
+      points.social +
+      points.portal_quests +
+      points.referral +
+      points.community +
+      points.minigame1,
+  }
+
+  return result
+}

--- a/apps/portal/app/lib/services/points.ts
+++ b/apps/portal/app/lib/services/points.ts
@@ -36,8 +36,6 @@ export interface RelicPoints {
 }
 
 export async function fetchRelicPoints(address: string): Promise<RelicPoints> {
-  console.log('fetchRelicPoints called with address:', address)
-
   const data = await pointsClient.request<
     GetRelicPointsQuery,
     GetRelicPointsQueryVariables
@@ -102,8 +100,6 @@ export interface Points {
 }
 
 export async function fetchPoints(address: string): Promise<Points> {
-  console.log('fetchPoints called with address:', address)
-
   const data = await pointsClient.request<
     GetPointsQuery,
     GetPointsQueryVariables

--- a/apps/portal/app/routes/app+/quest+/index.tsx
+++ b/apps/portal/app/routes/app+/quest+/index.tsx
@@ -21,7 +21,7 @@ import { QuestSetCard } from '@components/quest/quest-set-card'
 import { QuestSetProgressCard } from '@components/quest/quest-set-progress-card'
 import { ReferralCard } from '@components/referral-card/referral-card'
 import RelicPointCard from '@components/relic-point-card/relic-point-card'
-import { fetchPoints, fetchRelicPoints } from '@lib/services/points'
+import { fetchRelicPoints } from '@lib/services/points'
 import { invariant } from '@lib/utils/misc'
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { Await, Link, useLoaderData } from '@remix-run/react'
@@ -43,15 +43,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userWallet = await requireUserWallet(request)
   invariant(userWallet, 'Unauthorized')
 
-  const [relicCounts, protocolFees, relicPoints, points] = await Promise.all([
+  const [relicCounts, protocolFees, relicPoints] = await Promise.all([
     fetchRelicCounts(userWallet.toLowerCase()),
     fetchProtocolFees(userWallet.toLowerCase()),
     fetchRelicPoints(userWallet.toLowerCase()),
-    fetchPoints(userWallet.toLowerCase()),
   ])
-
-  console.log('relicPoints', relicPoints)
-  console.log('points', points)
 
   const userProfile = await fetchWrapper(request, {
     method: UsersService.getUserByWalletPublic,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -44,6 +44,7 @@
     "embla-carousel": "^8.1.3",
     "embla-carousel-react": "^8.1.3",
     "framer-motion": "^11.2.10",
+    "graphql-request": "^7.1.0",
     "isbot": "^4.1.0",
     "jotai": "^2.8.3",
     "react": "^18.2.0",

--- a/packages/graphql/codegen.ts
+++ b/packages/graphql/codegen.ts
@@ -36,6 +36,7 @@ const commonGenerateOptions: Types.ConfiguredOutput = {
 const config: CodegenConfig = {
   overwrite: true,
   hooks: { afterAllFileWrite: ['prettier --write'] },
+  // Try local schema first, fall back to remote if needed
   schema: {
     [API_URL_DEV]: {
       method: 'POST',

--- a/packages/graphql/codegen.ts
+++ b/packages/graphql/codegen.ts
@@ -36,18 +36,14 @@ const commonGenerateOptions: Types.ConfiguredOutput = {
 const config: CodegenConfig = {
   overwrite: true,
   hooks: { afterAllFileWrite: ['prettier --write'] },
-  // Try local schema first, fall back to remote if needed
-  schema: [
-    './schema.graphql',
-    {
-      [API_URL_DEV]: {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+  schema: {
+    [API_URL_DEV]: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
       },
     },
-  ],
+  },
   ignoreNoDocuments: true,
   documents: ['**/*.graphql'],
   generates: {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xintuition/graphql",
   "description": "GraphQL",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/graphql/schema.graphql
+++ b/packages/graphql/schema.graphql
@@ -1027,7 +1027,21 @@ type atom_values {
   """
   book: books
   book_id: numeric
+  """
+  An object relationship
+  """
+  byte_object: byte_object
+  byte_object_id: numeric
+  """
+  An object relationship
+  """
+  caip10: caip10
   id: numeric!
+  """
+  An object relationship
+  """
+  json_object: json_objects
+  json_object_id: numeric
   """
   An object relationship
   """
@@ -1038,6 +1052,11 @@ type atom_values {
   """
   person: persons
   person_id: numeric
+  """
+  An object relationship
+  """
+  text_object: text_objects
+  text_object_id: numeric
   """
   An object relationship
   """
@@ -1075,9 +1094,12 @@ aggregate avg on columns
 """
 type atom_values_avg_fields {
   book_id: Float
+  byte_object_id: Float
   id: Float
+  json_object_id: Float
   organization_id: Float
   person_id: Float
+  text_object_id: Float
   thing_id: Float
 }
 
@@ -1093,11 +1115,18 @@ input atom_values_bool_exp {
   atom: atoms_bool_exp
   book: books_bool_exp
   book_id: numeric_comparison_exp
+  byte_object: byte_object_bool_exp
+  byte_object_id: numeric_comparison_exp
+  caip10: caip10_bool_exp
   id: numeric_comparison_exp
+  json_object: json_objects_bool_exp
+  json_object_id: numeric_comparison_exp
   organization: organizations_bool_exp
   organization_id: numeric_comparison_exp
   person: persons_bool_exp
   person_id: numeric_comparison_exp
+  text_object: text_objects_bool_exp
+  text_object_id: numeric_comparison_exp
   thing: things_bool_exp
   thing_id: numeric_comparison_exp
 }
@@ -1108,9 +1137,12 @@ aggregate max on columns
 type atom_values_max_fields {
   account_id: String
   book_id: numeric
+  byte_object_id: numeric
   id: numeric
+  json_object_id: numeric
   organization_id: numeric
   person_id: numeric
+  text_object_id: numeric
   thing_id: numeric
 }
 
@@ -1120,9 +1152,12 @@ aggregate min on columns
 type atom_values_min_fields {
   account_id: String
   book_id: numeric
+  byte_object_id: numeric
   id: numeric
+  json_object_id: numeric
   organization_id: numeric
   person_id: numeric
+  text_object_id: numeric
   thing_id: numeric
 }
 
@@ -1135,11 +1170,18 @@ input atom_values_order_by {
   atom: atoms_order_by
   book: books_order_by
   book_id: order_by
+  byte_object: byte_object_order_by
+  byte_object_id: order_by
+  caip10: caip10_order_by
   id: order_by
+  json_object: json_objects_order_by
+  json_object_id: order_by
   organization: organizations_order_by
   organization_id: order_by
   person: persons_order_by
   person_id: order_by
+  text_object: text_objects_order_by
+  text_object_id: order_by
   thing: things_order_by
   thing_id: order_by
 }
@@ -1159,7 +1201,15 @@ enum atom_values_select_column {
   """
   column name
   """
+  byte_object_id
+  """
+  column name
+  """
   id
+  """
+  column name
+  """
+  json_object_id
   """
   column name
   """
@@ -1171,6 +1221,10 @@ enum atom_values_select_column {
   """
   column name
   """
+  text_object_id
+  """
+  column name
+  """
   thing_id
 }
 
@@ -1179,9 +1233,12 @@ aggregate stddev on columns
 """
 type atom_values_stddev_fields {
   book_id: Float
+  byte_object_id: Float
   id: Float
+  json_object_id: Float
   organization_id: Float
   person_id: Float
+  text_object_id: Float
   thing_id: Float
 }
 
@@ -1190,9 +1247,12 @@ aggregate stddev_pop on columns
 """
 type atom_values_stddev_pop_fields {
   book_id: Float
+  byte_object_id: Float
   id: Float
+  json_object_id: Float
   organization_id: Float
   person_id: Float
+  text_object_id: Float
   thing_id: Float
 }
 
@@ -1201,9 +1261,12 @@ aggregate stddev_samp on columns
 """
 type atom_values_stddev_samp_fields {
   book_id: Float
+  byte_object_id: Float
   id: Float
+  json_object_id: Float
   organization_id: Float
   person_id: Float
+  text_object_id: Float
   thing_id: Float
 }
 
@@ -1227,9 +1290,12 @@ Initial value of the column from where the streaming should start
 input atom_values_stream_cursor_value_input {
   account_id: String
   book_id: numeric
+  byte_object_id: numeric
   id: numeric
+  json_object_id: numeric
   organization_id: numeric
   person_id: numeric
+  text_object_id: numeric
   thing_id: numeric
 }
 
@@ -1238,9 +1304,12 @@ aggregate sum on columns
 """
 type atom_values_sum_fields {
   book_id: numeric
+  byte_object_id: numeric
   id: numeric
+  json_object_id: numeric
   organization_id: numeric
   person_id: numeric
+  text_object_id: numeric
   thing_id: numeric
 }
 
@@ -1249,9 +1318,12 @@ aggregate var_pop on columns
 """
 type atom_values_var_pop_fields {
   book_id: Float
+  byte_object_id: Float
   id: Float
+  json_object_id: Float
   organization_id: Float
   person_id: Float
+  text_object_id: Float
   thing_id: Float
 }
 
@@ -1260,9 +1332,12 @@ aggregate var_samp on columns
 """
 type atom_values_var_samp_fields {
   book_id: Float
+  byte_object_id: Float
   id: Float
+  json_object_id: Float
   organization_id: Float
   person_id: Float
+  text_object_id: Float
   thing_id: Float
 }
 
@@ -1271,9 +1346,12 @@ aggregate variance on columns
 """
 type atom_values_variance_fields {
   book_id: Float
+  byte_object_id: Float
   id: Float
+  json_object_id: Float
   organization_id: Float
   person_id: Float
+  text_object_id: Float
   thing_id: Float
 }
 
@@ -1701,7 +1779,7 @@ type atoms {
     """
     where: signals_bool_exp
   ): signals_aggregate!
-  transaction_hash: bytea!
+  transaction_hash: String!
   type: atom_type!
   """
   An object relationship
@@ -1825,7 +1903,7 @@ input atoms_bool_exp {
   label: String_comparison_exp
   signals: signals_bool_exp
   signals_aggregate: signals_aggregate_bool_exp
-  transaction_hash: bytea_comparison_exp
+  transaction_hash: String_comparison_exp
   type: atom_type_comparison_exp
   value: atom_values_bool_exp
   value_id: numeric_comparison_exp
@@ -1846,6 +1924,7 @@ type atoms_max_fields {
   id: numeric
   image: String
   label: String
+  transaction_hash: String
   type: atom_type
   value_id: numeric
   vault_id: numeric
@@ -1864,6 +1943,7 @@ input atoms_max_order_by {
   id: order_by
   image: order_by
   label: order_by
+  transaction_hash: order_by
   type: order_by
   value_id: order_by
   vault_id: order_by
@@ -1882,6 +1962,7 @@ type atoms_min_fields {
   id: numeric
   image: String
   label: String
+  transaction_hash: String
   type: atom_type
   value_id: numeric
   vault_id: numeric
@@ -1900,6 +1981,7 @@ input atoms_min_order_by {
   id: order_by
   image: order_by
   label: order_by
+  transaction_hash: order_by
   type: order_by
   value_id: order_by
   vault_id: order_by
@@ -2088,7 +2170,7 @@ input atoms_stream_cursor_value_input {
   id: numeric
   image: String
   label: String
-  transaction_hash: bytea
+  transaction_hash: String
   type: atom_type
   value_id: numeric
   vault_id: numeric
@@ -2396,6 +2478,164 @@ type books_variance_fields {
   id: Float
 }
 
+"""
+columns and relationships of "byte_object"
+"""
+type byte_object {
+  data: bytea!
+  id: numeric!
+}
+
+"""
+aggregated selection of "byte_object"
+"""
+type byte_object_aggregate {
+  aggregate: byte_object_aggregate_fields
+  nodes: [byte_object!]!
+}
+
+"""
+aggregate fields of "byte_object"
+"""
+type byte_object_aggregate_fields {
+  avg: byte_object_avg_fields
+  count(columns: [byte_object_select_column!], distinct: Boolean): Int!
+  max: byte_object_max_fields
+  min: byte_object_min_fields
+  stddev: byte_object_stddev_fields
+  stddev_pop: byte_object_stddev_pop_fields
+  stddev_samp: byte_object_stddev_samp_fields
+  sum: byte_object_sum_fields
+  var_pop: byte_object_var_pop_fields
+  var_samp: byte_object_var_samp_fields
+  variance: byte_object_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type byte_object_avg_fields {
+  id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "byte_object". All fields are combined with a logical 'AND'.
+"""
+input byte_object_bool_exp {
+  _and: [byte_object_bool_exp!]
+  _not: byte_object_bool_exp
+  _or: [byte_object_bool_exp!]
+  data: bytea_comparison_exp
+  id: numeric_comparison_exp
+}
+
+"""
+aggregate max on columns
+"""
+type byte_object_max_fields {
+  id: numeric
+}
+
+"""
+aggregate min on columns
+"""
+type byte_object_min_fields {
+  id: numeric
+}
+
+"""
+Ordering options when selecting data from "byte_object".
+"""
+input byte_object_order_by {
+  data: order_by
+  id: order_by
+}
+
+"""
+select columns of table "byte_object"
+"""
+enum byte_object_select_column {
+  """
+  column name
+  """
+  data
+  """
+  column name
+  """
+  id
+}
+
+"""
+aggregate stddev on columns
+"""
+type byte_object_stddev_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type byte_object_stddev_pop_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type byte_object_stddev_samp_fields {
+  id: Float
+}
+
+"""
+Streaming cursor of the table "byte_object"
+"""
+input byte_object_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: byte_object_stream_cursor_value_input!
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input byte_object_stream_cursor_value_input {
+  data: bytea
+  id: numeric
+}
+
+"""
+aggregate sum on columns
+"""
+type byte_object_sum_fields {
+  id: numeric
+}
+
+"""
+aggregate var_pop on columns
+"""
+type byte_object_var_pop_fields {
+  id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type byte_object_var_samp_fields {
+  id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type byte_object_variance_fields {
+  id: Float
+}
+
 scalar bytea
 
 """
@@ -2511,6 +2751,194 @@ input cached_images_stream_cursor_value_input {
   safe: Boolean
   score: jsonb
   url: String
+}
+
+"""
+columns and relationships of "caip10"
+"""
+type caip10 {
+  account_address: String!
+  chain_id: Int!
+  id: numeric!
+  namespace: String!
+}
+
+"""
+aggregated selection of "caip10"
+"""
+type caip10_aggregate {
+  aggregate: caip10_aggregate_fields
+  nodes: [caip10!]!
+}
+
+"""
+aggregate fields of "caip10"
+"""
+type caip10_aggregate_fields {
+  avg: caip10_avg_fields
+  count(columns: [caip10_select_column!], distinct: Boolean): Int!
+  max: caip10_max_fields
+  min: caip10_min_fields
+  stddev: caip10_stddev_fields
+  stddev_pop: caip10_stddev_pop_fields
+  stddev_samp: caip10_stddev_samp_fields
+  sum: caip10_sum_fields
+  var_pop: caip10_var_pop_fields
+  var_samp: caip10_var_samp_fields
+  variance: caip10_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type caip10_avg_fields {
+  chain_id: Float
+  id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "caip10". All fields are combined with a logical 'AND'.
+"""
+input caip10_bool_exp {
+  _and: [caip10_bool_exp!]
+  _not: caip10_bool_exp
+  _or: [caip10_bool_exp!]
+  account_address: String_comparison_exp
+  chain_id: Int_comparison_exp
+  id: numeric_comparison_exp
+  namespace: String_comparison_exp
+}
+
+"""
+aggregate max on columns
+"""
+type caip10_max_fields {
+  account_address: String
+  chain_id: Int
+  id: numeric
+  namespace: String
+}
+
+"""
+aggregate min on columns
+"""
+type caip10_min_fields {
+  account_address: String
+  chain_id: Int
+  id: numeric
+  namespace: String
+}
+
+"""
+Ordering options when selecting data from "caip10".
+"""
+input caip10_order_by {
+  account_address: order_by
+  chain_id: order_by
+  id: order_by
+  namespace: order_by
+}
+
+"""
+select columns of table "caip10"
+"""
+enum caip10_select_column {
+  """
+  column name
+  """
+  account_address
+  """
+  column name
+  """
+  chain_id
+  """
+  column name
+  """
+  id
+  """
+  column name
+  """
+  namespace
+}
+
+"""
+aggregate stddev on columns
+"""
+type caip10_stddev_fields {
+  chain_id: Float
+  id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type caip10_stddev_pop_fields {
+  chain_id: Float
+  id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type caip10_stddev_samp_fields {
+  chain_id: Float
+  id: Float
+}
+
+"""
+Streaming cursor of the table "caip10"
+"""
+input caip10_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: caip10_stream_cursor_value_input!
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input caip10_stream_cursor_value_input {
+  account_address: String
+  chain_id: Int
+  id: numeric
+  namespace: String
+}
+
+"""
+aggregate sum on columns
+"""
+type caip10_sum_fields {
+  chain_id: Int
+  id: numeric
+}
+
+"""
+aggregate var_pop on columns
+"""
+type caip10_var_pop_fields {
+  chain_id: Float
+  id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type caip10_var_samp_fields {
+  chain_id: Float
+  id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type caip10_variance_fields {
+  chain_id: Float
+  id: Float
 }
 
 """
@@ -3227,7 +3655,7 @@ type deposits {
     """
     where: signals_bool_exp
   ): signals_aggregate!
-  transaction_hash: bytea!
+  transaction_hash: String!
   """
   An object relationship
   """
@@ -3354,7 +3782,7 @@ input deposits_bool_exp {
   shares_for_receiver: numeric_comparison_exp
   signals: signals_bool_exp
   signals_aggregate: signals_aggregate_bool_exp
-  transaction_hash: bytea_comparison_exp
+  transaction_hash: String_comparison_exp
   vault: vaults_bool_exp
   vault_id: numeric_comparison_exp
 }
@@ -3372,6 +3800,7 @@ type deposits_max_fields {
   sender_assets_after_total_fees: numeric
   sender_id: String
   shares_for_receiver: numeric
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -3388,6 +3817,7 @@ input deposits_max_order_by {
   sender_assets_after_total_fees: order_by
   sender_id: order_by
   shares_for_receiver: order_by
+  transaction_hash: order_by
   vault_id: order_by
 }
 
@@ -3404,6 +3834,7 @@ type deposits_min_fields {
   sender_assets_after_total_fees: numeric
   sender_id: String
   shares_for_receiver: numeric
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -3420,6 +3851,7 @@ input deposits_min_order_by {
   sender_assets_after_total_fees: order_by
   sender_id: order_by
   shares_for_receiver: order_by
+  transaction_hash: order_by
   vault_id: order_by
 }
 
@@ -3640,7 +4072,7 @@ input deposits_stream_cursor_value_input {
   sender_assets_after_total_fees: numeric
   sender_id: String
   shares_for_receiver: numeric
-  transaction_hash: bytea
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -3792,7 +4224,7 @@ type events {
   """
   redemption: redemptions
   redemption_id: String
-  transaction_hash: bytea!
+  transaction_hash: String!
   """
   An object relationship
   """
@@ -3892,7 +4324,7 @@ input events_bool_exp {
   id: String_comparison_exp
   redemption: redemptions_bool_exp
   redemption_id: String_comparison_exp
-  transaction_hash: bytea_comparison_exp
+  transaction_hash: String_comparison_exp
   triple: triples_bool_exp
   triple_id: numeric_comparison_exp
   type: event_type_comparison_exp
@@ -3909,6 +4341,7 @@ type events_max_fields {
   fee_transfer_id: String
   id: String
   redemption_id: String
+  transaction_hash: String
   triple_id: numeric
   type: event_type
 }
@@ -3924,6 +4357,7 @@ input events_max_order_by {
   fee_transfer_id: order_by
   id: order_by
   redemption_id: order_by
+  transaction_hash: order_by
   triple_id: order_by
   type: order_by
 }
@@ -3939,6 +4373,7 @@ type events_min_fields {
   fee_transfer_id: String
   id: String
   redemption_id: String
+  transaction_hash: String
   triple_id: numeric
   type: event_type
 }
@@ -3954,6 +4389,7 @@ input events_min_order_by {
   fee_transfer_id: order_by
   id: order_by
   redemption_id: order_by
+  transaction_hash: order_by
   triple_id: order_by
   type: order_by
 }
@@ -4110,7 +4546,7 @@ input events_stream_cursor_value_input {
   fee_transfer_id: String
   id: String
   redemption_id: String
-  transaction_hash: bytea
+  transaction_hash: String
   triple_id: numeric
   type: event_type
 }
@@ -4263,7 +4699,7 @@ type fee_transfers {
   """
   sender: accounts
   sender_id: String!
-  transaction_hash: bytea!
+  transaction_hash: String!
 }
 
 """
@@ -4354,7 +4790,7 @@ input fee_transfers_bool_exp {
   receiver_id: String_comparison_exp
   sender: accounts_bool_exp
   sender_id: String_comparison_exp
-  transaction_hash: bytea_comparison_exp
+  transaction_hash: String_comparison_exp
 }
 
 """
@@ -4367,6 +4803,7 @@ type fee_transfers_max_fields {
   id: String
   receiver_id: String
   sender_id: String
+  transaction_hash: String
 }
 
 """
@@ -4379,6 +4816,7 @@ input fee_transfers_max_order_by {
   id: order_by
   receiver_id: order_by
   sender_id: order_by
+  transaction_hash: order_by
 }
 
 """
@@ -4391,6 +4829,7 @@ type fee_transfers_min_fields {
   id: String
   receiver_id: String
   sender_id: String
+  transaction_hash: String
 }
 
 """
@@ -4403,6 +4842,7 @@ input fee_transfers_min_order_by {
   id: order_by
   receiver_id: order_by
   sender_id: order_by
+  transaction_hash: order_by
 }
 
 """
@@ -4533,7 +4973,7 @@ input fee_transfers_stream_cursor_value_input {
   id: String
   receiver_id: String
   sender_id: String
-  transaction_hash: bytea
+  transaction_hash: String
 }
 
 """
@@ -4627,6 +5067,169 @@ input float8_comparison_exp {
 
 input following_args {
   address: String
+}
+
+"""
+columns and relationships of "json_object"
+"""
+type json_objects {
+  data(
+    """
+    JSON select path
+    """
+    path: String
+  ): jsonb!
+  id: numeric!
+}
+
+"""
+aggregated selection of "json_object"
+"""
+type json_objects_aggregate {
+  aggregate: json_objects_aggregate_fields
+  nodes: [json_objects!]!
+}
+
+"""
+aggregate fields of "json_object"
+"""
+type json_objects_aggregate_fields {
+  avg: json_objects_avg_fields
+  count(columns: [json_objects_select_column!], distinct: Boolean): Int!
+  max: json_objects_max_fields
+  min: json_objects_min_fields
+  stddev: json_objects_stddev_fields
+  stddev_pop: json_objects_stddev_pop_fields
+  stddev_samp: json_objects_stddev_samp_fields
+  sum: json_objects_sum_fields
+  var_pop: json_objects_var_pop_fields
+  var_samp: json_objects_var_samp_fields
+  variance: json_objects_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type json_objects_avg_fields {
+  id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "json_object". All fields are combined with a logical 'AND'.
+"""
+input json_objects_bool_exp {
+  _and: [json_objects_bool_exp!]
+  _not: json_objects_bool_exp
+  _or: [json_objects_bool_exp!]
+  data: jsonb_comparison_exp
+  id: numeric_comparison_exp
+}
+
+"""
+aggregate max on columns
+"""
+type json_objects_max_fields {
+  id: numeric
+}
+
+"""
+aggregate min on columns
+"""
+type json_objects_min_fields {
+  id: numeric
+}
+
+"""
+Ordering options when selecting data from "json_object".
+"""
+input json_objects_order_by {
+  data: order_by
+  id: order_by
+}
+
+"""
+select columns of table "json_object"
+"""
+enum json_objects_select_column {
+  """
+  column name
+  """
+  data
+  """
+  column name
+  """
+  id
+}
+
+"""
+aggregate stddev on columns
+"""
+type json_objects_stddev_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type json_objects_stddev_pop_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type json_objects_stddev_samp_fields {
+  id: Float
+}
+
+"""
+Streaming cursor of the table "json_objects"
+"""
+input json_objects_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: json_objects_stream_cursor_value_input!
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input json_objects_stream_cursor_value_input {
+  data: jsonb
+  id: numeric
+}
+
+"""
+aggregate sum on columns
+"""
+type json_objects_sum_fields {
+  id: numeric
+}
+
+"""
+aggregate var_pop on columns
+"""
+type json_objects_var_pop_fields {
+  id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type json_objects_var_samp_fields {
+  id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type json_objects_variance_fields {
+  id: Float
 }
 
 scalar jsonb
@@ -5984,6 +6587,60 @@ type query_root {
     where: books_bool_exp
   ): books_aggregate!
   """
+  fetch data from the table: "byte_object"
+  """
+  byte_object(
+    """
+    distinct select on columns
+    """
+    distinct_on: [byte_object_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [byte_object_order_by!]
+    """
+    filter the rows returned
+    """
+    where: byte_object_bool_exp
+  ): [byte_object!]!
+  """
+  fetch aggregated fields from the table: "byte_object"
+  """
+  byte_object_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [byte_object_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [byte_object_order_by!]
+    """
+    filter the rows returned
+    """
+    where: byte_object_bool_exp
+  ): byte_object_aggregate!
+  """
+  fetch data from the table: "byte_object" using primary key columns
+  """
+  byte_object_by_pk(id: numeric!): byte_object
+  """
   fetch data from the table: "cached_image" using primary key columns
   """
   cached_image(url: String!): cached_images
@@ -6012,6 +6669,60 @@ type query_root {
     """
     where: cached_images_bool_exp
   ): [cached_images!]!
+  """
+  fetch data from the table: "caip10" using primary key columns
+  """
+  caip10(id: numeric!): caip10
+  """
+  fetch aggregated fields from the table: "caip10"
+  """
+  caip10_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [caip10_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [caip10_order_by!]
+    """
+    filter the rows returned
+    """
+    where: caip10_bool_exp
+  ): caip10_aggregate!
+  """
+  fetch data from the table: "caip10"
+  """
+  caip10s(
+    """
+    distinct select on columns
+    """
+    distinct_on: [caip10_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [caip10_order_by!]
+    """
+    filter the rows returned
+    """
+    where: caip10_bool_exp
+  ): [caip10!]!
   """
   fetch data from the table: "chainlink_price" using primary key columns
   """
@@ -6373,6 +7084,60 @@ type query_root {
     """
     where: accounts_bool_exp
   ): accounts_aggregate!
+  """
+  fetch data from the table: "json_object" using primary key columns
+  """
+  json_object(id: numeric!): json_objects
+  """
+  fetch data from the table: "json_object"
+  """
+  json_objects(
+    """
+    distinct select on columns
+    """
+    distinct_on: [json_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [json_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: json_objects_bool_exp
+  ): [json_objects!]!
+  """
+  fetch aggregated fields from the table: "json_object"
+  """
+  json_objects_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [json_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [json_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: json_objects_bool_exp
+  ): json_objects_aggregate!
   """
   fetch data from the table: "organization" using primary key columns
   """
@@ -6810,6 +7575,60 @@ type query_root {
     where: stats_bool_exp
   ): stats_aggregate!
   """
+  fetch data from the table: "text_object" using primary key columns
+  """
+  text_object(id: numeric!): text_objects
+  """
+  fetch data from the table: "text_object"
+  """
+  text_objects(
+    """
+    distinct select on columns
+    """
+    distinct_on: [text_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [text_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: text_objects_bool_exp
+  ): [text_objects!]!
+  """
+  fetch aggregated fields from the table: "text_object"
+  """
+  text_objects_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [text_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [text_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: text_objects_bool_exp
+  ): text_objects_aggregate!
+  """
   fetch data from the table: "thing" using primary key columns
   """
   thing(id: numeric!): things
@@ -7094,7 +7913,7 @@ type redemptions {
     """
     where: signals_bool_exp
   ): signals_aggregate!
-  transaction_hash: bytea!
+  transaction_hash: String!
   """
   An object relationship
   """
@@ -7203,7 +8022,7 @@ input redemptions_bool_exp {
   shares_redeemed_by_sender: numeric_comparison_exp
   signals: signals_bool_exp
   signals_aggregate: signals_aggregate_bool_exp
-  transaction_hash: bytea_comparison_exp
+  transaction_hash: String_comparison_exp
   vault: vaults_bool_exp
   vault_id: numeric_comparison_exp
 }
@@ -7221,6 +8040,7 @@ type redemptions_max_fields {
   sender_id: String
   sender_total_shares_in_vault: numeric
   shares_redeemed_by_sender: numeric
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -7237,6 +8057,7 @@ input redemptions_max_order_by {
   sender_id: order_by
   sender_total_shares_in_vault: order_by
   shares_redeemed_by_sender: order_by
+  transaction_hash: order_by
   vault_id: order_by
 }
 
@@ -7253,6 +8074,7 @@ type redemptions_min_fields {
   sender_id: String
   sender_total_shares_in_vault: numeric
   shares_redeemed_by_sender: numeric
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -7269,6 +8091,7 @@ input redemptions_min_order_by {
   sender_id: order_by
   sender_total_shares_in_vault: order_by
   shares_redeemed_by_sender: order_by
+  transaction_hash: order_by
   vault_id: order_by
 }
 
@@ -7449,7 +8272,7 @@ input redemptions_stream_cursor_value_input {
   sender_id: String
   sender_total_shares_in_vault: numeric
   shares_redeemed_by_sender: numeric
-  transaction_hash: bytea
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -7585,7 +8408,7 @@ type signals {
   """
   redemption: redemptions
   redemption_id: String
-  transaction_hash: bytea!
+  transaction_hash: String!
   """
   An object relationship
   """
@@ -7687,7 +8510,7 @@ input signals_bool_exp {
   id: String_comparison_exp
   redemption: redemptions_bool_exp
   redemption_id: String_comparison_exp
-  transaction_hash: bytea_comparison_exp
+  transaction_hash: String_comparison_exp
   triple: triples_bool_exp
   triple_id: numeric_comparison_exp
 }
@@ -7708,6 +8531,7 @@ type signals_max_fields {
   deposit_id: String
   id: String
   redemption_id: String
+  transaction_hash: String
   triple_id: numeric
 }
 
@@ -7723,6 +8547,7 @@ input signals_max_order_by {
   deposit_id: order_by
   id: order_by
   redemption_id: order_by
+  transaction_hash: order_by
   triple_id: order_by
 }
 
@@ -7738,6 +8563,7 @@ type signals_min_fields {
   deposit_id: String
   id: String
   redemption_id: String
+  transaction_hash: String
   triple_id: numeric
 }
 
@@ -7753,6 +8579,7 @@ input signals_min_order_by {
   deposit_id: order_by
   id: order_by
   redemption_id: order_by
+  transaction_hash: order_by
   triple_id: order_by
 }
 
@@ -7915,7 +8742,7 @@ input signals_stream_cursor_value_input {
   deposit_id: String
   id: String
   redemption_id: String
-  transaction_hash: bytea
+  transaction_hash: String
   triple_id: numeric
 }
 
@@ -8627,6 +9454,77 @@ type subscription_root {
     where: books_bool_exp
   ): [books!]!
   """
+  fetch data from the table: "byte_object"
+  """
+  byte_object(
+    """
+    distinct select on columns
+    """
+    distinct_on: [byte_object_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [byte_object_order_by!]
+    """
+    filter the rows returned
+    """
+    where: byte_object_bool_exp
+  ): [byte_object!]!
+  """
+  fetch aggregated fields from the table: "byte_object"
+  """
+  byte_object_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [byte_object_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [byte_object_order_by!]
+    """
+    filter the rows returned
+    """
+    where: byte_object_bool_exp
+  ): byte_object_aggregate!
+  """
+  fetch data from the table: "byte_object" using primary key columns
+  """
+  byte_object_by_pk(id: numeric!): byte_object
+  """
+  fetch data from the table in a streaming manner: "byte_object"
+  """
+  byte_object_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [byte_object_stream_cursor_input]!
+    """
+    filter the rows returned
+    """
+    where: byte_object_bool_exp
+  ): [byte_object!]!
+  """
   fetch data from the table: "cached_image" using primary key columns
   """
   cached_image(url: String!): cached_images
@@ -8672,6 +9570,77 @@ type subscription_root {
     """
     where: cached_images_bool_exp
   ): [cached_images!]!
+  """
+  fetch data from the table: "caip10" using primary key columns
+  """
+  caip10(id: numeric!): caip10
+  """
+  fetch aggregated fields from the table: "caip10"
+  """
+  caip10_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [caip10_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [caip10_order_by!]
+    """
+    filter the rows returned
+    """
+    where: caip10_bool_exp
+  ): caip10_aggregate!
+  """
+  fetch data from the table in a streaming manner: "caip10"
+  """
+  caip10_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [caip10_stream_cursor_input]!
+    """
+    filter the rows returned
+    """
+    where: caip10_bool_exp
+  ): [caip10!]!
+  """
+  fetch data from the table: "caip10"
+  """
+  caip10s(
+    """
+    distinct select on columns
+    """
+    distinct_on: [caip10_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [caip10_order_by!]
+    """
+    filter the rows returned
+    """
+    where: caip10_bool_exp
+  ): [caip10!]!
   """
   fetch data from the table: "chainlink_price" using primary key columns
   """
@@ -9118,6 +10087,77 @@ type subscription_root {
     """
     where: accounts_bool_exp
   ): accounts_aggregate!
+  """
+  fetch data from the table: "json_object" using primary key columns
+  """
+  json_object(id: numeric!): json_objects
+  """
+  fetch data from the table: "json_object"
+  """
+  json_objects(
+    """
+    distinct select on columns
+    """
+    distinct_on: [json_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [json_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: json_objects_bool_exp
+  ): [json_objects!]!
+  """
+  fetch aggregated fields from the table: "json_object"
+  """
+  json_objects_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [json_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [json_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: json_objects_bool_exp
+  ): json_objects_aggregate!
+  """
+  fetch data from the table in a streaming manner: "json_object"
+  """
+  json_objects_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [json_objects_stream_cursor_input]!
+    """
+    filter the rows returned
+    """
+    where: json_objects_bool_exp
+  ): [json_objects!]!
   """
   fetch data from the table: "organization" using primary key columns
   """
@@ -9674,6 +10714,77 @@ type subscription_root {
     where: stats_bool_exp
   ): [stats!]!
   """
+  fetch data from the table: "text_object" using primary key columns
+  """
+  text_object(id: numeric!): text_objects
+  """
+  fetch data from the table: "text_object"
+  """
+  text_objects(
+    """
+    distinct select on columns
+    """
+    distinct_on: [text_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [text_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: text_objects_bool_exp
+  ): [text_objects!]!
+  """
+  fetch aggregated fields from the table: "text_object"
+  """
+  text_objects_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [text_objects_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [text_objects_order_by!]
+    """
+    filter the rows returned
+    """
+    where: text_objects_bool_exp
+  ): text_objects_aggregate!
+  """
+  fetch data from the table in a streaming manner: "text_object"
+  """
+  text_objects_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [text_objects_stream_cursor_input]!
+    """
+    filter the rows returned
+    """
+    where: text_objects_bool_exp
+  ): [text_objects!]!
+  """
   fetch data from the table: "thing" using primary key columns
   """
   thing(id: numeric!): things
@@ -9886,6 +10997,166 @@ type subscription_root {
     """
     where: vaults_bool_exp
   ): [vaults!]!
+}
+
+"""
+columns and relationships of "text_object"
+"""
+type text_objects {
+  data: String!
+  id: numeric!
+}
+
+"""
+aggregated selection of "text_object"
+"""
+type text_objects_aggregate {
+  aggregate: text_objects_aggregate_fields
+  nodes: [text_objects!]!
+}
+
+"""
+aggregate fields of "text_object"
+"""
+type text_objects_aggregate_fields {
+  avg: text_objects_avg_fields
+  count(columns: [text_objects_select_column!], distinct: Boolean): Int!
+  max: text_objects_max_fields
+  min: text_objects_min_fields
+  stddev: text_objects_stddev_fields
+  stddev_pop: text_objects_stddev_pop_fields
+  stddev_samp: text_objects_stddev_samp_fields
+  sum: text_objects_sum_fields
+  var_pop: text_objects_var_pop_fields
+  var_samp: text_objects_var_samp_fields
+  variance: text_objects_variance_fields
+}
+
+"""
+aggregate avg on columns
+"""
+type text_objects_avg_fields {
+  id: Float
+}
+
+"""
+Boolean expression to filter rows from the table "text_object". All fields are combined with a logical 'AND'.
+"""
+input text_objects_bool_exp {
+  _and: [text_objects_bool_exp!]
+  _not: text_objects_bool_exp
+  _or: [text_objects_bool_exp!]
+  data: String_comparison_exp
+  id: numeric_comparison_exp
+}
+
+"""
+aggregate max on columns
+"""
+type text_objects_max_fields {
+  data: String
+  id: numeric
+}
+
+"""
+aggregate min on columns
+"""
+type text_objects_min_fields {
+  data: String
+  id: numeric
+}
+
+"""
+Ordering options when selecting data from "text_object".
+"""
+input text_objects_order_by {
+  data: order_by
+  id: order_by
+}
+
+"""
+select columns of table "text_object"
+"""
+enum text_objects_select_column {
+  """
+  column name
+  """
+  data
+  """
+  column name
+  """
+  id
+}
+
+"""
+aggregate stddev on columns
+"""
+type text_objects_stddev_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type text_objects_stddev_pop_fields {
+  id: Float
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type text_objects_stddev_samp_fields {
+  id: Float
+}
+
+"""
+Streaming cursor of the table "text_objects"
+"""
+input text_objects_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: text_objects_stream_cursor_value_input!
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input text_objects_stream_cursor_value_input {
+  data: String
+  id: numeric
+}
+
+"""
+aggregate sum on columns
+"""
+type text_objects_sum_fields {
+  id: numeric
+}
+
+"""
+aggregate var_pop on columns
+"""
+type text_objects_var_pop_fields {
+  id: Float
+}
+
+"""
+aggregate var_samp on columns
+"""
+type text_objects_var_samp_fields {
+  id: Float
+}
+
+"""
+aggregate variance on columns
+"""
+type text_objects_variance_fields {
+  id: Float
 }
 
 """
@@ -10239,7 +11510,7 @@ type triples {
   """
   subject: atoms!
   subject_id: numeric!
-  transaction_hash: bytea!
+  transaction_hash: String!
   """
   An object relationship
   """
@@ -10352,7 +11623,7 @@ input triples_bool_exp {
   signals_aggregate: signals_aggregate_bool_exp
   subject: atoms_bool_exp
   subject_id: numeric_comparison_exp
-  transaction_hash: bytea_comparison_exp
+  transaction_hash: String_comparison_exp
   vault: vaults_bool_exp
   vault_id: numeric_comparison_exp
 }
@@ -10369,6 +11640,7 @@ type triples_max_fields {
   object_id: numeric
   predicate_id: numeric
   subject_id: numeric
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -10384,6 +11656,7 @@ input triples_max_order_by {
   object_id: order_by
   predicate_id: order_by
   subject_id: order_by
+  transaction_hash: order_by
   vault_id: order_by
 }
 
@@ -10399,6 +11672,7 @@ type triples_min_fields {
   object_id: numeric
   predicate_id: numeric
   subject_id: numeric
+  transaction_hash: String
   vault_id: numeric
 }
 
@@ -10414,6 +11688,7 @@ input triples_min_order_by {
   object_id: order_by
   predicate_id: order_by
   subject_id: order_by
+  transaction_hash: order_by
   vault_id: order_by
 }
 
@@ -10597,7 +11872,7 @@ input triples_stream_cursor_value_input {
   object_id: numeric
   predicate_id: numeric
   subject_id: numeric
-  transaction_hash: bytea
+  transaction_hash: String
   vault_id: numeric
 }
 

--- a/packages/graphql/src/generated/index.ts
+++ b/packages/graphql/src/generated/index.ts
@@ -678,13 +678,24 @@ export type Atom_Values = {
   /** An object relationship */
   book?: Maybe<Books>
   book_id?: Maybe<Scalars['numeric']['output']>
+  /** An object relationship */
+  byte_object?: Maybe<Byte_Object>
+  byte_object_id?: Maybe<Scalars['numeric']['output']>
+  /** An object relationship */
+  caip10?: Maybe<Caip10>
   id: Scalars['numeric']['output']
+  /** An object relationship */
+  json_object?: Maybe<Json_Objects>
+  json_object_id?: Maybe<Scalars['numeric']['output']>
   /** An object relationship */
   organization?: Maybe<Organizations>
   organization_id?: Maybe<Scalars['numeric']['output']>
   /** An object relationship */
   person?: Maybe<Persons>
   person_id?: Maybe<Scalars['numeric']['output']>
+  /** An object relationship */
+  text_object?: Maybe<Text_Objects>
+  text_object_id?: Maybe<Scalars['numeric']['output']>
   /** An object relationship */
   thing?: Maybe<Things>
   thing_id?: Maybe<Scalars['numeric']['output']>
@@ -723,9 +734,12 @@ export type Atom_Values_Aggregate_FieldsCountArgs = {
 export type Atom_Values_Avg_Fields = {
   __typename?: 'atom_values_avg_fields'
   book_id?: Maybe<Scalars['Float']['output']>
+  byte_object_id?: Maybe<Scalars['Float']['output']>
   id?: Maybe<Scalars['Float']['output']>
+  json_object_id?: Maybe<Scalars['Float']['output']>
   organization_id?: Maybe<Scalars['Float']['output']>
   person_id?: Maybe<Scalars['Float']['output']>
+  text_object_id?: Maybe<Scalars['Float']['output']>
   thing_id?: Maybe<Scalars['Float']['output']>
 }
 
@@ -739,11 +753,18 @@ export type Atom_Values_Bool_Exp = {
   atom?: InputMaybe<Atoms_Bool_Exp>
   book?: InputMaybe<Books_Bool_Exp>
   book_id?: InputMaybe<Numeric_Comparison_Exp>
+  byte_object?: InputMaybe<Byte_Object_Bool_Exp>
+  byte_object_id?: InputMaybe<Numeric_Comparison_Exp>
+  caip10?: InputMaybe<Caip10_Bool_Exp>
   id?: InputMaybe<Numeric_Comparison_Exp>
+  json_object?: InputMaybe<Json_Objects_Bool_Exp>
+  json_object_id?: InputMaybe<Numeric_Comparison_Exp>
   organization?: InputMaybe<Organizations_Bool_Exp>
   organization_id?: InputMaybe<Numeric_Comparison_Exp>
   person?: InputMaybe<Persons_Bool_Exp>
   person_id?: InputMaybe<Numeric_Comparison_Exp>
+  text_object?: InputMaybe<Text_Objects_Bool_Exp>
+  text_object_id?: InputMaybe<Numeric_Comparison_Exp>
   thing?: InputMaybe<Things_Bool_Exp>
   thing_id?: InputMaybe<Numeric_Comparison_Exp>
 }
@@ -753,9 +774,12 @@ export type Atom_Values_Max_Fields = {
   __typename?: 'atom_values_max_fields'
   account_id?: Maybe<Scalars['String']['output']>
   book_id?: Maybe<Scalars['numeric']['output']>
+  byte_object_id?: Maybe<Scalars['numeric']['output']>
   id?: Maybe<Scalars['numeric']['output']>
+  json_object_id?: Maybe<Scalars['numeric']['output']>
   organization_id?: Maybe<Scalars['numeric']['output']>
   person_id?: Maybe<Scalars['numeric']['output']>
+  text_object_id?: Maybe<Scalars['numeric']['output']>
   thing_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -764,9 +788,12 @@ export type Atom_Values_Min_Fields = {
   __typename?: 'atom_values_min_fields'
   account_id?: Maybe<Scalars['String']['output']>
   book_id?: Maybe<Scalars['numeric']['output']>
+  byte_object_id?: Maybe<Scalars['numeric']['output']>
   id?: Maybe<Scalars['numeric']['output']>
+  json_object_id?: Maybe<Scalars['numeric']['output']>
   organization_id?: Maybe<Scalars['numeric']['output']>
   person_id?: Maybe<Scalars['numeric']['output']>
+  text_object_id?: Maybe<Scalars['numeric']['output']>
   thing_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -777,11 +804,18 @@ export type Atom_Values_Order_By = {
   atom?: InputMaybe<Atoms_Order_By>
   book?: InputMaybe<Books_Order_By>
   book_id?: InputMaybe<Order_By>
+  byte_object?: InputMaybe<Byte_Object_Order_By>
+  byte_object_id?: InputMaybe<Order_By>
+  caip10?: InputMaybe<Caip10_Order_By>
   id?: InputMaybe<Order_By>
+  json_object?: InputMaybe<Json_Objects_Order_By>
+  json_object_id?: InputMaybe<Order_By>
   organization?: InputMaybe<Organizations_Order_By>
   organization_id?: InputMaybe<Order_By>
   person?: InputMaybe<Persons_Order_By>
   person_id?: InputMaybe<Order_By>
+  text_object?: InputMaybe<Text_Objects_Order_By>
+  text_object_id?: InputMaybe<Order_By>
   thing?: InputMaybe<Things_Order_By>
   thing_id?: InputMaybe<Order_By>
 }
@@ -793,11 +827,17 @@ export type Atom_Values_Select_Column =
   /** column name */
   | 'book_id'
   /** column name */
+  | 'byte_object_id'
+  /** column name */
   | 'id'
+  /** column name */
+  | 'json_object_id'
   /** column name */
   | 'organization_id'
   /** column name */
   | 'person_id'
+  /** column name */
+  | 'text_object_id'
   /** column name */
   | 'thing_id'
 
@@ -805,9 +845,12 @@ export type Atom_Values_Select_Column =
 export type Atom_Values_Stddev_Fields = {
   __typename?: 'atom_values_stddev_fields'
   book_id?: Maybe<Scalars['Float']['output']>
+  byte_object_id?: Maybe<Scalars['Float']['output']>
   id?: Maybe<Scalars['Float']['output']>
+  json_object_id?: Maybe<Scalars['Float']['output']>
   organization_id?: Maybe<Scalars['Float']['output']>
   person_id?: Maybe<Scalars['Float']['output']>
+  text_object_id?: Maybe<Scalars['Float']['output']>
   thing_id?: Maybe<Scalars['Float']['output']>
 }
 
@@ -815,9 +858,12 @@ export type Atom_Values_Stddev_Fields = {
 export type Atom_Values_Stddev_Pop_Fields = {
   __typename?: 'atom_values_stddev_pop_fields'
   book_id?: Maybe<Scalars['Float']['output']>
+  byte_object_id?: Maybe<Scalars['Float']['output']>
   id?: Maybe<Scalars['Float']['output']>
+  json_object_id?: Maybe<Scalars['Float']['output']>
   organization_id?: Maybe<Scalars['Float']['output']>
   person_id?: Maybe<Scalars['Float']['output']>
+  text_object_id?: Maybe<Scalars['Float']['output']>
   thing_id?: Maybe<Scalars['Float']['output']>
 }
 
@@ -825,9 +871,12 @@ export type Atom_Values_Stddev_Pop_Fields = {
 export type Atom_Values_Stddev_Samp_Fields = {
   __typename?: 'atom_values_stddev_samp_fields'
   book_id?: Maybe<Scalars['Float']['output']>
+  byte_object_id?: Maybe<Scalars['Float']['output']>
   id?: Maybe<Scalars['Float']['output']>
+  json_object_id?: Maybe<Scalars['Float']['output']>
   organization_id?: Maybe<Scalars['Float']['output']>
   person_id?: Maybe<Scalars['Float']['output']>
+  text_object_id?: Maybe<Scalars['Float']['output']>
   thing_id?: Maybe<Scalars['Float']['output']>
 }
 
@@ -843,9 +892,12 @@ export type Atom_Values_Stream_Cursor_Input = {
 export type Atom_Values_Stream_Cursor_Value_Input = {
   account_id?: InputMaybe<Scalars['String']['input']>
   book_id?: InputMaybe<Scalars['numeric']['input']>
+  byte_object_id?: InputMaybe<Scalars['numeric']['input']>
   id?: InputMaybe<Scalars['numeric']['input']>
+  json_object_id?: InputMaybe<Scalars['numeric']['input']>
   organization_id?: InputMaybe<Scalars['numeric']['input']>
   person_id?: InputMaybe<Scalars['numeric']['input']>
+  text_object_id?: InputMaybe<Scalars['numeric']['input']>
   thing_id?: InputMaybe<Scalars['numeric']['input']>
 }
 
@@ -853,9 +905,12 @@ export type Atom_Values_Stream_Cursor_Value_Input = {
 export type Atom_Values_Sum_Fields = {
   __typename?: 'atom_values_sum_fields'
   book_id?: Maybe<Scalars['numeric']['output']>
+  byte_object_id?: Maybe<Scalars['numeric']['output']>
   id?: Maybe<Scalars['numeric']['output']>
+  json_object_id?: Maybe<Scalars['numeric']['output']>
   organization_id?: Maybe<Scalars['numeric']['output']>
   person_id?: Maybe<Scalars['numeric']['output']>
+  text_object_id?: Maybe<Scalars['numeric']['output']>
   thing_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -863,9 +918,12 @@ export type Atom_Values_Sum_Fields = {
 export type Atom_Values_Var_Pop_Fields = {
   __typename?: 'atom_values_var_pop_fields'
   book_id?: Maybe<Scalars['Float']['output']>
+  byte_object_id?: Maybe<Scalars['Float']['output']>
   id?: Maybe<Scalars['Float']['output']>
+  json_object_id?: Maybe<Scalars['Float']['output']>
   organization_id?: Maybe<Scalars['Float']['output']>
   person_id?: Maybe<Scalars['Float']['output']>
+  text_object_id?: Maybe<Scalars['Float']['output']>
   thing_id?: Maybe<Scalars['Float']['output']>
 }
 
@@ -873,9 +931,12 @@ export type Atom_Values_Var_Pop_Fields = {
 export type Atom_Values_Var_Samp_Fields = {
   __typename?: 'atom_values_var_samp_fields'
   book_id?: Maybe<Scalars['Float']['output']>
+  byte_object_id?: Maybe<Scalars['Float']['output']>
   id?: Maybe<Scalars['Float']['output']>
+  json_object_id?: Maybe<Scalars['Float']['output']>
   organization_id?: Maybe<Scalars['Float']['output']>
   person_id?: Maybe<Scalars['Float']['output']>
+  text_object_id?: Maybe<Scalars['Float']['output']>
   thing_id?: Maybe<Scalars['Float']['output']>
 }
 
@@ -883,9 +944,12 @@ export type Atom_Values_Var_Samp_Fields = {
 export type Atom_Values_Variance_Fields = {
   __typename?: 'atom_values_variance_fields'
   book_id?: Maybe<Scalars['Float']['output']>
+  byte_object_id?: Maybe<Scalars['Float']['output']>
   id?: Maybe<Scalars['Float']['output']>
+  json_object_id?: Maybe<Scalars['Float']['output']>
   organization_id?: Maybe<Scalars['Float']['output']>
   person_id?: Maybe<Scalars['Float']['output']>
+  text_object_id?: Maybe<Scalars['Float']['output']>
   thing_id?: Maybe<Scalars['Float']['output']>
 }
 
@@ -938,7 +1002,7 @@ export type Atoms = {
   signals: Array<Signals>
   /** An aggregate relationship */
   signals_aggregate: Signals_Aggregate
-  transaction_hash: Scalars['bytea']['output']
+  transaction_hash: Scalars['String']['output']
   type: Scalars['atom_type']['output']
   /** An object relationship */
   value?: Maybe<Atom_Values>
@@ -1199,7 +1263,7 @@ export type Atoms_Bool_Exp = {
   label?: InputMaybe<String_Comparison_Exp>
   signals?: InputMaybe<Signals_Bool_Exp>
   signals_aggregate?: InputMaybe<Signals_Aggregate_Bool_Exp>
-  transaction_hash?: InputMaybe<Bytea_Comparison_Exp>
+  transaction_hash?: InputMaybe<String_Comparison_Exp>
   type?: InputMaybe<Atom_Type_Comparison_Exp>
   value?: InputMaybe<Atom_Values_Bool_Exp>
   value_id?: InputMaybe<Numeric_Comparison_Exp>
@@ -1219,6 +1283,7 @@ export type Atoms_Max_Fields = {
   id?: Maybe<Scalars['numeric']['output']>
   image?: Maybe<Scalars['String']['output']>
   label?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   type?: Maybe<Scalars['atom_type']['output']>
   value_id?: Maybe<Scalars['numeric']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
@@ -1235,6 +1300,7 @@ export type Atoms_Max_Order_By = {
   id?: InputMaybe<Order_By>
   image?: InputMaybe<Order_By>
   label?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   type?: InputMaybe<Order_By>
   value_id?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
@@ -1252,6 +1318,7 @@ export type Atoms_Min_Fields = {
   id?: Maybe<Scalars['numeric']['output']>
   image?: Maybe<Scalars['String']['output']>
   label?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   type?: Maybe<Scalars['atom_type']['output']>
   value_id?: Maybe<Scalars['numeric']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
@@ -1268,6 +1335,7 @@ export type Atoms_Min_Order_By = {
   id?: InputMaybe<Order_By>
   image?: InputMaybe<Order_By>
   label?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   type?: InputMaybe<Order_By>
   value_id?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
@@ -1408,7 +1476,7 @@ export type Atoms_Stream_Cursor_Value_Input = {
   id?: InputMaybe<Scalars['numeric']['input']>
   image?: InputMaybe<Scalars['String']['input']>
   label?: InputMaybe<Scalars['String']['input']>
-  transaction_hash?: InputMaybe<Scalars['bytea']['input']>
+  transaction_hash?: InputMaybe<Scalars['String']['input']>
   type?: InputMaybe<Scalars['atom_type']['input']>
   value_id?: InputMaybe<Scalars['numeric']['input']>
   vault_id?: InputMaybe<Scalars['numeric']['input']>
@@ -1666,6 +1734,138 @@ export type Books_Variance_Fields = {
   id?: Maybe<Scalars['Float']['output']>
 }
 
+/** columns and relationships of "byte_object" */
+export type Byte_Object = {
+  __typename?: 'byte_object'
+  data: Scalars['bytea']['output']
+  id: Scalars['numeric']['output']
+}
+
+/** aggregated selection of "byte_object" */
+export type Byte_Object_Aggregate = {
+  __typename?: 'byte_object_aggregate'
+  aggregate?: Maybe<Byte_Object_Aggregate_Fields>
+  nodes: Array<Byte_Object>
+}
+
+/** aggregate fields of "byte_object" */
+export type Byte_Object_Aggregate_Fields = {
+  __typename?: 'byte_object_aggregate_fields'
+  avg?: Maybe<Byte_Object_Avg_Fields>
+  count: Scalars['Int']['output']
+  max?: Maybe<Byte_Object_Max_Fields>
+  min?: Maybe<Byte_Object_Min_Fields>
+  stddev?: Maybe<Byte_Object_Stddev_Fields>
+  stddev_pop?: Maybe<Byte_Object_Stddev_Pop_Fields>
+  stddev_samp?: Maybe<Byte_Object_Stddev_Samp_Fields>
+  sum?: Maybe<Byte_Object_Sum_Fields>
+  var_pop?: Maybe<Byte_Object_Var_Pop_Fields>
+  var_samp?: Maybe<Byte_Object_Var_Samp_Fields>
+  variance?: Maybe<Byte_Object_Variance_Fields>
+}
+
+/** aggregate fields of "byte_object" */
+export type Byte_Object_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Byte_Object_Select_Column>>
+  distinct?: InputMaybe<Scalars['Boolean']['input']>
+}
+
+/** aggregate avg on columns */
+export type Byte_Object_Avg_Fields = {
+  __typename?: 'byte_object_avg_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Boolean expression to filter rows from the table "byte_object". All fields are combined with a logical 'AND'. */
+export type Byte_Object_Bool_Exp = {
+  _and?: InputMaybe<Array<Byte_Object_Bool_Exp>>
+  _not?: InputMaybe<Byte_Object_Bool_Exp>
+  _or?: InputMaybe<Array<Byte_Object_Bool_Exp>>
+  data?: InputMaybe<Bytea_Comparison_Exp>
+  id?: InputMaybe<Numeric_Comparison_Exp>
+}
+
+/** aggregate max on columns */
+export type Byte_Object_Max_Fields = {
+  __typename?: 'byte_object_max_fields'
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** aggregate min on columns */
+export type Byte_Object_Min_Fields = {
+  __typename?: 'byte_object_min_fields'
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** Ordering options when selecting data from "byte_object". */
+export type Byte_Object_Order_By = {
+  data?: InputMaybe<Order_By>
+  id?: InputMaybe<Order_By>
+}
+
+/** select columns of table "byte_object" */
+export type Byte_Object_Select_Column =
+  /** column name */
+  | 'data'
+  /** column name */
+  | 'id'
+
+/** aggregate stddev on columns */
+export type Byte_Object_Stddev_Fields = {
+  __typename?: 'byte_object_stddev_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_pop on columns */
+export type Byte_Object_Stddev_Pop_Fields = {
+  __typename?: 'byte_object_stddev_pop_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_samp on columns */
+export type Byte_Object_Stddev_Samp_Fields = {
+  __typename?: 'byte_object_stddev_samp_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Streaming cursor of the table "byte_object" */
+export type Byte_Object_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Byte_Object_Stream_Cursor_Value_Input
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>
+}
+
+/** Initial value of the column from where the streaming should start */
+export type Byte_Object_Stream_Cursor_Value_Input = {
+  data?: InputMaybe<Scalars['bytea']['input']>
+  id?: InputMaybe<Scalars['numeric']['input']>
+}
+
+/** aggregate sum on columns */
+export type Byte_Object_Sum_Fields = {
+  __typename?: 'byte_object_sum_fields'
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** aggregate var_pop on columns */
+export type Byte_Object_Var_Pop_Fields = {
+  __typename?: 'byte_object_var_pop_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate var_samp on columns */
+export type Byte_Object_Var_Samp_Fields = {
+  __typename?: 'byte_object_var_samp_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate variance on columns */
+export type Byte_Object_Variance_Fields = {
+  __typename?: 'byte_object_variance_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
 /** Boolean expression to compare columns of type "bytea". All fields are combined with logical 'AND'. */
 export type Bytea_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['bytea']['input']>
@@ -1749,6 +1949,164 @@ export type Cached_Images_Stream_Cursor_Value_Input = {
   safe?: InputMaybe<Scalars['Boolean']['input']>
   score?: InputMaybe<Scalars['jsonb']['input']>
   url?: InputMaybe<Scalars['String']['input']>
+}
+
+/** columns and relationships of "caip10" */
+export type Caip10 = {
+  __typename?: 'caip10'
+  account_address: Scalars['String']['output']
+  chain_id: Scalars['Int']['output']
+  id: Scalars['numeric']['output']
+  namespace: Scalars['String']['output']
+}
+
+/** aggregated selection of "caip10" */
+export type Caip10_Aggregate = {
+  __typename?: 'caip10_aggregate'
+  aggregate?: Maybe<Caip10_Aggregate_Fields>
+  nodes: Array<Caip10>
+}
+
+/** aggregate fields of "caip10" */
+export type Caip10_Aggregate_Fields = {
+  __typename?: 'caip10_aggregate_fields'
+  avg?: Maybe<Caip10_Avg_Fields>
+  count: Scalars['Int']['output']
+  max?: Maybe<Caip10_Max_Fields>
+  min?: Maybe<Caip10_Min_Fields>
+  stddev?: Maybe<Caip10_Stddev_Fields>
+  stddev_pop?: Maybe<Caip10_Stddev_Pop_Fields>
+  stddev_samp?: Maybe<Caip10_Stddev_Samp_Fields>
+  sum?: Maybe<Caip10_Sum_Fields>
+  var_pop?: Maybe<Caip10_Var_Pop_Fields>
+  var_samp?: Maybe<Caip10_Var_Samp_Fields>
+  variance?: Maybe<Caip10_Variance_Fields>
+}
+
+/** aggregate fields of "caip10" */
+export type Caip10_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Caip10_Select_Column>>
+  distinct?: InputMaybe<Scalars['Boolean']['input']>
+}
+
+/** aggregate avg on columns */
+export type Caip10_Avg_Fields = {
+  __typename?: 'caip10_avg_fields'
+  chain_id?: Maybe<Scalars['Float']['output']>
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Boolean expression to filter rows from the table "caip10". All fields are combined with a logical 'AND'. */
+export type Caip10_Bool_Exp = {
+  _and?: InputMaybe<Array<Caip10_Bool_Exp>>
+  _not?: InputMaybe<Caip10_Bool_Exp>
+  _or?: InputMaybe<Array<Caip10_Bool_Exp>>
+  account_address?: InputMaybe<String_Comparison_Exp>
+  chain_id?: InputMaybe<Int_Comparison_Exp>
+  id?: InputMaybe<Numeric_Comparison_Exp>
+  namespace?: InputMaybe<String_Comparison_Exp>
+}
+
+/** aggregate max on columns */
+export type Caip10_Max_Fields = {
+  __typename?: 'caip10_max_fields'
+  account_address?: Maybe<Scalars['String']['output']>
+  chain_id?: Maybe<Scalars['Int']['output']>
+  id?: Maybe<Scalars['numeric']['output']>
+  namespace?: Maybe<Scalars['String']['output']>
+}
+
+/** aggregate min on columns */
+export type Caip10_Min_Fields = {
+  __typename?: 'caip10_min_fields'
+  account_address?: Maybe<Scalars['String']['output']>
+  chain_id?: Maybe<Scalars['Int']['output']>
+  id?: Maybe<Scalars['numeric']['output']>
+  namespace?: Maybe<Scalars['String']['output']>
+}
+
+/** Ordering options when selecting data from "caip10". */
+export type Caip10_Order_By = {
+  account_address?: InputMaybe<Order_By>
+  chain_id?: InputMaybe<Order_By>
+  id?: InputMaybe<Order_By>
+  namespace?: InputMaybe<Order_By>
+}
+
+/** select columns of table "caip10" */
+export type Caip10_Select_Column =
+  /** column name */
+  | 'account_address'
+  /** column name */
+  | 'chain_id'
+  /** column name */
+  | 'id'
+  /** column name */
+  | 'namespace'
+
+/** aggregate stddev on columns */
+export type Caip10_Stddev_Fields = {
+  __typename?: 'caip10_stddev_fields'
+  chain_id?: Maybe<Scalars['Float']['output']>
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_pop on columns */
+export type Caip10_Stddev_Pop_Fields = {
+  __typename?: 'caip10_stddev_pop_fields'
+  chain_id?: Maybe<Scalars['Float']['output']>
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_samp on columns */
+export type Caip10_Stddev_Samp_Fields = {
+  __typename?: 'caip10_stddev_samp_fields'
+  chain_id?: Maybe<Scalars['Float']['output']>
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Streaming cursor of the table "caip10" */
+export type Caip10_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Caip10_Stream_Cursor_Value_Input
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>
+}
+
+/** Initial value of the column from where the streaming should start */
+export type Caip10_Stream_Cursor_Value_Input = {
+  account_address?: InputMaybe<Scalars['String']['input']>
+  chain_id?: InputMaybe<Scalars['Int']['input']>
+  id?: InputMaybe<Scalars['numeric']['input']>
+  namespace?: InputMaybe<Scalars['String']['input']>
+}
+
+/** aggregate sum on columns */
+export type Caip10_Sum_Fields = {
+  __typename?: 'caip10_sum_fields'
+  chain_id?: Maybe<Scalars['Int']['output']>
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** aggregate var_pop on columns */
+export type Caip10_Var_Pop_Fields = {
+  __typename?: 'caip10_var_pop_fields'
+  chain_id?: Maybe<Scalars['Float']['output']>
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate var_samp on columns */
+export type Caip10_Var_Samp_Fields = {
+  __typename?: 'caip10_var_samp_fields'
+  chain_id?: Maybe<Scalars['Float']['output']>
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate variance on columns */
+export type Caip10_Variance_Fields = {
+  __typename?: 'caip10_variance_fields'
+  chain_id?: Maybe<Scalars['Float']['output']>
+  id?: Maybe<Scalars['Float']['output']>
 }
 
 /** columns and relationships of "chainlink_price" */
@@ -2263,7 +2621,7 @@ export type Deposits = {
   signals: Array<Signals>
   /** An aggregate relationship */
   signals_aggregate: Signals_Aggregate
-  transaction_hash: Scalars['bytea']['output']
+  transaction_hash: Scalars['String']['output']
   /** An object relationship */
   vault: Vaults
   vault_id: Scalars['numeric']['output']
@@ -2421,7 +2779,7 @@ export type Deposits_Bool_Exp = {
   shares_for_receiver?: InputMaybe<Numeric_Comparison_Exp>
   signals?: InputMaybe<Signals_Bool_Exp>
   signals_aggregate?: InputMaybe<Signals_Aggregate_Bool_Exp>
-  transaction_hash?: InputMaybe<Bytea_Comparison_Exp>
+  transaction_hash?: InputMaybe<String_Comparison_Exp>
   vault?: InputMaybe<Vaults_Bool_Exp>
   vault_id?: InputMaybe<Numeric_Comparison_Exp>
 }
@@ -2438,6 +2796,7 @@ export type Deposits_Max_Fields = {
   sender_assets_after_total_fees?: Maybe<Scalars['numeric']['output']>
   sender_id?: Maybe<Scalars['String']['output']>
   shares_for_receiver?: Maybe<Scalars['numeric']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -2452,6 +2811,7 @@ export type Deposits_Max_Order_By = {
   sender_assets_after_total_fees?: InputMaybe<Order_By>
   sender_id?: InputMaybe<Order_By>
   shares_for_receiver?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
 }
 
@@ -2467,6 +2827,7 @@ export type Deposits_Min_Fields = {
   sender_assets_after_total_fees?: Maybe<Scalars['numeric']['output']>
   sender_id?: Maybe<Scalars['String']['output']>
   shares_for_receiver?: Maybe<Scalars['numeric']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -2481,6 +2842,7 @@ export type Deposits_Min_Order_By = {
   sender_assets_after_total_fees?: InputMaybe<Order_By>
   sender_id?: InputMaybe<Order_By>
   shares_for_receiver?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
 }
 
@@ -2639,7 +3001,7 @@ export type Deposits_Stream_Cursor_Value_Input = {
   sender_assets_after_total_fees?: InputMaybe<Scalars['numeric']['input']>
   sender_id?: InputMaybe<Scalars['String']['input']>
   shares_for_receiver?: InputMaybe<Scalars['numeric']['input']>
-  transaction_hash?: InputMaybe<Scalars['bytea']['input']>
+  transaction_hash?: InputMaybe<Scalars['String']['input']>
   vault_id?: InputMaybe<Scalars['numeric']['input']>
 }
 
@@ -2766,7 +3128,7 @@ export type Events = {
   /** An object relationship */
   redemption?: Maybe<Redemptions>
   redemption_id?: Maybe<Scalars['String']['output']>
-  transaction_hash: Scalars['bytea']['output']
+  transaction_hash: Scalars['String']['output']
   /** An object relationship */
   triple?: Maybe<Triples>
   triple_id?: Maybe<Scalars['numeric']['output']>
@@ -2861,7 +3223,7 @@ export type Events_Bool_Exp = {
   id?: InputMaybe<String_Comparison_Exp>
   redemption?: InputMaybe<Redemptions_Bool_Exp>
   redemption_id?: InputMaybe<String_Comparison_Exp>
-  transaction_hash?: InputMaybe<Bytea_Comparison_Exp>
+  transaction_hash?: InputMaybe<String_Comparison_Exp>
   triple?: InputMaybe<Triples_Bool_Exp>
   triple_id?: InputMaybe<Numeric_Comparison_Exp>
   type?: InputMaybe<Event_Type_Comparison_Exp>
@@ -2877,6 +3239,7 @@ export type Events_Max_Fields = {
   fee_transfer_id?: Maybe<Scalars['String']['output']>
   id?: Maybe<Scalars['String']['output']>
   redemption_id?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   triple_id?: Maybe<Scalars['numeric']['output']>
   type?: Maybe<Scalars['event_type']['output']>
 }
@@ -2890,6 +3253,7 @@ export type Events_Max_Order_By = {
   fee_transfer_id?: InputMaybe<Order_By>
   id?: InputMaybe<Order_By>
   redemption_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   triple_id?: InputMaybe<Order_By>
   type?: InputMaybe<Order_By>
 }
@@ -2904,6 +3268,7 @@ export type Events_Min_Fields = {
   fee_transfer_id?: Maybe<Scalars['String']['output']>
   id?: Maybe<Scalars['String']['output']>
   redemption_id?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   triple_id?: Maybe<Scalars['numeric']['output']>
   type?: Maybe<Scalars['event_type']['output']>
 }
@@ -2917,6 +3282,7 @@ export type Events_Min_Order_By = {
   fee_transfer_id?: InputMaybe<Order_By>
   id?: InputMaybe<Order_By>
   redemption_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   triple_id?: InputMaybe<Order_By>
   type?: InputMaybe<Order_By>
 }
@@ -3031,7 +3397,7 @@ export type Events_Stream_Cursor_Value_Input = {
   fee_transfer_id?: InputMaybe<Scalars['String']['input']>
   id?: InputMaybe<Scalars['String']['input']>
   redemption_id?: InputMaybe<Scalars['String']['input']>
-  transaction_hash?: InputMaybe<Scalars['bytea']['input']>
+  transaction_hash?: InputMaybe<Scalars['String']['input']>
   triple_id?: InputMaybe<Scalars['numeric']['input']>
   type?: InputMaybe<Scalars['event_type']['input']>
 }
@@ -3121,7 +3487,7 @@ export type Fee_Transfers = {
   /** An object relationship */
   sender?: Maybe<Accounts>
   sender_id: Scalars['String']['output']
-  transaction_hash: Scalars['bytea']['output']
+  transaction_hash: Scalars['String']['output']
 }
 
 /** columns and relationships of "fee_transfer" */
@@ -3227,7 +3593,7 @@ export type Fee_Transfers_Bool_Exp = {
   receiver_id?: InputMaybe<String_Comparison_Exp>
   sender?: InputMaybe<Accounts_Bool_Exp>
   sender_id?: InputMaybe<String_Comparison_Exp>
-  transaction_hash?: InputMaybe<Bytea_Comparison_Exp>
+  transaction_hash?: InputMaybe<String_Comparison_Exp>
 }
 
 /** aggregate max on columns */
@@ -3239,6 +3605,7 @@ export type Fee_Transfers_Max_Fields = {
   id?: Maybe<Scalars['String']['output']>
   receiver_id?: Maybe<Scalars['String']['output']>
   sender_id?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
 }
 
 /** order by max() on columns of table "fee_transfer" */
@@ -3249,6 +3616,7 @@ export type Fee_Transfers_Max_Order_By = {
   id?: InputMaybe<Order_By>
   receiver_id?: InputMaybe<Order_By>
   sender_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
 }
 
 /** aggregate min on columns */
@@ -3260,6 +3628,7 @@ export type Fee_Transfers_Min_Fields = {
   id?: Maybe<Scalars['String']['output']>
   receiver_id?: Maybe<Scalars['String']['output']>
   sender_id?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
 }
 
 /** order by min() on columns of table "fee_transfer" */
@@ -3270,6 +3639,7 @@ export type Fee_Transfers_Min_Order_By = {
   id?: InputMaybe<Order_By>
   receiver_id?: InputMaybe<Order_By>
   sender_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
 }
 
 /** Ordering options when selecting data from "fee_transfer". */
@@ -3364,7 +3734,7 @@ export type Fee_Transfers_Stream_Cursor_Value_Input = {
   id?: InputMaybe<Scalars['String']['input']>
   receiver_id?: InputMaybe<Scalars['String']['input']>
   sender_id?: InputMaybe<Scalars['String']['input']>
-  transaction_hash?: InputMaybe<Scalars['bytea']['input']>
+  transaction_hash?: InputMaybe<Scalars['String']['input']>
 }
 
 /** aggregate sum on columns */
@@ -3442,6 +3812,143 @@ export type Float8_Comparison_Exp = {
 
 export type Following_Args = {
   address?: InputMaybe<Scalars['String']['input']>
+}
+
+/** columns and relationships of "json_object" */
+export type Json_Objects = {
+  __typename?: 'json_objects'
+  data: Scalars['jsonb']['output']
+  id: Scalars['numeric']['output']
+}
+
+/** columns and relationships of "json_object" */
+export type Json_ObjectsDataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>
+}
+
+/** aggregated selection of "json_object" */
+export type Json_Objects_Aggregate = {
+  __typename?: 'json_objects_aggregate'
+  aggregate?: Maybe<Json_Objects_Aggregate_Fields>
+  nodes: Array<Json_Objects>
+}
+
+/** aggregate fields of "json_object" */
+export type Json_Objects_Aggregate_Fields = {
+  __typename?: 'json_objects_aggregate_fields'
+  avg?: Maybe<Json_Objects_Avg_Fields>
+  count: Scalars['Int']['output']
+  max?: Maybe<Json_Objects_Max_Fields>
+  min?: Maybe<Json_Objects_Min_Fields>
+  stddev?: Maybe<Json_Objects_Stddev_Fields>
+  stddev_pop?: Maybe<Json_Objects_Stddev_Pop_Fields>
+  stddev_samp?: Maybe<Json_Objects_Stddev_Samp_Fields>
+  sum?: Maybe<Json_Objects_Sum_Fields>
+  var_pop?: Maybe<Json_Objects_Var_Pop_Fields>
+  var_samp?: Maybe<Json_Objects_Var_Samp_Fields>
+  variance?: Maybe<Json_Objects_Variance_Fields>
+}
+
+/** aggregate fields of "json_object" */
+export type Json_Objects_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Json_Objects_Select_Column>>
+  distinct?: InputMaybe<Scalars['Boolean']['input']>
+}
+
+/** aggregate avg on columns */
+export type Json_Objects_Avg_Fields = {
+  __typename?: 'json_objects_avg_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Boolean expression to filter rows from the table "json_object". All fields are combined with a logical 'AND'. */
+export type Json_Objects_Bool_Exp = {
+  _and?: InputMaybe<Array<Json_Objects_Bool_Exp>>
+  _not?: InputMaybe<Json_Objects_Bool_Exp>
+  _or?: InputMaybe<Array<Json_Objects_Bool_Exp>>
+  data?: InputMaybe<Jsonb_Comparison_Exp>
+  id?: InputMaybe<Numeric_Comparison_Exp>
+}
+
+/** aggregate max on columns */
+export type Json_Objects_Max_Fields = {
+  __typename?: 'json_objects_max_fields'
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** aggregate min on columns */
+export type Json_Objects_Min_Fields = {
+  __typename?: 'json_objects_min_fields'
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** Ordering options when selecting data from "json_object". */
+export type Json_Objects_Order_By = {
+  data?: InputMaybe<Order_By>
+  id?: InputMaybe<Order_By>
+}
+
+/** select columns of table "json_object" */
+export type Json_Objects_Select_Column =
+  /** column name */
+  | 'data'
+  /** column name */
+  | 'id'
+
+/** aggregate stddev on columns */
+export type Json_Objects_Stddev_Fields = {
+  __typename?: 'json_objects_stddev_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_pop on columns */
+export type Json_Objects_Stddev_Pop_Fields = {
+  __typename?: 'json_objects_stddev_pop_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_samp on columns */
+export type Json_Objects_Stddev_Samp_Fields = {
+  __typename?: 'json_objects_stddev_samp_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Streaming cursor of the table "json_objects" */
+export type Json_Objects_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Json_Objects_Stream_Cursor_Value_Input
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>
+}
+
+/** Initial value of the column from where the streaming should start */
+export type Json_Objects_Stream_Cursor_Value_Input = {
+  data?: InputMaybe<Scalars['jsonb']['input']>
+  id?: InputMaybe<Scalars['numeric']['input']>
+}
+
+/** aggregate sum on columns */
+export type Json_Objects_Sum_Fields = {
+  __typename?: 'json_objects_sum_fields'
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** aggregate var_pop on columns */
+export type Json_Objects_Var_Pop_Fields = {
+  __typename?: 'json_objects_var_pop_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate var_samp on columns */
+export type Json_Objects_Var_Samp_Fields = {
+  __typename?: 'json_objects_var_samp_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate variance on columns */
+export type Json_Objects_Variance_Fields = {
+  __typename?: 'json_objects_variance_fields'
+  id?: Maybe<Scalars['Float']['output']>
 }
 
 export type Jsonb_Cast_Exp = {
@@ -4358,10 +4865,22 @@ export type Query_Root = {
   books: Array<Books>
   /** fetch aggregated fields from the table: "book" */
   books_aggregate: Books_Aggregate
+  /** fetch data from the table: "byte_object" */
+  byte_object: Array<Byte_Object>
+  /** fetch aggregated fields from the table: "byte_object" */
+  byte_object_aggregate: Byte_Object_Aggregate
+  /** fetch data from the table: "byte_object" using primary key columns */
+  byte_object_by_pk?: Maybe<Byte_Object>
   /** fetch data from the table: "cached_image" using primary key columns */
   cached_image?: Maybe<Cached_Images>
   /** fetch data from the table: "cached_image" */
   cached_images: Array<Cached_Images>
+  /** fetch data from the table: "caip10" using primary key columns */
+  caip10?: Maybe<Caip10>
+  /** fetch aggregated fields from the table: "caip10" */
+  caip10_aggregate: Caip10_Aggregate
+  /** fetch data from the table: "caip10" */
+  caip10s: Array<Caip10>
   /** fetch data from the table: "chainlink_price" using primary key columns */
   chainlink_price?: Maybe<Chainlink_Prices>
   /** fetch data from the table: "chainlink_price" */
@@ -4398,6 +4917,12 @@ export type Query_Root = {
   following: Array<Accounts>
   /** execute function "following" and query aggregates on result of table type "account" */
   following_aggregate: Accounts_Aggregate
+  /** fetch data from the table: "json_object" using primary key columns */
+  json_object?: Maybe<Json_Objects>
+  /** fetch data from the table: "json_object" */
+  json_objects: Array<Json_Objects>
+  /** fetch aggregated fields from the table: "json_object" */
+  json_objects_aggregate: Json_Objects_Aggregate
   /** fetch data from the table: "organization" using primary key columns */
   organization?: Maybe<Organizations>
   /** fetch data from the table: "organization" */
@@ -4444,6 +4969,12 @@ export type Query_Root = {
   stats: Array<Stats>
   /** fetch aggregated fields from the table: "stats" */
   stats_aggregate: Stats_Aggregate
+  /** fetch data from the table: "text_object" using primary key columns */
+  text_object?: Maybe<Text_Objects>
+  /** fetch data from the table: "text_object" */
+  text_objects: Array<Text_Objects>
+  /** fetch aggregated fields from the table: "text_object" */
+  text_objects_aggregate: Text_Objects_Aggregate
   /** fetch data from the table: "thing" using primary key columns */
   thing?: Maybe<Things>
   /** fetch data from the table: "thing" */
@@ -4562,6 +5093,26 @@ export type Query_RootBooks_AggregateArgs = {
   where?: InputMaybe<Books_Bool_Exp>
 }
 
+export type Query_RootByte_ObjectArgs = {
+  distinct_on?: InputMaybe<Array<Byte_Object_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Byte_Object_Order_By>>
+  where?: InputMaybe<Byte_Object_Bool_Exp>
+}
+
+export type Query_RootByte_Object_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Byte_Object_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Byte_Object_Order_By>>
+  where?: InputMaybe<Byte_Object_Bool_Exp>
+}
+
+export type Query_RootByte_Object_By_PkArgs = {
+  id: Scalars['numeric']['input']
+}
+
 export type Query_RootCached_ImageArgs = {
   url: Scalars['String']['input']
 }
@@ -4572,6 +5123,26 @@ export type Query_RootCached_ImagesArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>
   order_by?: InputMaybe<Array<Cached_Images_Order_By>>
   where?: InputMaybe<Cached_Images_Bool_Exp>
+}
+
+export type Query_RootCaip10Args = {
+  id: Scalars['numeric']['input']
+}
+
+export type Query_RootCaip10_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Caip10_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Caip10_Order_By>>
+  where?: InputMaybe<Caip10_Bool_Exp>
+}
+
+export type Query_RootCaip10sArgs = {
+  distinct_on?: InputMaybe<Array<Caip10_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Caip10_Order_By>>
+  where?: InputMaybe<Caip10_Bool_Exp>
 }
 
 export type Query_RootChainlink_PriceArgs = {
@@ -4700,6 +5271,26 @@ export type Query_RootFollowing_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>
   order_by?: InputMaybe<Array<Accounts_Order_By>>
   where?: InputMaybe<Accounts_Bool_Exp>
+}
+
+export type Query_RootJson_ObjectArgs = {
+  id: Scalars['numeric']['input']
+}
+
+export type Query_RootJson_ObjectsArgs = {
+  distinct_on?: InputMaybe<Array<Json_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Json_Objects_Order_By>>
+  where?: InputMaybe<Json_Objects_Bool_Exp>
+}
+
+export type Query_RootJson_Objects_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Json_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Json_Objects_Order_By>>
+  where?: InputMaybe<Json_Objects_Bool_Exp>
 }
 
 export type Query_RootOrganizationArgs = {
@@ -4860,6 +5451,26 @@ export type Query_RootStats_AggregateArgs = {
   where?: InputMaybe<Stats_Bool_Exp>
 }
 
+export type Query_RootText_ObjectArgs = {
+  id: Scalars['numeric']['input']
+}
+
+export type Query_RootText_ObjectsArgs = {
+  distinct_on?: InputMaybe<Array<Text_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Text_Objects_Order_By>>
+  where?: InputMaybe<Text_Objects_Bool_Exp>
+}
+
+export type Query_RootText_Objects_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Text_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Text_Objects_Order_By>>
+  where?: InputMaybe<Text_Objects_Bool_Exp>
+}
+
 export type Query_RootThingArgs = {
   id: Scalars['numeric']['input']
 }
@@ -4944,7 +5555,7 @@ export type Redemptions = {
   signals: Array<Signals>
   /** An aggregate relationship */
   signals_aggregate: Signals_Aggregate
-  transaction_hash: Scalars['bytea']['output']
+  transaction_hash: Scalars['String']['output']
   /** An object relationship */
   vault: Vaults
   vault_id: Scalars['numeric']['output']
@@ -5084,7 +5695,7 @@ export type Redemptions_Bool_Exp = {
   shares_redeemed_by_sender?: InputMaybe<Numeric_Comparison_Exp>
   signals?: InputMaybe<Signals_Bool_Exp>
   signals_aggregate?: InputMaybe<Signals_Aggregate_Bool_Exp>
-  transaction_hash?: InputMaybe<Bytea_Comparison_Exp>
+  transaction_hash?: InputMaybe<String_Comparison_Exp>
   vault?: InputMaybe<Vaults_Bool_Exp>
   vault_id?: InputMaybe<Numeric_Comparison_Exp>
 }
@@ -5101,6 +5712,7 @@ export type Redemptions_Max_Fields = {
   sender_id?: Maybe<Scalars['String']['output']>
   sender_total_shares_in_vault?: Maybe<Scalars['numeric']['output']>
   shares_redeemed_by_sender?: Maybe<Scalars['numeric']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -5115,6 +5727,7 @@ export type Redemptions_Max_Order_By = {
   sender_id?: InputMaybe<Order_By>
   sender_total_shares_in_vault?: InputMaybe<Order_By>
   shares_redeemed_by_sender?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
 }
 
@@ -5130,6 +5743,7 @@ export type Redemptions_Min_Fields = {
   sender_id?: Maybe<Scalars['String']['output']>
   sender_total_shares_in_vault?: Maybe<Scalars['numeric']['output']>
   shares_redeemed_by_sender?: Maybe<Scalars['numeric']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -5144,6 +5758,7 @@ export type Redemptions_Min_Order_By = {
   sender_id?: InputMaybe<Order_By>
   sender_total_shares_in_vault?: InputMaybe<Order_By>
   shares_redeemed_by_sender?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
 }
 
@@ -5280,7 +5895,7 @@ export type Redemptions_Stream_Cursor_Value_Input = {
   sender_id?: InputMaybe<Scalars['String']['input']>
   sender_total_shares_in_vault?: InputMaybe<Scalars['numeric']['input']>
   shares_redeemed_by_sender?: InputMaybe<Scalars['numeric']['input']>
-  transaction_hash?: InputMaybe<Scalars['bytea']['input']>
+  transaction_hash?: InputMaybe<Scalars['String']['input']>
   vault_id?: InputMaybe<Scalars['numeric']['input']>
 }
 
@@ -5395,7 +6010,7 @@ export type Signals = {
   /** An object relationship */
   redemption?: Maybe<Redemptions>
   redemption_id?: Maybe<Scalars['String']['output']>
-  transaction_hash: Scalars['bytea']['output']
+  transaction_hash: Scalars['String']['output']
   /** An object relationship */
   triple?: Maybe<Triples>
   triple_id?: Maybe<Scalars['numeric']['output']>
@@ -5492,7 +6107,7 @@ export type Signals_Bool_Exp = {
   id?: InputMaybe<String_Comparison_Exp>
   redemption?: InputMaybe<Redemptions_Bool_Exp>
   redemption_id?: InputMaybe<String_Comparison_Exp>
-  transaction_hash?: InputMaybe<Bytea_Comparison_Exp>
+  transaction_hash?: InputMaybe<String_Comparison_Exp>
   triple?: InputMaybe<Triples_Bool_Exp>
   triple_id?: InputMaybe<Numeric_Comparison_Exp>
 }
@@ -5512,6 +6127,7 @@ export type Signals_Max_Fields = {
   deposit_id?: Maybe<Scalars['String']['output']>
   id?: Maybe<Scalars['String']['output']>
   redemption_id?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   triple_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -5525,6 +6141,7 @@ export type Signals_Max_Order_By = {
   deposit_id?: InputMaybe<Order_By>
   id?: InputMaybe<Order_By>
   redemption_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   triple_id?: InputMaybe<Order_By>
 }
 
@@ -5539,6 +6156,7 @@ export type Signals_Min_Fields = {
   deposit_id?: Maybe<Scalars['String']['output']>
   id?: Maybe<Scalars['String']['output']>
   redemption_id?: Maybe<Scalars['String']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   triple_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -5552,6 +6170,7 @@ export type Signals_Min_Order_By = {
   deposit_id?: InputMaybe<Order_By>
   id?: InputMaybe<Order_By>
   redemption_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   triple_id?: InputMaybe<Order_By>
 }
 
@@ -5672,7 +6291,7 @@ export type Signals_Stream_Cursor_Value_Input = {
   deposit_id?: InputMaybe<Scalars['String']['input']>
   id?: InputMaybe<Scalars['String']['input']>
   redemption_id?: InputMaybe<Scalars['String']['input']>
-  transaction_hash?: InputMaybe<Scalars['bytea']['input']>
+  transaction_hash?: InputMaybe<Scalars['String']['input']>
   triple_id?: InputMaybe<Scalars['numeric']['input']>
 }
 
@@ -6028,12 +6647,28 @@ export type Subscription_Root = {
   books_aggregate: Books_Aggregate
   /** fetch data from the table in a streaming manner: "book" */
   books_stream: Array<Books>
+  /** fetch data from the table: "byte_object" */
+  byte_object: Array<Byte_Object>
+  /** fetch aggregated fields from the table: "byte_object" */
+  byte_object_aggregate: Byte_Object_Aggregate
+  /** fetch data from the table: "byte_object" using primary key columns */
+  byte_object_by_pk?: Maybe<Byte_Object>
+  /** fetch data from the table in a streaming manner: "byte_object" */
+  byte_object_stream: Array<Byte_Object>
   /** fetch data from the table: "cached_image" using primary key columns */
   cached_image?: Maybe<Cached_Images>
   /** fetch data from the table: "cached_image" */
   cached_images: Array<Cached_Images>
   /** fetch data from the table in a streaming manner: "cached_image" */
   cached_images_stream: Array<Cached_Images>
+  /** fetch data from the table: "caip10" using primary key columns */
+  caip10?: Maybe<Caip10>
+  /** fetch aggregated fields from the table: "caip10" */
+  caip10_aggregate: Caip10_Aggregate
+  /** fetch data from the table in a streaming manner: "caip10" */
+  caip10_stream: Array<Caip10>
+  /** fetch data from the table: "caip10" */
+  caip10s: Array<Caip10>
   /** fetch data from the table: "chainlink_price" using primary key columns */
   chainlink_price?: Maybe<Chainlink_Prices>
   /** fetch data from the table: "chainlink_price" */
@@ -6080,6 +6715,14 @@ export type Subscription_Root = {
   following: Array<Accounts>
   /** execute function "following" and query aggregates on result of table type "account" */
   following_aggregate: Accounts_Aggregate
+  /** fetch data from the table: "json_object" using primary key columns */
+  json_object?: Maybe<Json_Objects>
+  /** fetch data from the table: "json_object" */
+  json_objects: Array<Json_Objects>
+  /** fetch aggregated fields from the table: "json_object" */
+  json_objects_aggregate: Json_Objects_Aggregate
+  /** fetch data from the table in a streaming manner: "json_object" */
+  json_objects_stream: Array<Json_Objects>
   /** fetch data from the table: "organization" using primary key columns */
   organization?: Maybe<Organizations>
   /** fetch data from the table: "organization" */
@@ -6140,6 +6783,14 @@ export type Subscription_Root = {
   stats_aggregate: Stats_Aggregate
   /** fetch data from the table in a streaming manner: "stats" */
   stats_stream: Array<Stats>
+  /** fetch data from the table: "text_object" using primary key columns */
+  text_object?: Maybe<Text_Objects>
+  /** fetch data from the table: "text_object" */
+  text_objects: Array<Text_Objects>
+  /** fetch aggregated fields from the table: "text_object" */
+  text_objects_aggregate: Text_Objects_Aggregate
+  /** fetch data from the table in a streaming manner: "text_object" */
+  text_objects_stream: Array<Text_Objects>
   /** fetch data from the table: "thing" using primary key columns */
   thing?: Maybe<Things>
   /** fetch data from the table: "thing" */
@@ -6288,6 +6939,32 @@ export type Subscription_RootBooks_StreamArgs = {
   where?: InputMaybe<Books_Bool_Exp>
 }
 
+export type Subscription_RootByte_ObjectArgs = {
+  distinct_on?: InputMaybe<Array<Byte_Object_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Byte_Object_Order_By>>
+  where?: InputMaybe<Byte_Object_Bool_Exp>
+}
+
+export type Subscription_RootByte_Object_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Byte_Object_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Byte_Object_Order_By>>
+  where?: InputMaybe<Byte_Object_Bool_Exp>
+}
+
+export type Subscription_RootByte_Object_By_PkArgs = {
+  id: Scalars['numeric']['input']
+}
+
+export type Subscription_RootByte_Object_StreamArgs = {
+  batch_size: Scalars['Int']['input']
+  cursor: Array<InputMaybe<Byte_Object_Stream_Cursor_Input>>
+  where?: InputMaybe<Byte_Object_Bool_Exp>
+}
+
 export type Subscription_RootCached_ImageArgs = {
   url: Scalars['String']['input']
 }
@@ -6304,6 +6981,32 @@ export type Subscription_RootCached_Images_StreamArgs = {
   batch_size: Scalars['Int']['input']
   cursor: Array<InputMaybe<Cached_Images_Stream_Cursor_Input>>
   where?: InputMaybe<Cached_Images_Bool_Exp>
+}
+
+export type Subscription_RootCaip10Args = {
+  id: Scalars['numeric']['input']
+}
+
+export type Subscription_RootCaip10_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Caip10_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Caip10_Order_By>>
+  where?: InputMaybe<Caip10_Bool_Exp>
+}
+
+export type Subscription_RootCaip10_StreamArgs = {
+  batch_size: Scalars['Int']['input']
+  cursor: Array<InputMaybe<Caip10_Stream_Cursor_Input>>
+  where?: InputMaybe<Caip10_Bool_Exp>
+}
+
+export type Subscription_RootCaip10sArgs = {
+  distinct_on?: InputMaybe<Array<Caip10_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Caip10_Order_By>>
+  where?: InputMaybe<Caip10_Bool_Exp>
 }
 
 export type Subscription_RootChainlink_PriceArgs = {
@@ -6462,6 +7165,32 @@ export type Subscription_RootFollowing_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>
   order_by?: InputMaybe<Array<Accounts_Order_By>>
   where?: InputMaybe<Accounts_Bool_Exp>
+}
+
+export type Subscription_RootJson_ObjectArgs = {
+  id: Scalars['numeric']['input']
+}
+
+export type Subscription_RootJson_ObjectsArgs = {
+  distinct_on?: InputMaybe<Array<Json_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Json_Objects_Order_By>>
+  where?: InputMaybe<Json_Objects_Bool_Exp>
+}
+
+export type Subscription_RootJson_Objects_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Json_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Json_Objects_Order_By>>
+  where?: InputMaybe<Json_Objects_Bool_Exp>
+}
+
+export type Subscription_RootJson_Objects_StreamArgs = {
+  batch_size: Scalars['Int']['input']
+  cursor: Array<InputMaybe<Json_Objects_Stream_Cursor_Input>>
+  where?: InputMaybe<Json_Objects_Bool_Exp>
 }
 
 export type Subscription_RootOrganizationArgs = {
@@ -6664,6 +7393,32 @@ export type Subscription_RootStats_StreamArgs = {
   where?: InputMaybe<Stats_Bool_Exp>
 }
 
+export type Subscription_RootText_ObjectArgs = {
+  id: Scalars['numeric']['input']
+}
+
+export type Subscription_RootText_ObjectsArgs = {
+  distinct_on?: InputMaybe<Array<Text_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Text_Objects_Order_By>>
+  where?: InputMaybe<Text_Objects_Bool_Exp>
+}
+
+export type Subscription_RootText_Objects_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Text_Objects_Select_Column>>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  order_by?: InputMaybe<Array<Text_Objects_Order_By>>
+  where?: InputMaybe<Text_Objects_Bool_Exp>
+}
+
+export type Subscription_RootText_Objects_StreamArgs = {
+  batch_size: Scalars['Int']['input']
+  cursor: Array<InputMaybe<Text_Objects_Stream_Cursor_Input>>
+  where?: InputMaybe<Text_Objects_Bool_Exp>
+}
+
 export type Subscription_RootThingArgs = {
   id: Scalars['numeric']['input']
 }
@@ -6740,6 +7495,140 @@ export type Subscription_RootVaults_StreamArgs = {
   batch_size: Scalars['Int']['input']
   cursor: Array<InputMaybe<Vaults_Stream_Cursor_Input>>
   where?: InputMaybe<Vaults_Bool_Exp>
+}
+
+/** columns and relationships of "text_object" */
+export type Text_Objects = {
+  __typename?: 'text_objects'
+  data: Scalars['String']['output']
+  id: Scalars['numeric']['output']
+}
+
+/** aggregated selection of "text_object" */
+export type Text_Objects_Aggregate = {
+  __typename?: 'text_objects_aggregate'
+  aggregate?: Maybe<Text_Objects_Aggregate_Fields>
+  nodes: Array<Text_Objects>
+}
+
+/** aggregate fields of "text_object" */
+export type Text_Objects_Aggregate_Fields = {
+  __typename?: 'text_objects_aggregate_fields'
+  avg?: Maybe<Text_Objects_Avg_Fields>
+  count: Scalars['Int']['output']
+  max?: Maybe<Text_Objects_Max_Fields>
+  min?: Maybe<Text_Objects_Min_Fields>
+  stddev?: Maybe<Text_Objects_Stddev_Fields>
+  stddev_pop?: Maybe<Text_Objects_Stddev_Pop_Fields>
+  stddev_samp?: Maybe<Text_Objects_Stddev_Samp_Fields>
+  sum?: Maybe<Text_Objects_Sum_Fields>
+  var_pop?: Maybe<Text_Objects_Var_Pop_Fields>
+  var_samp?: Maybe<Text_Objects_Var_Samp_Fields>
+  variance?: Maybe<Text_Objects_Variance_Fields>
+}
+
+/** aggregate fields of "text_object" */
+export type Text_Objects_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Text_Objects_Select_Column>>
+  distinct?: InputMaybe<Scalars['Boolean']['input']>
+}
+
+/** aggregate avg on columns */
+export type Text_Objects_Avg_Fields = {
+  __typename?: 'text_objects_avg_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Boolean expression to filter rows from the table "text_object". All fields are combined with a logical 'AND'. */
+export type Text_Objects_Bool_Exp = {
+  _and?: InputMaybe<Array<Text_Objects_Bool_Exp>>
+  _not?: InputMaybe<Text_Objects_Bool_Exp>
+  _or?: InputMaybe<Array<Text_Objects_Bool_Exp>>
+  data?: InputMaybe<String_Comparison_Exp>
+  id?: InputMaybe<Numeric_Comparison_Exp>
+}
+
+/** aggregate max on columns */
+export type Text_Objects_Max_Fields = {
+  __typename?: 'text_objects_max_fields'
+  data?: Maybe<Scalars['String']['output']>
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** aggregate min on columns */
+export type Text_Objects_Min_Fields = {
+  __typename?: 'text_objects_min_fields'
+  data?: Maybe<Scalars['String']['output']>
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** Ordering options when selecting data from "text_object". */
+export type Text_Objects_Order_By = {
+  data?: InputMaybe<Order_By>
+  id?: InputMaybe<Order_By>
+}
+
+/** select columns of table "text_object" */
+export type Text_Objects_Select_Column =
+  /** column name */
+  | 'data'
+  /** column name */
+  | 'id'
+
+/** aggregate stddev on columns */
+export type Text_Objects_Stddev_Fields = {
+  __typename?: 'text_objects_stddev_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_pop on columns */
+export type Text_Objects_Stddev_Pop_Fields = {
+  __typename?: 'text_objects_stddev_pop_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate stddev_samp on columns */
+export type Text_Objects_Stddev_Samp_Fields = {
+  __typename?: 'text_objects_stddev_samp_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** Streaming cursor of the table "text_objects" */
+export type Text_Objects_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Text_Objects_Stream_Cursor_Value_Input
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>
+}
+
+/** Initial value of the column from where the streaming should start */
+export type Text_Objects_Stream_Cursor_Value_Input = {
+  data?: InputMaybe<Scalars['String']['input']>
+  id?: InputMaybe<Scalars['numeric']['input']>
+}
+
+/** aggregate sum on columns */
+export type Text_Objects_Sum_Fields = {
+  __typename?: 'text_objects_sum_fields'
+  id?: Maybe<Scalars['numeric']['output']>
+}
+
+/** aggregate var_pop on columns */
+export type Text_Objects_Var_Pop_Fields = {
+  __typename?: 'text_objects_var_pop_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate var_samp on columns */
+export type Text_Objects_Var_Samp_Fields = {
+  __typename?: 'text_objects_var_samp_fields'
+  id?: Maybe<Scalars['Float']['output']>
+}
+
+/** aggregate variance on columns */
+export type Text_Objects_Variance_Fields = {
+  __typename?: 'text_objects_variance_fields'
+  id?: Maybe<Scalars['Float']['output']>
 }
 
 /** columns and relationships of "thing" */
@@ -6950,7 +7839,7 @@ export type Triples = {
   /** An object relationship */
   subject: Atoms
   subject_id: Scalars['numeric']['output']
-  transaction_hash: Scalars['bytea']['output']
+  transaction_hash: Scalars['String']['output']
   /** An object relationship */
   vault?: Maybe<Vaults>
   vault_id: Scalars['numeric']['output']
@@ -7094,7 +7983,7 @@ export type Triples_Bool_Exp = {
   signals_aggregate?: InputMaybe<Signals_Aggregate_Bool_Exp>
   subject?: InputMaybe<Atoms_Bool_Exp>
   subject_id?: InputMaybe<Numeric_Comparison_Exp>
-  transaction_hash?: InputMaybe<Bytea_Comparison_Exp>
+  transaction_hash?: InputMaybe<String_Comparison_Exp>
   vault?: InputMaybe<Vaults_Bool_Exp>
   vault_id?: InputMaybe<Numeric_Comparison_Exp>
 }
@@ -7110,6 +7999,7 @@ export type Triples_Max_Fields = {
   object_id?: Maybe<Scalars['numeric']['output']>
   predicate_id?: Maybe<Scalars['numeric']['output']>
   subject_id?: Maybe<Scalars['numeric']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -7123,6 +8013,7 @@ export type Triples_Max_Order_By = {
   object_id?: InputMaybe<Order_By>
   predicate_id?: InputMaybe<Order_By>
   subject_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
 }
 
@@ -7137,6 +8028,7 @@ export type Triples_Min_Fields = {
   object_id?: Maybe<Scalars['numeric']['output']>
   predicate_id?: Maybe<Scalars['numeric']['output']>
   subject_id?: Maybe<Scalars['numeric']['output']>
+  transaction_hash?: Maybe<Scalars['String']['output']>
   vault_id?: Maybe<Scalars['numeric']['output']>
 }
 
@@ -7150,6 +8042,7 @@ export type Triples_Min_Order_By = {
   object_id?: InputMaybe<Order_By>
   predicate_id?: InputMaybe<Order_By>
   subject_id?: InputMaybe<Order_By>
+  transaction_hash?: InputMaybe<Order_By>
   vault_id?: InputMaybe<Order_By>
 }
 
@@ -7291,7 +8184,7 @@ export type Triples_Stream_Cursor_Value_Input = {
   object_id?: InputMaybe<Scalars['numeric']['input']>
   predicate_id?: InputMaybe<Scalars['numeric']['input']>
   subject_id?: InputMaybe<Scalars['numeric']['input']>
-  transaction_hash?: InputMaybe<Scalars['bytea']['input']>
+  transaction_hash?: InputMaybe<Scalars['String']['input']>
   vault_id?: InputMaybe<Scalars['numeric']['input']>
 }
 
@@ -7969,7 +8862,7 @@ export type AtomTxnFragment = {
   __typename?: 'atoms'
   block_number: any
   block_timestamp: any
-  transaction_hash: any
+  transaction_hash: string
   creator_id: string
 }
 
@@ -8161,7 +9054,7 @@ export type EventDetailsFragment = {
   block_number: any
   block_timestamp: any
   type: any
-  transaction_hash: any
+  transaction_hash: string
   atom_id?: any | null
   triple_id?: any | null
   deposit_id?: string | null
@@ -8884,7 +9777,7 @@ export type TripleTxnFragment = {
   __typename?: 'triples'
   block_number: any
   block_timestamp: any
-  transaction_hash: any
+  transaction_hash: string
   creator_id: string
 }
 
@@ -9940,7 +10833,7 @@ export type GetAtomsQuery = {
     wallet_id: string
     block_number: any
     block_timestamp: any
-    transaction_hash: any
+    transaction_hash: string
     creator_id: string
     vault_id: any
     creator?: {
@@ -10140,7 +11033,7 @@ export type GetAtomsWithPositionsQuery = {
     wallet_id: string
     block_number: any
     block_timestamp: any
-    transaction_hash: any
+    transaction_hash: string
     creator_id: string
     vault?: {
       __typename?: 'vaults'
@@ -10223,7 +11116,7 @@ export type GetAtomsWithAggregatesQuery = {
       wallet_id: string
       block_number: any
       block_timestamp: any
-      transaction_hash: any
+      transaction_hash: string
       creator_id: string
       vault_id: any
       creator?: {
@@ -10318,7 +11211,7 @@ export type GetAtomQuery = {
     wallet_id: string
     block_number: any
     block_timestamp: any
-    transaction_hash: any
+    transaction_hash: string
     creator_id: string
     vault_id: any
     creator?: {
@@ -12834,7 +13727,7 @@ export type GetTriplesQuery = {
     object_id: any
     block_number: any
     block_timestamp: any
-    transaction_hash: any
+    transaction_hash: string
     creator_id: string
     vault_id: any
     counter_vault_id: any
@@ -13389,7 +14282,7 @@ export type GetTriplesWithAggregatesQuery = {
       object_id: any
       block_number: any
       block_timestamp: any
-      transaction_hash: any
+      transaction_hash: string
       creator_id: string
       vault_id: any
       counter_vault_id: any
@@ -13948,7 +14841,7 @@ export type GetTripleQuery = {
     object_id: any
     block_number: any
     block_timestamp: any
-    transaction_hash: any
+    transaction_hash: string
     creator_id: string
     vault_id: any
     counter_vault_id: any

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,6 +520,9 @@ importers:
       framer-motion:
         specifier: ^11.2.10
         version: 11.2.10(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      graphql-request:
+        specifier: ^7.1.0
+        version: 7.1.0(graphql@16.9.0)
       isbot:
         specifier: ^4.1.0
         version: 4.4.0
@@ -22100,8 +22103,8 @@ snapshots:
   '@solana/web3.js@1.95.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.4)':
     dependencies:
       '@babel/runtime': 7.25.7
-      '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.5.0
       bigint-buffer: 1.1.5
@@ -24049,7 +24052,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.0.1
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.14.2)(@vitest/ui@1.6.0)(jsdom@22.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.31.1)
+      vitest: 1.6.0(@types/node@18.16.9)(@vitest/ui@1.6.0)(jsdom@22.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.31.1)
 
   '@vitest/utils@1.3.1':
     dependencies:


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [x] portal
- [ ] template

Packages

- [ ] 1ui
- [ ] api
- [x] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Updates Relic points to use the new points API. This also adds support for other points using the new points API but I did not swap those out. Had to update the graphql schema to fix codegen build errors (thanks @jonathanprozzi).

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
