### PR TITLE
ENG-5821 feat(launchpad): prefill atom name from search term

### DIFF
--- a/apps/launchpad/app/components/survey-modal/create-step.tsx
+++ b/apps/launchpad/app/components/survey-modal/create-step.tsx
@@ -68,9 +68,13 @@ const INITIAL_STEPS: Step[] = [
 
 export interface CreateStepProps {
   onCreationSuccess: (metadata: NewAtomMetadata) => void
+  initialName?: string
 }
 
-export function CreateStep({ onCreationSuccess }: CreateStepProps) {
+export function CreateStep({
+  onCreationSuccess,
+  initialName,
+}: CreateStepProps) {
   const [currentStep, setCurrentStep] = useState('metadata')
   const [steps, setSteps] = useState<Step[]>(INITIAL_STEPS)
   const [ipfsUri, setIpfsUri] = useState<string | null>(null)
@@ -295,7 +299,9 @@ export function CreateStep({ onCreationSuccess }: CreateStepProps) {
           <SurveyFormContainer
             onSubmit={handleMetadataSubmit}
             isLoading={isPending}
-            defaultValues={atomData || undefined}
+            defaultValues={
+              atomData || (initialName ? { name: initialName } : undefined)
+            }
           />
         )
       case 'review':

--- a/apps/launchpad/app/components/survey-modal/survey-modal.tsx
+++ b/apps/launchpad/app/components/survey-modal/survey-modal.tsx
@@ -615,7 +615,10 @@ export function OnboardingModal({
                 )}
 
                 {state.currentStep === STEPS.CREATE && (
-                  <CreateStep onCreationSuccess={onCreationSuccess} />
+                  <CreateStep
+                    onCreationSuccess={onCreationSuccess}
+                    initialName={searchTerm}
+                  />
                 )}
 
                 {state.currentStep === STEPS.SIGNAL && state.selectedTopic && (

--- a/apps/launchpad/app/routes/_app+/quests+/questions+/$epochId+/$questionId.tsx
+++ b/apps/launchpad/app/routes/_app+/quests+/questions+/$epochId+/$questionId.tsx
@@ -541,12 +541,12 @@ export default function MiniGameOne() {
                               className="w-full h-full object-cover rounded-lg"
                             />
                           </div>
-                          <div className="text-left">
+                          <div className="text-left w-full">
                             <div className="text-white text-base leading-5">
                               {atomData?.atom?.label ?? ''}
                             </div>
                           </div>
-                          <div className="flex w-full justify-end px-6">
+                          <div className="flex justify-end px-6">
                             <CheckCircle className="text-success h-6 w-6" />
                           </div>
                         </button>


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template
- [x] launchpad

Packages

- [ ] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

Improves UX by carrying over the search term from the Topics step to prefill the name field in the Create step when no matching atom is found. This creates a more seamless experience for users who want to create an atom based on their search.

Changes:
- Added `initialName` prop to CreateStep component
- Modified SurveyFormContainer defaultValues to use search term
- Passed searchTerm from parent OnboardingModal component

Testing:
1. Search for a non-existent atom in Topics step
2. Click "Create" button
3. Verify name field is prefilled with search term

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
