### PR TITLE
ENG-5829 feat(1ui): updates 1ui components with use client where needed

### DIFF
--- a/packages/1ui/src/components/Button/Button.tsx
+++ b/packages/1ui/src/components/Button/Button.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 
 import { Slot } from '@radix-ui/react-slot'

--- a/packages/1ui/src/components/Claim/Claim.tsx
+++ b/packages/1ui/src/components/Claim/Claim.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useState } from 'react'
 
 import {

--- a/packages/1ui/src/components/Copy/Copy.tsx
+++ b/packages/1ui/src/components/Copy/Copy.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useState } from 'react'
 
 import { cn } from 'styles'

--- a/packages/1ui/src/components/Icon/Icon.tsx
+++ b/packages/1ui/src/components/Icon/Icon.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 
 import { cn } from '../../styles'


### PR DESCRIPTION
## Affected Packages

Apps

- [ ] data populator
- [ ] portal
- [ ] template

Packages

- [x] 1ui
- [ ] api
- [ ] graphql
- [ ] protocol
- [ ] sdk

Tools

- [ ] tools

## Overview

- Cherrypicks this from the work I was doing to support Next inside (and outside) of the monorepo when using `1ui` -- needed to add in `'use client'` for certain components in it. Moved to a separate PR so to not include in the other ones

## Screen Captures

If applicable, add screenshots or screen captures of your changes.

## Declaration

- [x] I hereby declare that I have abided by the rules and regulations as outlined in the [CONTRIBUTING.md](https://github.com/0xIntuition/intuition-ts/blob/main/CONTRIBUTING.md)
