### PR TITLE
feat(sdk,graphql): deprecate pinThing mutation in favor of direct Pinata uploads

### DIFF
--- a/apps/nextjs-template/src/components/intuition/IntuitionCreateThingButton.tsx
+++ b/apps/nextjs-template/src/components/intuition/IntuitionCreateThingButton.tsx
@@ -17,9 +17,19 @@ export const IntuitionCreateThingButton = ({
     if (!walletClient || !publicClient) {
       return
     }
+    const pinataApiJWT = process.env.NEXT_PUBLIC_PINATA_API_JWT
+    if (!pinataApiJWT) {
+      alert('Pinata API JWT not configured')
+      return
+    }
     const multiVaultAddress = intuitionDeployments.MultiVault[chainId]
     const data = await createAtomFromThing(
-      { walletClient, publicClient, address: multiVaultAddress },
+      {
+        walletClient,
+        publicClient,
+        address: multiVaultAddress,
+        pinataApiJWT,
+      },
       {
         url: 'https://www.intuition.systems/',
         name: 'Intuition',

--- a/apps/nextjs-template/src/components/intuition/IntuitionCreateThingButton.tsx
+++ b/apps/nextjs-template/src/components/intuition/IntuitionCreateThingButton.tsx
@@ -17,6 +17,10 @@ export const IntuitionCreateThingButton = ({
     if (!walletClient || !publicClient) {
       return
     }
+    // WARNING: NEXT_PUBLIC_* environment variables are exposed to the browser.
+    // This is INSECURE for production use as users can extract your API key.
+    // For production, use a backend API route to proxy Pinata uploads securely.
+    // Example: POST /api/upload-to-pinata with server-side JWT handling.
     const pinataApiJWT = process.env.NEXT_PUBLIC_PINATA_API_JWT
     if (!pinataApiJWT) {
       alert('Pinata API JWT not configured')
@@ -33,7 +37,7 @@ export const IntuitionCreateThingButton = ({
       {
         url: 'https://www.intuition.systems/',
         name: 'Intuition',
-        description: `'A decentralized trust protocol: ${new Date().toLocaleDateString()}`,
+        description: `A decentralized trust protocol: ${new Date().toLocaleDateString()}`,
         image: 'https://example.com/image.png',
       },
     )

--- a/apps/nextjs-template/src/components/intuition/IntuitionCreateThingButton.tsx
+++ b/apps/nextjs-template/src/components/intuition/IntuitionCreateThingButton.tsx
@@ -17,10 +17,20 @@ export const IntuitionCreateThingButton = ({
     if (!walletClient || !publicClient) {
       return
     }
-    // WARNING: NEXT_PUBLIC_* environment variables are exposed to the browser.
+    // ⚠️ SECURITY WARNING: DO NOT USE IN PRODUCTION ⚠️
+    // NEXT_PUBLIC_* environment variables are exposed to the browser.
     // This is INSECURE for production use as users can extract your API key.
-    // For production, use a backend API route to proxy Pinata uploads securely.
-    // Example: POST /api/upload-to-pinata with server-side JWT handling.
+    //
+    // For production, use a backend API route to proxy Pinata uploads securely:
+    // 1. Create an API route: app/api/upload-to-pinata/route.ts
+    // 2. Store JWT in server-side env (not NEXT_PUBLIC_*)
+    // 3. Call it from client: const response = await fetch('/api/upload-to-pinata', {
+    //      method: 'POST',
+    //      headers: { 'Content-Type': 'application/json' },
+    //      body: JSON.stringify(data)
+    //    })
+    //
+    // THIS EXAMPLE IS FOR DEVELOPMENT/TESTING ONLY
     const pinataApiJWT = process.env.NEXT_PUBLIC_PINATA_API_JWT
     if (!pinataApiJWT) {
       alert('Pinata API JWT not configured')

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+### Deprecations
+
+- **DEPRECATED:** The `pinThing` GraphQL mutation is now deprecated. Use `uploadJsonToPinata` from `@0xintuition/sdk` instead for direct Pinata uploads. The SDK now supports client-side IPFS pinning without requiring backend mediation.
+
+### Documentation
+
+- Added deprecation notices to the `pinThing` mutation documentation in README.md.
+- Updated mutation file with deprecation comments and migration guidance.
+
 ## 2.0.1
 
 ## 2.0.2

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -49,30 +49,39 @@ Explore the API interactively with Apollo Studio Sandbox:
 ## Core Concepts
 
 ### Atoms
+
 **Atoms** are the fundamental entities in the Intuition knowledge graph. Each atom represents an identity, concept, or piece of data (e.g., a person, organization, tag, or blockchain address).
 
 ### Triples
+
 **Triples** are statements that connect atoms in subject-predicate-object relationships. For example: `(Alice, knows, Bob)` or `(Document, hasTag, TypeScript)`.
 
 ### Vaults
+
 **Vaults** are asset pools associated with atoms and triples. Users deposit assets into vaults and receive shares based on bonding curves. See the [@0xintuition/protocol](../protocol/README.md) documentation for details on bonding curves and vault mechanics.
 
 ### Positions
+
 **Positions** represent user ownership (shares) in vaults. Each position tracks an account's shares in a specific vault.
 
 ### Accounts
+
 **Accounts** are blockchain addresses participating in the protocol, including:
+
 - User wallets
 - Atom wallets (smart contract wallets for atoms)
 - Protocol vaults
 
 ### Deposits & Redemptions
+
 **Deposits** are transactions where users add assets to vaults and receive shares. **Redemptions** are the reverse: users burn shares to withdraw assets.
 
 ### Events
+
 **Events** capture the complete on-chain event history, including deposits, redemptions, atom creation, triple creation, and more.
 
 ### Stats
+
 **Stats** provide protocol-wide statistics and aggregated metrics.
 
 ---
@@ -86,7 +95,7 @@ The Intuition GraphQL API works with any GraphQL client. Below are minimal examp
 **For JavaScript/TypeScript projects**: Instead of hardcoding API endpoints, import them from this package:
 
 ```typescript
-import { API_URL_PROD, API_URL_DEV } from '@0xintuition/graphql'
+import { API_URL_DEV, API_URL_PROD } from '@0xintuition/graphql'
 
 // API_URL_PROD = 'https://mainnet.intuition.sh/v1/graphql'
 // API_URL_DEV = 'https://testnet.intuition.sh/v1/graphql'
@@ -95,8 +104,9 @@ import { API_URL_PROD, API_URL_DEV } from '@0xintuition/graphql'
 #### graphql-request
 
 ```typescript
-import { GraphQLClient } from 'graphql-request'
 import { API_URL_PROD } from '@0xintuition/graphql'
+
+import { GraphQLClient } from 'graphql-request'
 
 const client = new GraphQLClient(API_URL_PROD)
 
@@ -118,12 +128,13 @@ const data = await client.request(query, { id: '0x...' })
 #### Apollo Client
 
 ```typescript
-import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
 import { API_URL_PROD } from '@0xintuition/graphql'
+
+import { ApolloClient, gql, InMemoryCache } from '@apollo/client'
 
 const client = new ApolloClient({
   uri: API_URL_PROD,
-  cache: new InMemoryCache()
+  cache: new InMemoryCache(),
 })
 
 const { data } = await client.query({
@@ -135,7 +146,7 @@ const { data } = await client.query({
       }
     }
   `,
-  variables: { id: '0x...' }
+  variables: { id: '0x...' },
 })
 ```
 
@@ -144,11 +155,12 @@ const { data } = await client.query({
 #### urql
 
 ```typescript
-import { createClient } from 'urql'
 import { API_URL_PROD } from '@0xintuition/graphql'
 
+import { createClient } from 'urql'
+
 const client = createClient({
-  url: API_URL_PROD
+  url: API_URL_PROD,
 })
 
 const result = await client.query(query, { id: '0x...' }).toPromise()
@@ -166,8 +178,8 @@ const response = await fetch(API_URL_PROD, {
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
     query: `query GetAtom($id: String!) { atom(term_id: $id) { term_id label } }`,
-    variables: { id: '0x...' }
-  })
+    variables: { id: '0x...' },
+  }),
 })
 
 const { data } = await response.json()
@@ -306,10 +318,7 @@ Use boolean expressions to filter results:
 ```graphql
 query GetRecentAtoms {
   atoms(
-    where: {
-      created_at: { _gte: "2024-01-01" }
-      type: { _eq: Person }
-    }
+    where: { created_at: { _gte: "2024-01-01" }, type: { _eq: Person } }
     limit: 10
   ) {
     term_id
@@ -319,6 +328,7 @@ query GetRecentAtoms {
 ```
 
 **Available operators**:
+
 - `_eq`, `_neq` - Equality
 - `_gt`, `_gte`, `_lt`, `_lte` - Comparisons
 - `_in`, `_nin` - Array membership
@@ -331,10 +341,7 @@ query GetRecentAtoms {
 ```graphql
 query GetTopAtoms {
   atoms(
-    order_by: [
-      { term: { total_market_cap: desc } }
-      { created_at: desc }
-    ]
+    order_by: [{ term: { total_market_cap: desc } }, { created_at: desc }]
     limit: 10
   ) {
     term_id
@@ -397,7 +404,8 @@ query GetAtomWithCreator($id: String!) {
 
 ```graphql
 query GetAtom($id: String!) {
-  atom(term_id: $id) {  # Direct lookup by primary key
+  atom(term_id: $id) {
+    # Direct lookup by primary key
     term_id
     label
   }
@@ -466,7 +474,6 @@ query GetAtomWithVault($id: String!, $curveId: numeric!) {
 }
 ```
 
-
 ### Querying Triples
 
 #### Get Single Triple
@@ -503,8 +510,12 @@ query GetTriplesBySubject($subjectId: String!, $limit: Int!) {
     limit: $limit
   ) {
     term_id
-    predicate { label }
-    object { label }
+    predicate {
+      label
+    }
+    object {
+      label
+    }
   }
 }
 ```
@@ -519,9 +530,15 @@ query GetTriplesWithPositions(
 ) {
   triples(where: $where, limit: $limit) {
     term_id
-    subject { label }
-    predicate { label }
-    object { label }
+    subject {
+      label
+    }
+    predicate {
+      label
+    }
+    object {
+      label
+    }
     term {
       vaults(where: { curve_id: { _eq: $curveId } }) {
         total_shares
@@ -651,9 +668,15 @@ query GlobalSearch(
     limit: $triplesLimit
   ) {
     term_id
-    subject { label }
-    predicate { label }
-    object { label }
+    subject {
+      label
+    }
+    predicate {
+      label
+    }
+    object {
+      label
+    }
   }
 }
 ```
@@ -683,11 +706,7 @@ query GetAtomsPage($limit: Int!, $offset: Int!) {
       count
     }
   }
-  atoms(
-    limit: $limit
-    offset: $offset
-    order_by: { created_at: desc }
-  ) {
+  atoms(limit: $limit, offset: $offset, order_by: { created_at: desc }) {
     term_id
     label
     created_at
@@ -696,6 +715,7 @@ query GetAtomsPage($limit: Int!, $offset: Int!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "limit": 20,
@@ -734,6 +754,7 @@ query GetFollowing($address: String!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
@@ -797,15 +818,9 @@ query GetSignalsFromFollowing($address: String!, $limit: Int!) {
 Search positions with complex filtering:
 
 ```graphql
-query SearchPositions(
-  $addresses: _text!
-  $searchFields: jsonb!
-) {
+query SearchPositions($addresses: _text!, $searchFields: jsonb!) {
   search_positions_on_subject(
-    args: {
-      addresses: $addresses
-      search_fields: $searchFields
-    }
+    args: { addresses: $addresses, search_fields: $searchFields }
   ) {
     id
     shares
@@ -827,6 +842,7 @@ query SearchPositions(
 ```
 
 **Variables**:
+
 ```json
 {
   "addresses": "{0xabc..., 0xdef...}",
@@ -870,16 +886,9 @@ The API includes pre-computed time-series aggregations for efficient analytics.
 Daily price trends:
 
 ```graphql
-query GetDailyPriceTrends(
-  $termId: String!
-  $curveId: numeric!
-  $limit: Int!
-) {
+query GetDailyPriceTrends($termId: String!, $curveId: numeric!, $limit: Int!) {
   share_price_change_stats_daily(
-    where: {
-      term_id: { _eq: $termId }
-      curve_id: { _eq: $curveId }
-    }
+    where: { term_id: { _eq: $termId }, curve_id: { _eq: $curveId } }
     order_by: { bucket: desc }
     limit: $limit
   ) {
@@ -893,6 +902,7 @@ query GetDailyPriceTrends(
 ```
 
 **Variables**:
+
 ```json
 {
   "termId": "0x...",
@@ -902,6 +912,7 @@ query GetDailyPriceTrends(
 ```
 
 For different time granularities, use:
+
 - `share_price_change_stats_hourly` - Hourly aggregations
 - `share_price_change_stats_weekly` - Weekly aggregations
 - `share_price_change_stats_monthly` - Monthly aggregations
@@ -912,10 +923,7 @@ Query aggregated signal data over time:
 
 ```graphql
 query GetSignalStats($limit: Int!) {
-  signal_stats_daily(
-    order_by: { bucket: desc }
-    limit: $limit
-  ) {
+  signal_stats_daily(order_by: { bucket: desc }, limit: $limit) {
     bucket
     deposit_count
     redemption_count
@@ -931,10 +939,7 @@ query GetSignalStats($limit: Int!) {
 Query pre-aggregated collections grouped by (predicate, object):
 
 ```graphql
-query GetPopularCollections(
-  $predicateId: String!
-  $limit: Int!
-) {
+query GetPopularCollections($predicateId: String!, $limit: Int!) {
   predicate_objects(
     where: { predicate_id: { _eq: $predicateId } }
     order_by: { triple_count: desc }
@@ -955,6 +960,7 @@ query GetPopularCollections(
 ```
 
 **Variables**:
+
 ```json
 {
   "predicateId": "0x...",
@@ -970,27 +976,46 @@ Beyond count and sum, the API supports advanced statistical aggregations:
 
 ```graphql
 query GetPositionStatistics($accountId: String!) {
-  positions_aggregate(
-    where: { account_id: { _eq: $accountId } }
-  ) {
+  positions_aggregate(where: { account_id: { _eq: $accountId } }) {
     aggregate {
       count
-      sum { shares }
-      avg { shares }
-      min { shares }
-      max { shares }
-      stddev { shares }
-      stddev_pop { shares }
-      stddev_samp { shares }
-      variance { shares }
-      var_pop { shares }
-      var_samp { shares }
+      sum {
+        shares
+      }
+      avg {
+        shares
+      }
+      min {
+        shares
+      }
+      max {
+        shares
+      }
+      stddev {
+        shares
+      }
+      stddev_pop {
+        shares
+      }
+      stddev_samp {
+        shares
+      }
+      variance {
+        shares
+      }
+      var_pop {
+        shares
+      }
+      var_samp {
+        shares
+      }
     }
   }
 }
 ```
 
 **Use cases**:
+
 - `stddev` - Identify outliers in share distributions
 - `variance` - Measure position concentration
 - `avg` - Calculate average position size
@@ -1005,6 +1030,8 @@ The GraphQL API provides mutations for uploading and pinning content to IPFS. No
 
 #### Pin Thing
 
+> **⚠️ DEPRECATED**: This mutation is deprecated. Use `uploadJsonToPinata` from `@0xintuition/sdk` instead for direct Pinata uploads. The SDK now supports client-side IPFS pinning without requiring backend mediation. See the SDK documentation for updated implementations in `createAtomFromThing` and `batchCreateAtomsFromThings`.
+
 Pin a "Thing" object (general entity) to IPFS:
 
 ```graphql
@@ -1018,6 +1045,7 @@ mutation PinThing($thing: PinThingInput!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "thing": {
@@ -1030,6 +1058,7 @@ mutation PinThing($thing: PinThingInput!) {
 ```
 
 **Response**:
+
 ```json
 {
   "data": {
@@ -1057,6 +1086,7 @@ mutation PinPerson($person: PinPersonInput!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "person": {
@@ -1085,6 +1115,7 @@ mutation PinOrganization($organization: PinOrganizationInput!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "organization": {
@@ -1112,6 +1143,7 @@ mutation UploadJson($json: jsonb!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "json": {
@@ -1141,6 +1173,7 @@ mutation UploadImage($image: UploadImageInput!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "image": {
@@ -1152,6 +1185,7 @@ mutation UploadImage($image: UploadImageInput!) {
 ```
 
 **Response**:
+
 ```json
 {
   "data": {
@@ -1179,6 +1213,7 @@ mutation UploadImageFromUrl($image: UploadImageFromUrlInput!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "image": {
@@ -1211,10 +1246,7 @@ subscription WatchAtoms(
   $cursor: [atoms_stream_cursor_input]!
   $batchSize: Int!
 ) {
-  atoms_stream(
-    cursor: $cursor
-    batch_size: $batchSize
-  ) {
+  atoms_stream(cursor: $cursor, batch_size: $batchSize) {
     term_id
     label
     image
@@ -1224,12 +1256,15 @@ subscription WatchAtoms(
 ```
 
 **Variables**:
+
 ```json
 {
-  "cursor": [{
-    "initial_value": { "created_at": "2024-01-01T00:00:00Z" },
-    "ordering": "ASC"
-  }],
+  "cursor": [
+    {
+      "initial_value": { "created_at": "2024-01-01T00:00:00Z" },
+      "ordering": "ASC"
+    }
+  ],
   "batchSize": 10
 }
 ```
@@ -1247,9 +1282,7 @@ Subscriptions use cursors to enable resumable streams:
 #### Resumable Stream Example
 
 ```graphql
-subscription WatchPositions(
-  $cursor: [positions_stream_cursor_input]!
-) {
+subscription WatchPositions($cursor: [positions_stream_cursor_input]!) {
   positions_stream(
     cursor: $cursor
     batch_size: 20
@@ -1270,12 +1303,15 @@ subscription WatchPositions(
 ```
 
 **Variables**:
+
 ```json
 {
-  "cursor": [{
-    "initial_value": { "created_at": "2024-12-01T00:00:00Z" },
-    "ordering": "DESC"
-  }]
+  "cursor": [
+    {
+      "initial_value": { "created_at": "2024-12-01T00:00:00Z" },
+      "ordering": "DESC"
+    }
+  ]
 }
 ```
 
@@ -1287,15 +1323,18 @@ To resume from where you left off, update `initial_value` to the last received i
 
 ```graphql
 subscription WatchNewTriples($cursor: [triples_stream_cursor_input]!) {
-  triples_stream(
-    cursor: $cursor
-    batch_size: 5
-  ) {
+  triples_stream(cursor: $cursor, batch_size: 5) {
     term_id
     created_at
-    subject { label }
-    predicate { label }
-    object { label }
+    subject {
+      label
+    }
+    predicate {
+      label
+    }
+    object {
+      label
+    }
   }
 }
 ```
@@ -1352,12 +1391,14 @@ subscription WatchSignals(
 ### Subscription Best Practices
 
 **Use subscriptions when:**
+
 - Building real-time dashboards
 - Monitoring live protocol activity
 - Tracking position changes
 - Creating notification systems
 
 **Use polling when:**
+
 - Data updates infrequently
 - Real-time updates aren't critical
 - Minimizing server connections is important
@@ -1415,7 +1456,7 @@ query GetAtoms {
 ```graphql
 query CountPositions($accountId: String!) {
   positions(where: { account_id: { _eq: $accountId } }) {
-    id  # Fetching all data just to count
+    id # Fetching all data just to count
   }
 }
 ```
@@ -1437,11 +1478,7 @@ query CountPositions($accountId: String!) {
 ✅ **Efficient pattern**: Get both count and paginated data in one query
 
 ```graphql
-query GetPositionsWithCount(
-  $accountId: String!
-  $limit: Int!
-  $offset: Int!
-) {
+query GetPositionsWithCount($accountId: String!, $limit: Int!, $offset: Int!) {
   total: positions_aggregate(where: { account_id: { _eq: $accountId } }) {
     aggregate {
       count
@@ -1476,19 +1513,28 @@ query GetTriple($id: String!) {
       term_id
       label
       image
-      creator { id label }
+      creator {
+        id
+        label
+      }
     }
     predicate {
       term_id
       label
       image
-      creator { id label }
+      creator {
+        id
+        label
+      }
     }
     object {
       term_id
       label
       image
-      creator { id label }
+      creator {
+        id
+        label
+      }
     }
   }
 }
@@ -1509,9 +1555,15 @@ fragment AtomBasics on atoms {
 
 query GetTriple($id: String!) {
   triple(term_id: $id) {
-    subject { ...AtomBasics }
-    predicate { ...AtomBasics }
-    object { ...AtomBasics }
+    subject {
+      ...AtomBasics
+    }
+    predicate {
+      ...AtomBasics
+    }
+    object {
+      ...AtomBasics
+    }
   }
 }
 ```
@@ -1547,10 +1599,7 @@ query GetAtomsByType($type: atom_type!) {
 ```graphql
 query GetRecentPersonAtoms($since: timestamptz!) {
   atoms(
-    where: {
-      type: { _eq: Person }
-      created_at: { _gte: $since }
-    }
+    where: { type: { _eq: Person }, created_at: { _gte: $since } }
     limit: 100
   ) {
     term_id
@@ -1589,11 +1638,7 @@ Always use `limit` and `offset` for queries that could return many results:
 
 ```graphql
 query GetAllAtoms($limit: Int!, $offset: Int!) {
-  atoms(
-    limit: $limit
-    offset: $offset
-    order_by: { created_at: desc }
-  ) {
+  atoms(limit: $limit, offset: $offset, order_by: { created_at: desc }) {
     term_id
     label
   }
@@ -1625,10 +1670,7 @@ query GetPriceHistory($termId: String!) {
 ```graphql
 query GetDailyPriceStats($termId: String!, $curveId: numeric!) {
   share_price_change_stats_daily(
-    where: {
-      term_id: { _eq: $termId }
-      curve_id: { _eq: $curveId }
-    }
+    where: { term_id: { _eq: $termId }, curve_id: { _eq: $curveId } }
     order_by: { bucket: desc }
     limit: 30
   ) {
@@ -1642,11 +1684,13 @@ query GetDailyPriceStats($termId: String!, $curveId: numeric!) {
 ```
 
 **When to use pre-computed tables**:
+
 - Building charts/graphs for analytics dashboards
 - Computing trends over time
 - Displaying aggregate metrics by time period
 
 **Available time-series tables**:
+
 - `share_price_change_stats_daily`, `_hourly`, `_weekly`, `_monthly`
 - `signal_stats_daily`, `_hourly`, `_monthly`
 
@@ -1690,6 +1734,7 @@ query GetFollowingEfficiently($address: String!) {
 ```
 
 **Available database functions**:
+
 - `following` - Get accounts a user follows
 - `positions_from_following` - Social feed of positions
 - `search_positions_on_subject` - Complex position filtering
@@ -1698,6 +1743,7 @@ query GetFollowingEfficiently($address: String!) {
 - `signals_from_following` - Activity from followed accounts
 
 **Benefits**:
+
 - Faster query execution (runs in database, not client)
 - Less data transferred over network
 - More maintainable code
@@ -1707,6 +1753,7 @@ query GetFollowingEfficiently($address: String!) {
 Use subscriptions for real-time features, polling for everything else:
 
 ✅ **Use subscriptions when:**
+
 - Building real-time dashboards
 - Monitoring live protocol activity (e.g., new positions, price changes)
 - Creating notification systems
@@ -1714,23 +1761,28 @@ Use subscriptions for real-time features, polling for everything else:
 - Data changes frequently (multiple times per minute)
 
 **Example subscription use cases**:
+
 ```graphql
 subscription WatchMyPositions($cursor: [positions_stream_cursor_input]!) {
   positions_stream(cursor: $cursor, batch_size: 10) {
     id
     shares
-    vault { current_share_price }
+    vault {
+      current_share_price
+    }
   }
 }
 ```
 
 ✅ **Use polling when:**
+
 - Data updates infrequently (e.g., daily statistics)
 - Real-time updates aren't critical for UX
 - Minimizing server connections is important
 - Building static reports or analytics
 
 **Example polling pattern**:
+
 ```graphql
 query GetStats {
   stats {
@@ -1743,6 +1795,7 @@ query GetStats {
 ```
 
 **Subscription cursor management**:
+
 - Always provide `initial_value` to start from a specific point
 - Use `batch_size` to control data flow (typically 10-50)
 - Store last received cursor to resume after disconnection
@@ -1782,6 +1835,7 @@ query GetAtomWithVault($atomId: String!, $curveId: numeric!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "atomId": "0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21",
@@ -1790,6 +1844,7 @@ query GetAtomWithVault($atomId: String!, $curveId: numeric!) {
 ```
 
 **Best Practices Used**:
+
 - Uses variables for dynamic values
 - Requests only needed fields
 - Filters vault by curve_id using a variable
@@ -1801,11 +1856,7 @@ query GetAtomWithVault($atomId: String!, $curveId: numeric!) {
 Get a paginated list of triples with total count.
 
 ```graphql
-query GetTriplesPage(
-  $limit: Int!
-  $offset: Int!
-  $where: triples_bool_exp
-) {
+query GetTriplesPage($limit: Int!, $offset: Int!, $where: triples_bool_exp) {
   total: triples_aggregate(where: $where) {
     aggregate {
       count
@@ -1838,6 +1889,7 @@ query GetTriplesPage(
 ```
 
 **Variables**:
+
 ```json
 {
   "limit": 20,
@@ -1851,6 +1903,7 @@ query GetTriplesPage(
 ```
 
 **Best Practices Used**:
+
 - Combines aggregate count with paginated nodes
 - Uses variables for all dynamic values
 - Includes ordering for consistent pagination
@@ -1893,9 +1946,15 @@ query GetUserPositions($accountId: String!, $limit: Int!, $offset: Int!) {
         }
         triple {
           term_id
-          subject { label }
-          predicate { label }
-          object { label }
+          subject {
+            label
+          }
+          predicate {
+            label
+          }
+          object {
+            label
+          }
         }
       }
     }
@@ -1904,6 +1963,7 @@ query GetUserPositions($accountId: String!, $limit: Int!, $offset: Int!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "accountId": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
@@ -1913,6 +1973,7 @@ query GetUserPositions($accountId: String!, $limit: Int!, $offset: Int!) {
 ```
 
 **Best Practices Used**:
+
 - Gets aggregate stats alongside paginated results
 - Uses relationship traversal to get atom/triple details
 - Aliases aggregate query as `stats` for clarity
@@ -1961,14 +2022,21 @@ query GlobalSearch($searchTerm: String!) {
     limit: 10
   ) {
     term_id
-    subject { label }
-    predicate { label }
-    object { label }
+    subject {
+      label
+    }
+    predicate {
+      label
+    }
+    object {
+      label
+    }
   }
 }
 ```
 
 **Variables**:
+
 ```json
 {
   "searchTerm": "%ethereum%"
@@ -1976,6 +2044,7 @@ query GlobalSearch($searchTerm: String!) {
 ```
 
 **Best Practices Used**:
+
 - Uses `_or` conditions for multi-field search
 - Limits results per type to avoid over-fetching
 - Uses `_ilike` appropriately for pattern matching
@@ -2008,10 +2077,7 @@ query GetVaultStats($termId: String!, $curveId: numeric!) {
       }
     }
 
-    top_positions: positions(
-      limit: 5
-      order_by: { shares: desc }
-    ) {
+    top_positions: positions(limit: 5, order_by: { shares: desc }) {
       account {
         id
         label
@@ -2023,6 +2089,7 @@ query GetVaultStats($termId: String!, $curveId: numeric!) {
 ```
 
 **Variables**:
+
 ```json
 {
   "termId": "0x...",
@@ -2031,6 +2098,7 @@ query GetVaultStats($termId: String!, $curveId: numeric!) {
 ```
 
 **Best Practices Used**:
+
 - Uses aggregates for statistics (count, sum, avg)
 - Limits top positions query
 - Uses aliases for clarity (`top_positions`)
@@ -2046,11 +2114,7 @@ The following examples demonstrate more complex use cases and advanced API featu
 Build a social feed showing positions from accounts a user follows.
 
 ```graphql
-query GetFollowingFeed(
-  $address: String!
-  $limit: Int!
-  $offset: Int!
-) {
+query GetFollowingFeed($address: String!, $limit: Int!, $offset: Int!) {
   # Get total follower count
   following_count: following_aggregate(args: { address: $address }) {
     aggregate {
@@ -2087,9 +2151,17 @@ query GetFollowingFeed(
         }
         triple {
           term_id
-          subject { label image }
-          predicate { label }
-          object { label image }
+          subject {
+            label
+            image
+          }
+          predicate {
+            label
+          }
+          object {
+            label
+            image
+          }
         }
       }
     }
@@ -2115,15 +2187,22 @@ query GetFollowingFeed(
     }
     triple {
       term_id
-      subject { label }
-      predicate { label }
-      object { label }
+      subject {
+        label
+      }
+      predicate {
+        label
+      }
+      object {
+        label
+      }
     }
   }
 }
 ```
 
 **Variables**:
+
 ```json
 {
   "address": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
@@ -2135,6 +2214,7 @@ query GetFollowingFeed(
 **Use Case**: Build a social activity feed showing what the accounts you follow are investing in, similar to Twitter/X feed but for protocol positions.
 
 **Best Practices Used**:
+
 - Uses database functions (`positions_from_following`, `signals_from_following`) instead of manual filtering
 - Combines multiple related queries in one request
 - Includes aggregate count for pagination UI
@@ -2147,17 +2227,10 @@ query GetFollowingFeed(
 Analyze price trends over time using pre-computed aggregations.
 
 ```graphql
-query GetPriceTrendAnalysis(
-  $termId: String!
-  $curveId: numeric!
-  $days: Int!
-) {
+query GetPriceTrendAnalysis($termId: String!, $curveId: numeric!, $days: Int!) {
   # Get daily price changes for the last N days
   daily_trends: share_price_change_stats_daily(
-    where: {
-      term_id: { _eq: $termId }
-      curve_id: { _eq: $curveId }
-    }
+    where: { term_id: { _eq: $termId }, curve_id: { _eq: $curveId } }
     order_by: { bucket: desc }
     limit: $days
   ) {
@@ -2170,10 +2243,7 @@ query GetPriceTrendAnalysis(
 
   # Get hourly data for the last 24 hours for granular view
   hourly_trends: share_price_change_stats_hourly(
-    where: {
-      term_id: { _eq: $termId }
-      curve_id: { _eq: $curveId }
-    }
+    where: { term_id: { _eq: $termId }, curve_id: { _eq: $curveId } }
     order_by: { bucket: desc }
     limit: 24
   ) {
@@ -2195,10 +2265,7 @@ query GetPriceTrendAnalysis(
 
   # Get overall signal stats for context
   signal_trends: signal_stats_daily(
-    where: {
-      term_id: { _eq: $termId }
-      curve_id: { _eq: $curveId }
-    }
+    where: { term_id: { _eq: $termId }, curve_id: { _eq: $curveId } }
     order_by: { bucket: desc }
     limit: $days
   ) {
@@ -2211,6 +2278,7 @@ query GetPriceTrendAnalysis(
 ```
 
 **Variables**:
+
 ```json
 {
   "termId": "0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21",
@@ -2222,12 +2290,14 @@ query GetPriceTrendAnalysis(
 **Use Case**: Build analytics dashboards showing price trends, trading volume, and market activity over different time periods.
 
 **Best Practices Used**:
+
 - Leverages pre-computed time-series tables for performance
 - Combines multiple time granularities (daily, hourly) in one query
 - Includes current state for comparison
 - Uses variables for all dynamic values
 
 **Analysis Notes**:
+
 - Calculate percentage change: `(last_share_price - first_share_price) / first_share_price * 100`
 - `change_count` shows number of price changes in that time bucket
 - Weekly and monthly aggregations available via `share_price_change_stats_weekly` and `share_price_change_stats_monthly`
@@ -2246,10 +2316,7 @@ query AdvancedPositionSearch(
 ) {
   # Search positions with custom criteria
   results: search_positions_on_subject(
-    args: {
-      addresses: $addresses
-      search_fields: $searchFields
-    }
+    args: { addresses: $addresses, search_fields: $searchFields }
     limit: $limit
   ) {
     id
@@ -2296,10 +2363,7 @@ query AdvancedPositionSearch(
 
   # Get count for pagination
   results_aggregate: search_positions_on_subject_aggregate(
-    args: {
-      addresses: $addresses
-      search_fields: $searchFields
-    }
+    args: { addresses: $addresses, search_fields: $searchFields }
   ) {
     aggregate {
       count
@@ -2312,6 +2376,7 @@ query AdvancedPositionSearch(
 ```
 
 **Variables**:
+
 ```json
 {
   "addresses": "{0xd8da6bf26964af9d7eed9e03e53415d37aa96045,0xabc123...}",
@@ -2325,6 +2390,7 @@ query AdvancedPositionSearch(
 ```
 
 **Use Case**: Build advanced search UIs where users can filter positions by:
+
 - Multiple wallet addresses
 - Minimum share amounts
 - Term type (atom vs triple)
@@ -2332,6 +2398,7 @@ query AdvancedPositionSearch(
 - Other custom criteria in `search_fields`
 
 **Best Practices Used**:
+
 - Uses backend function for complex filtering (more efficient than client-side)
 - Includes aggregate variant for totals
 - Handles both atom and triple results
@@ -2353,10 +2420,7 @@ subscription LivePositionMonitor(
   positions_stream(
     cursor: $cursor
     batch_size: $batchSize
-    where: {
-      account_id: { _eq: $accountId }
-      shares: { _gt: "0" }
-    }
+    where: { account_id: { _eq: $accountId }, shares: { _gt: "0" } }
   ) {
     id
     shares
@@ -2377,9 +2441,15 @@ subscription LivePositionMonitor(
         }
         triple {
           term_id
-          subject { label }
-          predicate { label }
-          object { label }
+          subject {
+            label
+          }
+          predicate {
+            label
+          }
+          object {
+            label
+          }
         }
       }
     }
@@ -2388,41 +2458,50 @@ subscription LivePositionMonitor(
 ```
 
 **Variables (Initial)**:
+
 ```json
 {
-  "cursor": [{
-    "initial_value": { "created_at": "2024-12-01T00:00:00Z" },
-    "ordering": "ASC"
-  }],
+  "cursor": [
+    {
+      "initial_value": { "created_at": "2024-12-01T00:00:00Z" },
+      "ordering": "ASC"
+    }
+  ],
   "accountId": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
   "batchSize": 10
 }
 ```
 
 **Variables (Resuming)**:
+
 ```json
 {
-  "cursor": [{
-    "initial_value": { "created_at": "2024-12-12T15:30:00Z" },
-    "ordering": "ASC"
-  }],
+  "cursor": [
+    {
+      "initial_value": { "created_at": "2024-12-12T15:30:00Z" },
+      "ordering": "ASC"
+    }
+  ],
   "accountId": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
   "batchSize": 10
 }
 ```
 
 **Use Case**: Create real-time dashboards that update automatically when:
+
 - New positions are created
 - Existing positions change
 - User performs deposits or redemptions
 
 **Implementation Pattern**:
+
 1. Start subscription with initial cursor (e.g., last hour)
 2. Process incoming batches of updates
 3. Update UI state with new data
 4. If connection drops, resume from last received `created_at`
 
 **Best Practices Used**:
+
 - Filters for active positions (`shares > 0`)
 - Uses batch_size to control data flow
 - Cursor enables resumable streams after disconnection
@@ -2473,6 +2552,7 @@ query GetCreatedAtom($termId: String!, $curveId: numeric!) {
 ```
 
 **Step 1 Variables**:
+
 ```json
 {
   "person": {
@@ -2486,6 +2566,7 @@ query GetCreatedAtom($termId: String!, $curveId: numeric!) {
 ```
 
 **Step 1 Response**:
+
 ```json
 {
   "data": {
@@ -2499,6 +2580,7 @@ query GetCreatedAtom($termId: String!, $curveId: numeric!) {
 ```
 
 **Step 2 Variables** (after blockchain transaction):
+
 ```json
 {
   "termId": "0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21",
@@ -2518,12 +2600,14 @@ query GetCreatedAtom($termId: String!, $curveId: numeric!) {
 8. **Cache metadata** - Store IPFS hash for future reference
 
 **Error Handling Considerations**:
+
 - Mutation may fail if image classification fails (inappropriate content)
 - IPFS pinning may timeout - implement retry logic
 - Blockchain transaction may fail - check gas and approval
 - Atom may not appear immediately - poll or subscribe for updates
 
 **Best Practices Used**:
+
 - Separates IPFS operations from blockchain operations
 - Uses appropriate mutation for entity type
 - Queries include vault data for immediate display
@@ -2583,7 +2667,8 @@ Each tool has specific configuration requirements - refer to their official docu
 # BAD
 fragment VaultDetails on atoms {
   term {
-    vaults(where: { curve_id: { _eq: "1" } }) {  # ❌ Hardcoded!
+    vaults(where: { curve_id: { _eq: "1" } }) {
+      # ❌ Hardcoded!
       total_shares
     }
   }
@@ -2596,7 +2681,8 @@ fragment VaultDetails on atoms {
 # GOOD
 fragment VaultDetails on atoms {
   term {
-    vaults(where: { curve_id: { _eq: $curveId } }) {  # ✅ Variable
+    vaults(where: { curve_id: { _eq: $curveId } }) {
+      # ✅ Variable
       total_shares
     }
   }
@@ -2618,7 +2704,8 @@ query GetAtom($id: String!, $curveId: numeric!) {
 ```graphql
 # BAD
 query GetPositionCount($where: positions_bool_exp) {
-  positions(where: $where) {  # ❌ Fetches all data
+  positions(where: $where) {
+    # ❌ Fetches all data
     id
     shares
     account_id
@@ -2632,7 +2719,8 @@ query GetPositionCount($where: positions_bool_exp) {
 ```graphql
 # GOOD
 query GetPositionCount($where: positions_bool_exp) {
-  positions_aggregate(where: $where) {  # ✅ Only returns count
+  positions_aggregate(where: $where) {
+    # ✅ Only returns count
     aggregate {
       count
       sum {
@@ -2656,10 +2744,12 @@ query GetAtom($id: String!) {
     label
     creator {
       id
-      atoms {  # ❌ Fetching all creator's atoms when not needed
+      atoms {
+        # ❌ Fetching all creator's atoms when not needed
         term_id
         label
-        as_subject_triples {  # ❌ Even deeper unnecessary nesting
+        as_subject_triples {
+          # ❌ Even deeper unnecessary nesting
           term_id
         }
       }
@@ -2692,7 +2782,8 @@ query GetAtom($id: String!) {
 ```graphql
 # BAD
 query {
-  atoms(where: { type: { _eq: Person } }) {  # ❌ Hardcoded
+  atoms(where: { type: { _eq: Person } }) {
+    # ❌ Hardcoded
     term_id
     label
   }
@@ -2704,7 +2795,8 @@ query {
 ```graphql
 # GOOD
 query GetAtomsByType($type: atom_type!) {
-  atoms(where: { type: { _eq: $type } }) {  # ✅ Variable
+  atoms(where: { type: { _eq: $type } }) {
+    # ✅ Variable
     term_id
     label
   }
@@ -2724,17 +2816,26 @@ query GetTriple($id: String!) {
     subject {
       term_id
       label
-      creator { id label }  # ❌ Duplicated
+      creator {
+        id
+        label
+      } # ❌ Duplicated
     }
     predicate {
       term_id
       label
-      creator { id label }  # ❌ Duplicated
+      creator {
+        id
+        label
+      } # ❌ Duplicated
     }
     object {
       term_id
       label
-      creator { id label }  # ❌ Duplicated
+      creator {
+        id
+        label
+      } # ❌ Duplicated
     }
   }
 }
@@ -2755,9 +2856,15 @@ fragment AtomBasics on atoms {
 
 query GetTriple($id: String!) {
   triple(term_id: $id) {
-    subject { ...AtomBasics }  # ✅ Reusable
-    predicate { ...AtomBasics }
-    object { ...AtomBasics }
+    subject {
+      ...AtomBasics
+    } # ✅ Reusable
+    predicate {
+      ...AtomBasics
+    }
+    object {
+      ...AtomBasics
+    }
   }
 }
 ```
@@ -2771,7 +2878,8 @@ query GetTriple($id: String!) {
 ```graphql
 # BAD
 query GetAccount($address: String!) {
-  accounts(where: { id: { _ilike: $address } }) {  # ❌ Inefficient
+  accounts(where: { id: { _ilike: $address } }) {
+    # ❌ Inefficient
     id
     label
   }
@@ -2783,7 +2891,8 @@ query GetAccount($address: String!) {
 ```graphql
 # GOOD
 query GetAccount($address: String!) {
-  account(id: $address) {  # ✅ Primary key lookup
+  account(id: $address) {
+    # ✅ Primary key lookup
     id
     label
   }
@@ -2791,7 +2900,8 @@ query GetAccount($address: String!) {
 
 # Or with _eq
 query GetAccounts($address: String!) {
-  accounts(where: { id: { _eq: $address } }) {  # ✅ Exact match
+  accounts(where: { id: { _eq: $address } }) {
+    # ✅ Exact match
     id
     label
   }
@@ -2805,6 +2915,7 @@ query GetAccounts($address: String!) {
 **Problem**: Re-writing common field selections instead of using existing fragments.
 
 This package includes pre-built fragments in `src/fragments/`:
+
 - `atom.graphql` - Atom metadata, values, transactions, vault details
 - `triple.graphql` - Triple metadata, vault details
 - `position.graphql` - Position details and aggregates

--- a/packages/graphql/src/mutations/pin-thing.graphql
+++ b/packages/graphql/src/mutations/pin-thing.graphql
@@ -1,3 +1,6 @@
+# @deprecated This mutation is deprecated. Use uploadJsonToPinata from @0xintuition/sdk instead.
+# The SDK now supports direct Pinata uploads without requiring backend mediation.
+# See: packages/sdk/src/external/upload-json-to-pinata.ts
 mutation pinThing(
   $name: String!
   $description: String

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @0xintuition/sdk
 
+## Unreleased
+
+### Breaking Changes
+
+- **BREAKING:** `createAtomFromThing` now requires `pinataApiJWT` in the config parameter. The function signature has changed from `config: WriteConfig` to `config: CreateAtomConfigWithIpfs` (which extends `WriteConfig` with `pinataApiJWT: string`).
+- **BREAKING:** `batchCreateAtomsFromThings` now requires `pinataApiJWT` in the config parameter. The function signature has changed from `config: WriteConfig` to `config: CreateAtomConfigWithIpfs`.
+
+### Deprecations
+
+- **DEPRECATED:** The `pinThing` function is now deprecated. Use `uploadJsonToPinata` for direct Pinata uploads instead. The SDK now supports client-side IPFS pinning without requiring backend mediation.
+
+### Improvements
+
+- Both `createAtomFromThing` and `batchCreateAtomsFromThings` now use direct Pinata uploads via `uploadJsonToPinata` instead of the backend-mediated GraphQL API, providing better performance and reliability.
+- Updated documentation and examples to reflect the new Pinata JWT requirement.
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -48,6 +48,7 @@ bun install @0xintuition/sdk viem
 **Peer Dependencies:** `viem ^2.0.0`
 
 **Optional Dependencies:**
+
 - Pinata API JWT token for IPFS pinning (required for `createAtomFromIpfsUpload`)
 
 ---
@@ -56,12 +57,13 @@ bun install @0xintuition/sdk viem
 
 ```typescript
 import {
-  intuitionTestnet,
-  getMultiVaultAddressFromChainId,
   createAtomFromString,
   createTripleStatement,
   getAtomDetails,
+  getMultiVaultAddressFromChainId,
+  intuitionTestnet,
 } from '@0xintuition/sdk'
+
 import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
@@ -83,7 +85,7 @@ const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
 const atom = await createAtomFromString(
   { walletClient, publicClient, address },
   'Hello, Intuition!',
-  parseEther('0.01') // optional deposit
+  parseEther('0.01'), // optional deposit
 )
 
 console.log('Atom ID:', atom.state.termId)
@@ -98,6 +100,7 @@ console.log('Atom details:', details)
 ## Core Concepts
 
 ### Atoms
+
 **Atoms** are the fundamental entities in the Intuition knowledge graph. The SDK supports creating atoms from multiple sources:
 
 - **String**: Plain text data (e.g., `"developer"`)
@@ -107,7 +110,9 @@ console.log('Atom details:', details)
 - **Thing**: Structured JSON-LD objects pinned to IPFS
 
 ### Triples
+
 **Triples** (statements) connect atoms in subject-predicate-object relationships:
+
 - **Subject**: The atom being described
 - **Predicate**: The relationship type
 - **Object**: The target atom or value
@@ -115,9 +120,11 @@ console.log('Atom details:', details)
 Example: `(Alice, follows, Bob)` or `(Repository, hasLanguage, TypeScript)`
 
 ### Vaults & Shares
+
 Each atom and triple has an associated **vault** for deposits. Users deposit assets to receive shares, with prices determined by bonding curves.
 
 ### Thing Objects
+
 **Things** are rich, structured entities based on JSON-LD schema.org format:
 
 ```typescript
@@ -142,9 +149,10 @@ The SDK uses Viem clients for blockchain interactions:
 
 ```typescript
 import type { WriteConfig } from '@0xintuition/sdk'
+import { intuitionTestnet } from '@0xintuition/sdk'
+
 import { createPublicClient, createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { intuitionTestnet } from '@0xintuition/sdk'
 
 // For read-only operations
 const publicClient = createPublicClient({
@@ -201,7 +209,7 @@ const atom = await createAtomFromIpfsUpload(
   {
     name: 'Example',
     description: 'An example thing',
-  }
+  },
 )
 ```
 
@@ -214,16 +222,18 @@ const atom = await createAtomFromIpfsUpload(
 #### Single Atom Creation
 
 ##### `createAtomFromString`
+
 Create an atom from a plain text string.
 
 ```typescript
 import { createAtomFromString } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 const atom = await createAtomFromString(
   { walletClient, publicClient, address },
   'developer',
-  parseEther('0.01') // optional initial deposit
+  parseEther('0.01'), // optional initial deposit
 )
 
 // Returns:
@@ -240,13 +250,19 @@ const atom = await createAtomFromString(
 ```
 
 ##### `createAtomFromThing`
-Create an atom from a Thing object (automatically pins to IPFS).
+
+Create an atom from a Thing object (automatically pins to IPFS via Pinata).
 
 ```typescript
 import { createAtomFromThing } from '@0xintuition/sdk'
 
 const atom = await createAtomFromThing(
-  { walletClient, publicClient, address },
+  {
+    walletClient,
+    publicClient,
+    address,
+    pinataApiJWT: process.env.PINATA_API_JWT, // Pinata JWT token required
+  },
   {
     url: 'https://www.example.com',
     name: 'Example',
@@ -254,11 +270,12 @@ const atom = await createAtomFromThing(
     image: 'https://example.com/logo.png',
     tags: ['web3', 'defi'],
   },
-  parseEther('0.05')
+  parseEther('0.05'), // Optional deposit amount
 )
 ```
 
 ##### `createAtomFromEthereumAccount`
+
 Create an atom from an Ethereum address.
 
 ```typescript
@@ -266,7 +283,7 @@ import { createAtomFromEthereumAccount } from '@0xintuition/sdk'
 
 const atom = await createAtomFromEthereumAccount(
   { walletClient, publicClient, address },
-  '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+  '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
 )
 
 // The function accepts a simple Ethereum address string
@@ -279,6 +296,7 @@ const atom = await createAtomFromEthereumAccount(
 ```
 
 ##### `createAtomFromSmartContract`
+
 Create an atom from a smart contract address.
 
 ```typescript
@@ -286,7 +304,7 @@ import { createAtomFromSmartContract } from '@0xintuition/sdk'
 
 const atom = await createAtomFromSmartContract(
   { walletClient, publicClient, address },
-  '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'
+  '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
 )
 
 // The function accepts a simple Ethereum address string
@@ -294,6 +312,7 @@ const atom = await createAtomFromSmartContract(
 ```
 
 ##### `createAtomFromIpfsUri`
+
 Create an atom from an existing IPFS URI.
 
 ```typescript
@@ -301,11 +320,12 @@ import { createAtomFromIpfsUri } from '@0xintuition/sdk'
 
 const atom = await createAtomFromIpfsUri(
   { walletClient, publicClient, address },
-  'ipfs://bafkreib7534cszxn2c6qwoviv43sqh244yfrxomjbealjdwntd6a7atq6u'
+  'ipfs://bafkreib7534cszxn2c6qwoviv43sqh244yfrxomjbealjdwntd6a7atq6u',
 )
 ```
 
 ##### `createAtomFromIpfsUpload`
+
 Upload JSON to Pinata and create an atom.
 
 ```typescript
@@ -322,17 +342,19 @@ const atom = await createAtomFromIpfsUpload(
     name: 'My Project',
     description: 'A blockchain project',
     url: 'https://myproject.com',
-  }
+  },
 )
 ```
 
 #### Batch Atom Creation
 
 ##### `batchCreateAtomsFromEthereumAccounts`
+
 Create multiple atoms from Ethereum addresses in one transaction.
 
 ```typescript
 import { batchCreateAtomsFromEthereumAccounts } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 const result = await batchCreateAtomsFromEthereumAccounts(
@@ -342,7 +364,7 @@ const result = await batchCreateAtomsFromEthereumAccounts(
     '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb',
     '0x1234567890123456789012345678901234567890',
   ],
-  parseEther('0.01') // deposit per atom (optional)
+  parseEther('0.01'), // deposit per atom (optional)
 )
 
 // Returns:
@@ -354,6 +376,7 @@ const result = await batchCreateAtomsFromEthereumAccounts(
 ```
 
 ##### `batchCreateAtomsFromIpfsUris`
+
 Create multiple atoms from IPFS URIs.
 
 ```typescript
@@ -361,15 +384,12 @@ import { batchCreateAtomsFromIpfsUris } from '@0xintuition/sdk'
 
 const result = await batchCreateAtomsFromIpfsUris(
   { walletClient, publicClient, address },
-  [
-    'ipfs://bafkreib1...',
-    'ipfs://bafkreib2...',
-    'ipfs://bafkreib3...',
-  ]
+  ['ipfs://bafkreib1...', 'ipfs://bafkreib2...', 'ipfs://bafkreib3...'],
 )
 ```
 
 ##### `batchCreateAtomsFromSmartContracts`
+
 Create multiple atoms from smart contract addresses.
 
 ```typescript
@@ -381,35 +401,43 @@ const result = await batchCreateAtomsFromSmartContracts(
     '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // Uniswap
     '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9', // Aave
     '0xc00e94Cb662C3520282E6f5717214004A7f26888', // Compound
-  ]
+  ],
 )
 ```
 
 ##### `batchCreateAtomsFromThings`
-Create multiple atoms from Thing objects (with IPFS pinning).
+
+Create multiple atoms from Thing objects (with IPFS pinning via Pinata).
 
 ```typescript
 import { batchCreateAtomsFromThings } from '@0xintuition/sdk'
 
 const result = await batchCreateAtomsFromThings(
-  { walletClient, publicClient, address },
+  {
+    walletClient,
+    publicClient,
+    address,
+    pinataApiJWT: process.env.PINATA_API_JWT, // Pinata JWT token required
+  },
   [
     { name: 'Project A', url: 'https://a.com', description: '...' },
     { name: 'Project B', url: 'https://b.com', description: '...' },
-  ]
+  ],
+  parseEther('0.01'), // Optional deposit amount per atom
 )
 ```
 
 #### Atom Queries
 
 ##### `getAtomDetails`
+
 Fetch atom details from the Intuition API.
 
 ```typescript
 import { getAtomDetails } from '@0xintuition/sdk'
 
 const details = await getAtomDetails(
-  '0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21'
+  '0x57d94c116a33bb460428eced262b7ae2ec6f865e7aceef6357cec3d034e8ea21',
 )
 
 // Returns full atom metadata including:
@@ -419,13 +447,14 @@ const details = await getAtomDetails(
 ```
 
 ##### `calculateAtomId`
+
 Calculate atom ID from atom data (off-chain).
 
 ```typescript
 import { calculateAtomId } from '@0xintuition/sdk'
 
 const atomId = calculateAtomId(
-  'ipfs://bafkreib7534cszxn2c6qwoviv43sqh244yfrxomjbealjdwntd6a7atq6u'
+  'ipfs://bafkreib7534cszxn2c6qwoviv43sqh244yfrxomjbealjdwntd6a7atq6u',
 )
 // Returns: keccak256 hash of the atom data
 ```
@@ -435,28 +464,30 @@ const atomId = calculateAtomId(
 ### Triple Management
 
 ##### `createTripleStatement`
+
 Create a triple (subject-predicate-object statement).
 
 ```typescript
 import { createTripleStatement } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 // Assume you have three atom IDs
-const subjectId = '0x1234...'    // Alice
-const predicateId = '0x5678...'  // follows
-const objectId = '0x9abc...'     // Bob
+const subjectId = '0x1234...' // Alice
+const predicateId = '0x5678...' // follows
+const objectId = '0x9abc...' // Bob
 
 const triple = await createTripleStatement(
   { walletClient, publicClient, address },
   {
     args: [
-      [subjectId],              // subjects (array)
-      [predicateId],            // predicates (array)
-      [objectId],               // objects (array)
-      [parseEther('0.1')],      // deposits per triple (array)
+      [subjectId], // subjects (array)
+      [predicateId], // predicates (array)
+      [objectId], // objects (array)
+      [parseEther('0.1')], // deposits per triple (array)
     ],
-    value: parseEther('0.1'),   // total value
-  }
+    value: parseEther('0.1'), // total value
+  },
 )
 
 // Returns:
@@ -478,31 +509,34 @@ const triple = await createTripleStatement(
 ```
 
 ##### `batchCreateTripleStatements`
+
 Create multiple triples in one transaction.
 
 ```typescript
 import { batchCreateTripleStatements } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 const result = await batchCreateTripleStatements(
   { walletClient, publicClient, address },
   [
-    [subject1, subject2],             // subjects
-    [predicate1, predicate2],         // predicates
-    [object1, object2],               // objects
+    [subject1, subject2], // subjects
+    [predicate1, predicate2], // predicates
+    [object1, object2], // objects
     [parseEther('0.1'), parseEther('0.1')], // deposits per triple
-  ]
+  ],
 )
 ```
 
 ##### `getTripleDetails`
+
 Fetch triple details from the Intuition API.
 
 ```typescript
 import { getTripleDetails } from '@0xintuition/sdk'
 
 const details = await getTripleDetails(
-  '0x4957d3f442acc301ad71e73f26efd6af78647f57dacf2b3a686d91fa773fe0b6'
+  '0x4957d3f442acc301ad71e73f26efd6af78647f57dacf2b3a686d91fa773fe0b6',
 )
 
 // Returns:
@@ -513,6 +547,7 @@ const details = await getTripleDetails(
 ```
 
 ##### `calculateTripleId`
+
 Calculate triple ID from atom IDs (off-chain).
 
 ```typescript
@@ -521,12 +556,13 @@ import { calculateTripleId } from '@0xintuition/sdk'
 const tripleId = calculateTripleId(
   '0x1234...', // subject ID
   '0x5678...', // predicate ID
-  '0x9abc...'  // object ID
+  '0x9abc...', // object ID
 )
 // Returns: keccak256 hash of packed atom IDs
 ```
 
 ##### `calculateCounterTripleId`
+
 Calculate the counter-triple ID (opposing position).
 
 ```typescript
@@ -544,80 +580,74 @@ const counterTripleId = calculateCounterTripleId(tripleId)
 ### Vault Operations
 
 ##### `deposit`
+
 Deposit assets into a vault to receive shares.
 
 ```typescript
 import { deposit } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
-const result = await deposit(
-  { walletClient, publicClient, address },
-  [
-    walletClient.account.address, // receiver
-    vaultId,                       // termId (atom or triple ID)
-    1n,                            // curveId (use 1 for default curve)
-    parseEther('1'),               // assets (amount to deposit)
-    0n,                            // minShares (minimum shares to receive)
-  ]
-)
+const result = await deposit({ walletClient, publicClient, address }, [
+  walletClient.account.address, // receiver
+  vaultId, // termId (atom or triple ID)
+  1n, // curveId (use 1 for default curve)
+  parseEther('1'), // assets (amount to deposit)
+  0n, // minShares (minimum shares to receive)
+])
 
 // Note: The SDK deposit function wraps multiVaultDeposit from @0xintuition/protocol
 // The transaction value is handled by the underlying multiVaultDeposit function
 ```
 
 ##### `batchDeposit`
+
 Deposit into multiple vaults in one transaction.
 
 ```typescript
 import { batchDeposit } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
-const result = await batchDeposit(
-  { walletClient, publicClient, address },
-  [
-    walletClient.account.address,                          // receiver
-    [vault1, vault2, vault3],                              // termIds
-    [1n, 1n, 1n],                                          // curveIds (default curve for each)
-    [parseEther('1'), parseEther('0.5'), parseEther('2')], // assets for each vault
-    [0n, 0n, 0n],                                          // minShares for each
-  ]
-)
+const result = await batchDeposit({ walletClient, publicClient, address }, [
+  walletClient.account.address, // receiver
+  [vault1, vault2, vault3], // termIds
+  [1n, 1n, 1n], // curveIds (default curve for each)
+  [parseEther('1'), parseEther('0.5'), parseEther('2')], // assets for each vault
+  [0n, 0n, 0n], // minShares for each
+])
 ```
 
 ##### `redeem`
+
 Redeem shares from a vault to get assets back.
 
 ```typescript
 import { redeem } from '@0xintuition/sdk'
 
-const result = await redeem(
-  { walletClient, publicClient, address },
-  [
-    walletClient.account.address, // receiver
-    vaultId,                       // termId
-    1n,                            // curveId (use 1 for default curve)
-    sharesToRedeem,                // shares amount
-    0n,                            // minAssets (minimum assets to receive)
-  ]
-)
+const result = await redeem({ walletClient, publicClient, address }, [
+  walletClient.account.address, // receiver
+  vaultId, // termId
+  1n, // curveId (use 1 for default curve)
+  sharesToRedeem, // shares amount
+  0n, // minAssets (minimum assets to receive)
+])
 ```
 
 ##### `batchRedeem`
+
 Redeem shares from multiple vaults in one transaction.
 
 ```typescript
 import { batchRedeem } from '@0xintuition/sdk'
 
-const result = await batchRedeem(
-  { walletClient, publicClient, address },
-  [
-    walletClient.account.address, // receiver
-    [vault1, vault2],              // termIds
-    [1n, 1n],                      // curveIds (default curve for each)
-    [shares1, shares2],            // shares for each vault
-    [0n, 0n],                      // minAssets for each
-  ]
-)
+const result = await batchRedeem({ walletClient, publicClient, address }, [
+  walletClient.account.address, // receiver
+  [vault1, vault2], // termIds
+  [1n, 1n], // curveIds (default curve for each)
+  [shares1, shares2], // shares for each vault
+  [0n, 0n], // minAssets for each
+])
 ```
 
 ---
@@ -625,15 +655,16 @@ const result = await batchRedeem(
 ### Search & Discovery
 
 ##### `globalSearch`
+
 Search across atoms, accounts, triples, and collections.
 
 ```typescript
 import { globalSearch } from '@0xintuition/sdk'
 
 const results = await globalSearch('ethereum', {
-  atomsLimit: 10,      // optional, default: 5
-  accountsLimit: 10,   // optional, default: 5
-  triplesLimit: 10,    // optional, default: 5
+  atomsLimit: 10, // optional, default: 5
+  accountsLimit: 10, // optional, default: 5
+  triplesLimit: 10, // optional, default: 5
   collectionsLimit: 5, // optional, default: 5
 })
 
@@ -648,6 +679,7 @@ const results = await globalSearch('ethereum', {
 ```
 
 ##### `semanticSearch`
+
 Semantic search using vector embeddings.
 
 ```typescript
@@ -661,16 +693,13 @@ const results = await semanticSearch('decentralized knowledge graph', {
 ```
 
 ##### `findAtomIds`
+
 Find atom IDs for given atom data (batched queries).
 
 ```typescript
 import { findAtomIds } from '@0xintuition/sdk'
 
-const atomsWithIds = await findAtomIds([
-  'developer',
-  'blockchain',
-  'ethereum',
-])
+const atomsWithIds = await findAtomIds(['developer', 'blockchain', 'ethereum'])
 
 // Returns:
 // [
@@ -683,18 +712,16 @@ const atomsWithIds = await findAtomIds([
 ```
 
 ##### `findTripleIds`
+
 Find triple IDs for given atom ID combinations.
 
 ```typescript
 import { findTripleIds } from '@0xintuition/sdk'
 
-const triplesWithIds = await findTripleIds(
-  walletClient.account.address,
-  [
-    ['0xsubject1', '0xpredicate1', '0xobject1'],
-    ['0xsubject2', '0xpredicate2', '0xobject2'],
-  ]
-)
+const triplesWithIds = await findTripleIds(walletClient.account.address, [
+  ['0xsubject1', '0xpredicate1', '0xobject1'],
+  ['0xsubject2', '0xpredicate2', '0xobject2'],
+])
 
 // Returns:
 // [
@@ -714,7 +741,10 @@ const triplesWithIds = await findTripleIds(
 ### External Integrations
 
 ##### `pinThing`
-Pin a Thing object to IPFS via the Intuition API.
+
+> **⚠️ DEPRECATED**: This function is deprecated. Use `uploadJsonToPinata` for direct Pinata uploads instead. The SDK now supports client-side IPFS pinning in `createAtomFromThing` and `batchCreateAtomsFromThings` without requiring backend mediation.
+
+Pin a Thing object to IPFS via the Intuition API (backend-mediated, legacy).
 
 ```typescript
 import { pinThing, type PinThingMutationVariables } from '@0xintuition/sdk'
@@ -726,26 +756,24 @@ const uri = await pinThing({
     description: 'A great project',
     image: 'https://example.com/logo.png',
     tags: ['blockchain', 'defi'],
-  }
+  },
 })
 
 // Returns: 'ipfs://bafkreib...' or null on error
 ```
 
 ##### `uploadJsonToPinata`
+
 Upload JSON data to IPFS via Pinata (used internally by `createAtomFromIpfsUpload`).
 
 ```typescript
 import { uploadJsonToPinata } from '@0xintuition/sdk'
 
-const result = await uploadJsonToPinata(
-  'your-pinata-jwt-token',
-  {
-    name: 'My Data',
-    description: 'Some JSON data',
-    // ... any JSON-serializable data
-  }
-)
+const result = await uploadJsonToPinata('your-pinata-jwt-token', {
+  name: 'My Data',
+  description: 'Some JSON data',
+  // ... any JSON-serializable data
+})
 
 // Returns:
 // {
@@ -762,6 +790,7 @@ const result = await uploadJsonToPinata(
 These features are in active development and may change in future releases.
 
 ##### `sync`
+
 Powerful bulk synchronization function for creating missing atoms and triples.
 
 ```typescript
@@ -769,14 +798,14 @@ import { sync } from '@0xintuition/sdk'
 
 // Define your data structure
 const data = {
-  'Alice': {
-    'follows': ['Bob', 'Charlie'],
-    'likes': 'TypeScript'
+  Alice: {
+    follows: ['Bob', 'Charlie'],
+    likes: 'TypeScript',
   },
-  'Bob': {
-    'follows': 'Charlie',
-    'worksOn': 'Web3'
-  }
+  Bob: {
+    follows: 'Charlie',
+    worksOn: 'Web3',
+  },
 }
 
 // Dry run to estimate costs
@@ -788,7 +817,7 @@ const estimation = await sync(
     dryRun: true,
     logger: console.log,
   },
-  data
+  data,
 )
 
 console.log('Cost estimation:', estimation)
@@ -813,7 +842,7 @@ const finalResult = await sync(
     logger: console.log,
     batchSize: 50,
   },
-  data
+  data,
 )
 
 // Returns final cost estimation even after execution
@@ -821,6 +850,7 @@ console.log('Final result:', finalResult)
 ```
 
 **How `sync` works:**
+
 1. Analyzes data structure to identify atoms and triples
 2. Queries to find existing atoms and triples
 3. Creates missing atoms in batches (unless dryRun)
@@ -829,11 +859,13 @@ console.log('Final result:', finalResult)
 6. Returns cost estimation (always, as CostEstimation type)
 
 **Configuration:**
+
 - `dryRun`: Estimate costs without executing transactions
 - `batchSize`: Number of items per batch (default: 50)
 - `logger`: Custom logging function
 
 ##### `wait`
+
 Wait for transaction indexing with polling.
 
 ```typescript
@@ -841,12 +873,12 @@ import { wait } from '@0xintuition/sdk'
 
 // Wait for transaction to be indexed
 await wait(transactionHash, {
-  pollingInterval: 1000,        // poll every 1 second (default: 1000)
-  timeout: 60000,               // timeout after 60 seconds (default: 3600000ms)
-  postTransactionDelay: 2000,   // wait 2s after found (default: 2000)
+  pollingInterval: 1000, // poll every 1 second (default: 1000)
+  timeout: 60000, // timeout after 60 seconds (default: 3600000ms)
+  postTransactionDelay: 2000, // wait 2s after found (default: 2000)
   onProgress: (attempt) => {
     console.log(`Polling attempt ${attempt}`)
-  }
+  },
 })
 
 // Now safe to query the transaction data
@@ -854,17 +886,15 @@ await wait(transactionHash, {
 ```
 
 ##### `search`
+
 Search positions with field matching.
 
 ```typescript
 import { search } from '@0xintuition/sdk'
 
 const results = await search(
-  [
-    { subject: 'Alice' },
-    { predicate: 'follows' }
-  ],
-  [walletClient.account.address]
+  [{ subject: 'Alice' }, { predicate: 'follows' }],
+  [walletClient.account.address],
 )
 
 // Returns positions matching the search criteria
@@ -879,37 +909,31 @@ The SDK re-exports all functions from `@0xintuition/protocol`, giving you access
 
 ```typescript
 import {
+  // Event parsers
+  eventParseAtomCreated,
+  eventParseDeposited,
+  eventParseTripleCreated,
+  getMultiVaultAddressFromChainId,
+  // Deployments
+  intuitionDeployments,
+  // Networks
+  intuitionMainnet,
+  intuitionTestnet,
+  // Contract ABIs
+  MultiVaultAbi,
+  multiVaultConvertToShares,
+  multiVaultDeposit,
   // MultiVault operations
   multiVaultGetAtom,
-  multiVaultGetTriple,
-  multiVaultDeposit,
-  multiVaultRedeem,
-  multiVaultPreviewDeposit,
-  multiVaultConvertToShares,
   multiVaultGetShares,
-
+  multiVaultGetTriple,
+  multiVaultPreviewDeposit,
+  multiVaultRedeem,
+  TrustBondingAbi,
   // TrustBonding operations
   trustBondingCurrentEpoch,
   trustBondingGetUserApy,
   trustBondingGetUserCurrentClaimableRewards,
-
-  // Contract ABIs
-  MultiVaultAbi,
-  TrustBondingAbi,
-
-  // Networks
-  intuitionMainnet,
-  intuitionTestnet,
-
-  // Deployments
-  intuitionDeployments,
-  getMultiVaultAddressFromChainId,
-
-  // Event parsers
-  eventParseAtomCreated,
-  eventParseTripleCreated,
-  eventParseDeposited,
-
   // And 40+ more functions...
 } from '@0xintuition/sdk'
 ```
@@ -928,6 +952,7 @@ import {
   getMultiVaultAddressFromChainId,
   intuitionTestnet,
 } from '@0xintuition/sdk'
+
 import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
@@ -948,7 +973,7 @@ const address = getMultiVaultAddressFromChainId(intuitionTestnet.id)
 const atom = await createAtomFromString(
   { walletClient, publicClient, address },
   'TypeScript',
-  parseEther('0.01')
+  parseEther('0.01'),
 )
 
 console.log('Created atom:', atom.state.termId)
@@ -959,20 +984,21 @@ console.log('Transaction:', atom.transactionHash)
 
 ```typescript
 import { createAtomFromString, createTripleStatement } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 // Create three atoms
 const alice = await createAtomFromString(
   { walletClient, publicClient, address },
-  'Alice'
+  'Alice',
 )
 const follows = await createAtomFromString(
   { walletClient, publicClient, address },
-  'follows'
+  'follows',
 )
 const bob = await createAtomFromString(
   { walletClient, publicClient, address },
-  'Bob'
+  'Bob',
 )
 
 // Create triple: Alice follows Bob
@@ -980,13 +1006,13 @@ const triple = await createTripleStatement(
   { walletClient, publicClient, address },
   {
     args: [
-      [alice.state.termId],       // subjects
-      [follows.state.termId],     // predicates
-      [bob.state.termId],         // objects
-      [parseEther('0.1')],        // deposits
+      [alice.state.termId], // subjects
+      [follows.state.termId], // predicates
+      [bob.state.termId], // objects
+      [parseEther('0.1')], // deposits
     ],
     value: parseEther('0.1'),
-  }
+  },
 )
 
 console.log('Triple created:', triple.state[0].args.tripleId)
@@ -996,6 +1022,7 @@ console.log('Triple created:', triple.state[0].args.tripleId)
 
 ```typescript
 import { batchCreateAtomsFromEthereumAccounts } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 // Create atoms for multiple addresses
@@ -1008,10 +1035,13 @@ const addresses = [
 const result = await batchCreateAtomsFromEthereumAccounts(
   { walletClient, publicClient, address },
   addresses,
-  parseEther('0.01')
+  parseEther('0.01'),
 )
 
-console.log('Created atom IDs:', result.state.map(s => s.termId))
+console.log(
+  'Created atom IDs:',
+  result.state.map((s) => s.termId),
+)
 console.log('Single transaction:', result.transactionHash)
 ```
 
@@ -1021,15 +1051,16 @@ console.log('Single transaction:', result.transactionHash)
 import {
   createAtomFromString,
   deposit,
-  multiVaultPreviewDeposit,
   multiVaultGetShares,
+  multiVaultPreviewDeposit,
 } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 // Create an atom
 const atom = await createAtomFromString(
   { walletClient, publicClient, address },
-  'DeFi'
+  'DeFi',
 )
 
 const vaultId = atom.state.termId
@@ -1038,27 +1069,24 @@ const depositAmount = parseEther('1')
 // Preview deposit to see expected shares
 const expectedShares = await multiVaultPreviewDeposit(
   { address, publicClient },
-  { args: [vaultId, 1n, depositAmount] }
+  { args: [vaultId, 1n, depositAmount] },
 )
 
 console.log('Expected shares:', expectedShares)
 
 // Execute deposit
-await deposit(
-  { walletClient, publicClient, address },
-  [
-    walletClient.account.address, // receiver
-    vaultId,                       // termId
-    1n,                            // curveId (use 1 for default curve)
-    depositAmount,                 // assets (amount to deposit)
-    0n,                            // minShares (minimum shares to receive)
-  ]
-)
+await deposit({ walletClient, publicClient, address }, [
+  walletClient.account.address, // receiver
+  vaultId, // termId
+  1n, // curveId (use 1 for default curve)
+  depositAmount, // assets (amount to deposit)
+  0n, // minShares (minimum shares to receive)
+])
 
 // Check balance
 const shares = await multiVaultGetShares(
   { address, publicClient },
-  { args: [walletClient.account.address, vaultId] }
+  { args: [walletClient.account.address, vaultId] },
 )
 
 console.log('Total shares:', shares)
@@ -1067,7 +1095,7 @@ console.log('Total shares:', shares)
 ### Example 5: Global Search
 
 ```typescript
-import { globalSearch, getAtomDetails } from '@0xintuition/sdk'
+import { getAtomDetails, globalSearch } from '@0xintuition/sdk'
 
 // Search for atoms related to "ethereum"
 const results = await globalSearch('ethereum', {
@@ -1092,23 +1120,24 @@ if (results.atoms[0]) {
 
 ```typescript
 import { sync } from '@0xintuition/sdk'
+
 import { formatEther } from 'viem'
 
 // Define knowledge graph structure
 const knowledgeGraph = {
-  'Ethereum': {
-    'isA': 'Blockchain',
-    'hasLanguage': 'Solidity',
-    'supports': ['Smart Contracts', 'DeFi', 'NFTs']
+  Ethereum: {
+    isA: 'Blockchain',
+    hasLanguage: 'Solidity',
+    supports: ['Smart Contracts', 'DeFi', 'NFTs'],
   },
   'Vitalik Buterin': {
-    'created': 'Ethereum',
-    'worksOn': 'Blockchain'
+    created: 'Ethereum',
+    worksOn: 'Blockchain',
   },
-  'Solidity': {
-    'isA': 'Programming Language',
-    'usedFor': 'Smart Contracts'
-  }
+  Solidity: {
+    isA: 'Programming Language',
+    usedFor: 'Smart Contracts',
+  },
 }
 
 // First, run a dry-run to estimate costs
@@ -1121,7 +1150,7 @@ const estimation = await sync(
     dryRun: true,
     logger: (msg) => console.log(`[DRY RUN] ${msg}`),
   },
-  knowledgeGraph
+  knowledgeGraph,
 )
 
 console.log('\nCost Estimation:')
@@ -1144,7 +1173,7 @@ if (estimation.hasSufficientBalance) {
       batchSize: 50,
       logger: console.log,
     },
-    knowledgeGraph
+    knowledgeGraph,
   )
   console.log('Sync completed!')
   console.log('Final cost estimation:', result)
@@ -1157,11 +1186,17 @@ if (estimation.hasSufficientBalance) {
 
 ```typescript
 import { createAtomFromThing, getAtomDetails } from '@0xintuition/sdk'
+
 import { parseEther } from 'viem'
 
 // Create a rich entity with metadata
 const project = await createAtomFromThing(
-  { walletClient, publicClient, address },
+  {
+    walletClient,
+    publicClient,
+    address,
+    pinataApiJWT: process.env.PINATA_API_JWT, // Required for IPFS pinning
+  },
   {
     url: 'https://github.com/myorg/myproject',
     name: 'My Amazing Project',
@@ -1171,7 +1206,7 @@ const project = await createAtomFromThing(
     twitter: 'https://twitter.com/myproject',
     github: 'github.com/myorg/myproject',
   },
-  parseEther('0.05')
+  parseEther('0.05'),
 )
 
 console.log('Thing created and pinned to IPFS')
@@ -1190,29 +1225,20 @@ console.log('Full atom details:', details)
 import { findAtomIds, findTripleIds } from '@0xintuition/sdk'
 
 // Find atom IDs for known data
-const atomData = [
-  'TypeScript',
-  'JavaScript',
-  'Python',
-  'Rust',
-  'Solidity'
-]
+const atomData = ['TypeScript', 'JavaScript', 'Python', 'Rust', 'Solidity']
 
 const atoms = await findAtomIds(atomData)
 
 console.log('Found atoms:')
-atoms.forEach(atom => {
+atoms.forEach((atom) => {
   console.log(`- ${atom.data}: ${atom.term_id}`)
 })
 
 // Find triple IDs for specific combinations
 if (atoms.length >= 3) {
-  const triples = await findTripleIds(
-    walletClient.account.address,
-    [
-      [atoms[0].term_id, atoms[1].term_id, atoms[2].term_id],
-    ]
-  )
+  const triples = await findTripleIds(walletClient.account.address, [
+    [atoms[0].term_id, atoms[1].term_id, atoms[2].term_id],
+  ])
 
   console.log('Found triples:', triples.length)
 }
@@ -1225,10 +1251,7 @@ if (atoms.length >= 3) {
 ### Configuration Types
 
 ```typescript
-import type {
-  WriteConfig,
-  ReadConfig,
-} from '@0xintuition/sdk'
+import type { ReadConfig, WriteConfig } from '@0xintuition/sdk'
 
 // For write operations (transactions)
 type WriteConfig = {
@@ -1308,7 +1331,8 @@ type BatchAtomCreationResult = {
 // Triple creation result
 type TripleCreationResult = {
   transactionHash: `0x${string}`
-  state: Array<{  // array of parsed event objects
+  state: Array<{
+    // array of parsed event objects
     args: {
       tripleId: Hex
       subjectId: Hex
@@ -1326,7 +1350,10 @@ type TripleCreationResult = {
 ### Search Types
 
 ```typescript
-import type { GlobalSearchOptions, SemanticSearchOptions } from '@0xintuition/sdk'
+import type {
+  GlobalSearchOptions,
+  SemanticSearchOptions,
+} from '@0xintuition/sdk'
 
 // Exported interface from api/search.ts
 interface GlobalSearchOptions {
@@ -1338,7 +1365,7 @@ interface GlobalSearchOptions {
 
 // Exported interface from api/semantic-search.ts
 interface SemanticSearchOptions {
-  limit?: number  // optional, defaults to 3
+  limit?: number // optional, defaults to 3
 }
 
 // Note: AtomWithId and TripleWithIds are internal types used by
@@ -1443,14 +1470,15 @@ export function CreateAtomButton() {
 ### Using with TanStack Query
 
 ```typescript
-import { useMutation, useQuery } from '@tanstack/react-query'
 import {
   createAtomFromString,
   getAtomDetails,
   getMultiVaultAddressFromChainId,
 } from '@0xintuition/sdk'
-import { usePublicClient, useWalletClient, useChainId } from 'wagmi'
+
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { parseEther } from 'viem'
+import { useChainId, usePublicClient, useWalletClient } from 'wagmi'
 
 export function useCreateAtom() {
   const chainId = useChainId()
@@ -1467,7 +1495,7 @@ export function useCreateAtom() {
       return createAtomFromString(
         { walletClient, publicClient, address },
         data,
-        parseEther('0.01')
+        parseEther('0.01'),
       )
     },
   })
@@ -1476,7 +1504,7 @@ export function useCreateAtom() {
 export function useAtomDetails(atomId: string | undefined) {
   return useQuery({
     queryKey: ['atom', atomId],
-    queryFn: () => atomId ? getAtomDetails(atomId) : null,
+    queryFn: () => (atomId ? getAtomDetails(atomId) : null),
     enabled: !!atomId,
   })
 }
@@ -1516,8 +1544,8 @@ import { intuitionTestnet } from '@0xintuition/sdk'
 
 ```typescript
 import {
-  getMultiVaultAddressFromChainId,
   getContractAddressFromChainId,
+  getMultiVaultAddressFromChainId,
   intuitionDeployments,
 } from '@0xintuition/sdk'
 

--- a/packages/sdk/docs/functions/batchCreateAtomsFromThings.md
+++ b/packages/sdk/docs/functions/batchCreateAtomsFromThings.md
@@ -8,17 +8,19 @@
 
 > **batchCreateAtomsFromThings**(`config`, `data`, `depositAmount?`): `Promise`\<\{ `state`: `object`[]; `transactionHash`: `` `0x${string}` ``; `uris`: `string`[]; \}\>
 
-Defined in: [packages/sdk/src/core/batch-create-atoms-from-things.ts:20](https://github.com/0xIntuition/intuition-ts/blob/205e10cc7cd6d3c4b27f907604b3b77c2d750145/packages/sdk/src/core/batch-create-atoms-from-things.ts#L20)
+Defined in: [packages/sdk/src/core/batch-create-atoms-from-things.ts:20](https://github.com/0xIntuition/intuition-ts/blob/main/packages/sdk/src/core/batch-create-atoms-from-things.ts#L20)
 
-Pins multiple "things", creates atoms in batch, and returns creation events.
+Pins multiple "things" to IPFS via Pinata, creates atoms in batch, and returns creation events.
 
 ## Parameters
 
 ### config
 
-`WriteConfig`
+`CreateAtomConfigWithIpfs`
 
-Contract address and viem clients.
+Contract address, viem clients, and Pinata API JWT.
+
+**Type**: `WriteConfig & { pinataApiJWT: string }`
 
 ### data
 

--- a/packages/sdk/docs/functions/createAtomFromThing.md
+++ b/packages/sdk/docs/functions/createAtomFromThing.md
@@ -8,17 +8,19 @@
 
 > **createAtomFromThing**(`config`, `data`, `depositAmount?`): `Promise`\<\{ `state`: \{ `atomData`: `` `0x${string}` ``; `atomWallet`: `` `0x${string}` ``; `creator`: `` `0x${string}` ``; `termId`: `` `0x${string}` ``; \}; `transactionHash`: `` `0x${string}` ``; `uri`: `string`; \}\>
 
-Defined in: [packages/sdk/src/core/create-atom-from-thing.ts:20](https://github.com/0xIntuition/intuition-ts/blob/205e10cc7cd6d3c4b27f907604b3b77c2d750145/packages/sdk/src/core/create-atom-from-thing.ts#L20)
+Defined in: [packages/sdk/src/core/create-atom-from-thing.ts:20](https://github.com/0xIntuition/intuition-ts/blob/main/packages/sdk/src/core/create-atom-from-thing.ts#L20)
 
-Pins a "thing" to IPFS, creates an atom on-chain, and returns the event state.
+Pins a "thing" to IPFS via Pinata, creates an atom on-chain, and returns the event state.
 
 ## Parameters
 
 ### config
 
-`WriteConfig`
+`CreateAtomConfigWithIpfs`
 
-Contract address and viem clients.
+Contract address, viem clients, and Pinata API JWT.
+
+**Type**: `WriteConfig & { pinataApiJWT: string }`
 
 ### data
 

--- a/packages/sdk/docs/functions/pinThing.md
+++ b/packages/sdk/docs/functions/pinThing.md
@@ -6,11 +6,13 @@
 
 # Function: pinThing()
 
+> **⚠️ DEPRECATED**: This function is deprecated. Use `uploadJsonToPinata` from the SDK instead. The SDK now supports direct Pinata uploads without requiring backend mediation. See `createAtomFromThing` and `batchCreateAtomsFromThings` for updated implementations.
+
 > **pinThing**(`variables`): `Promise`\<`string` \| `null`\>
 
-Defined in: [packages/sdk/src/api/pin-thing.ts:13](https://github.com/0xIntuition/intuition-ts/blob/205e10cc7cd6d3c4b27f907604b3b77c2d750145/packages/sdk/src/api/pin-thing.ts#L13)
+Defined in: [packages/sdk/src/api/pin-thing.ts:16](https://github.com/0xIntuition/intuition-ts/blob/main/packages/sdk/src/api/pin-thing.ts#L16)
 
-Pins a "thing" via the GraphQL API and returns the resulting URI.
+Pins a "thing" via the GraphQL API and returns the resulting URI (deprecated, backend-mediated).
 
 ## Parameters
 

--- a/packages/sdk/src/api/pin-thing.ts
+++ b/packages/sdk/src/api/pin-thing.ts
@@ -9,6 +9,9 @@ import {
  * Pins a "thing" via the GraphQL API and returns the resulting URI.
  * @param variables PinThing mutation variables.
  * @returns IPFS URI string or null if pinning fails.
+ * @deprecated This function is deprecated. Use `uploadJsonToPinata` from the SDK instead.
+ * The SDK now supports direct Pinata uploads without requiring backend mediation.
+ * See `createAtomFromThing` and `batchCreateAtomsFromThings` for updated implementations.
  */
 export async function pinThing(variables: PinThingMutationVariables) {
   try {

--- a/packages/sdk/src/api/pin-thing.ts
+++ b/packages/sdk/src/api/pin-thing.ts
@@ -19,7 +19,6 @@ export async function pinThing(variables: PinThingMutationVariables) {
       PinThingDocument,
       variables,
     )()
-    data.pinThing?.uri
     if (data.pinThing?.uri) {
       return data.pinThing?.uri
     }

--- a/packages/sdk/src/core/batch-create-atoms-from-things.ts
+++ b/packages/sdk/src/core/batch-create-atoms-from-things.ts
@@ -3,22 +3,22 @@ import {
   eventParseAtomCreated,
   multiVaultCreateAtoms,
   multiVaultGetAtomCost,
-  type WriteConfig,
 } from '@0xintuition/protocol'
 
 import { toHex } from 'viem'
 
-import { pinThing } from '../api/pin-thing'
+import { uploadJsonToPinata } from '../external/upload-json-to-pinata'
+import type { CreateAtomConfigWithIpfs } from './create-atom-from-ipfs-upload'
 
 /**
  * Pins multiple "things", creates atoms in batch, and returns creation events.
- * @param config Contract address and viem clients.
+ * @param config Contract address, viem clients, and Pinata API JWT.
  * @param data Array of PinThing mutation variables.
  * @param depositAmount Optional additional deposit amount per atom.
  * @returns Created atom URIs, transaction hash, and decoded event args.
  */
 export async function batchCreateAtomsFromThings(
-  config: WriteConfig,
+  config: CreateAtomConfigWithIpfs,
   data: PinThingMutationVariables[],
   depositAmount?: bigint,
 ) {
@@ -36,10 +36,8 @@ export async function batchCreateAtomsFromThings(
   // Pin each thing and collect their URIs
   const uris: string[] = []
   for (const item of data) {
-    const uri = await pinThing(item)
-    if (!uri) {
-      throw new Error(`Failed to pin thing on IPFS: ${JSON.stringify(item)}`)
-    }
+    const dataIpfs = await uploadJsonToPinata(config.pinataApiJWT, item)
+    const uri = `ipfs://${dataIpfs.IpfsHash}`
     uris.push(uri)
   }
 

--- a/packages/sdk/src/core/create-atom-from-ipfs-upload.ts
+++ b/packages/sdk/src/core/create-atom-from-ipfs-upload.ts
@@ -1,5 +1,5 @@
 import {
-  eventParseDeposited,
+  eventParseAtomCreated,
   multiVaultCreateAtoms,
   multiVaultGetAtomCost,
   type WriteConfig,
@@ -47,10 +47,7 @@ export async function createAtomFromIpfsUpload(
     throw new Error('Failed to create atom onchain')
   }
 
-  const events = await eventParseDeposited(
-    config.publicClient ?? config.walletClient,
-    txHash,
-  )
+  const events = await eventParseAtomCreated(publicClient, txHash)
 
   return {
     uri,

--- a/packages/sdk/src/core/create-atom-from-thing.ts
+++ b/packages/sdk/src/core/create-atom-from-thing.ts
@@ -3,29 +3,27 @@ import {
   eventParseAtomCreated,
   multiVaultCreateAtoms,
   multiVaultGetAtomCost,
-  type WriteConfig,
 } from '@0xintuition/protocol'
 
 import { toHex } from 'viem'
 
-import { pinThing } from '../api/pin-thing'
+import { uploadJsonToPinata } from '../external/upload-json-to-pinata'
+import type { CreateAtomConfigWithIpfs } from './create-atom-from-ipfs-upload'
 
 /**
  * Pins a "thing" to IPFS, creates an atom on-chain, and returns the event state.
- * @param config Contract address and viem clients.
+ * @param config Contract address, viem clients, and Pinata API JWT.
  * @param data PinThing mutation variables used to build the IPFS payload.
  * @param depositAmount Optional additional deposit amount.
  * @returns Created atom URI, transaction hash, and decoded event args.
  */
 export async function createAtomFromThing(
-  config: WriteConfig,
+  config: CreateAtomConfigWithIpfs,
   data: PinThingMutationVariables,
   depositAmount?: bigint,
 ) {
-  const uriRef = await pinThing(data)
-  if (!uriRef) {
-    throw new Error('Failed to pin thing on IPFS')
-  }
+  const dataIpfs = await uploadJsonToPinata(config.pinataApiJWT, data)
+  const uriRef = `ipfs://${dataIpfs.IpfsHash}`
 
   const { address: ethMultiVaultAddress, publicClient } = config
   const atomBaseCost = await multiVaultGetAtomCost({

--- a/packages/sdk/src/core/create-atom-from-thing.ts
+++ b/packages/sdk/src/core/create-atom-from-thing.ts
@@ -23,6 +23,11 @@ export async function createAtomFromThing(
   depositAmount?: bigint,
 ) {
   const dataIpfs = await uploadJsonToPinata(config.pinataApiJWT, data)
+
+  if (!dataIpfs.IpfsHash || dataIpfs.IpfsHash.trim() === '') {
+    throw new Error('Invalid IPFS hash received from Pinata')
+  }
+
   const uriRef = `ipfs://${dataIpfs.IpfsHash}`
 
   const { address: ethMultiVaultAddress, publicClient } = config

--- a/packages/sdk/tests/external.test.ts
+++ b/packages/sdk/tests/external.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { uploadJsonToPinata } from '../src'
 
 describe('External', () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.restoreAllMocks()
+  })
+
   it('should upload a new file to IPFS using Pinata', async () => {
     const data = await uploadJsonToPinata(
       process.env.PINATA_API_JWT || 'unknown',
@@ -15,5 +20,87 @@ describe('External', () => {
     expect(data.IpfsHash).toEqual(
       'QmYiJdC6KbkUuKVYeuQLm3DRbaok3h6yPyJjPqas8cotqx',
     )
+  })
+
+  describe('Error Handling', () => {
+    it('should throw error when Pinata API returns non-200 response', async () => {
+      // Mock fetch to return a non-ok response
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Unauthorized',
+      })
+
+      await expect(
+        uploadJsonToPinata('invalid_jwt', {
+          name: 'Test',
+        }),
+      ).rejects.toThrow(
+        'Failed to upload JSON to Pinata: Pinata upload failed: Unauthorized',
+      )
+    })
+
+    it('should throw error when Pinata API returns empty IPFS hash', async () => {
+      // Mock fetch to return a response with empty IpfsHash
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          IpfsHash: '',
+          PinSize: 100,
+          Timestamp: new Date().toISOString(),
+          ID: 'test-id',
+          Name: null,
+          NumberOfFiles: 1,
+          MimeType: 'application/json',
+          GroupId: null,
+          Keyvalues: null,
+          isDuplicate: false,
+        }),
+      })
+
+      const result = await uploadJsonToPinata('valid_jwt', {
+        name: 'Test',
+      })
+
+      // The function returns the response, validation happens in calling functions
+      expect(result.IpfsHash).toBe('')
+    })
+
+    it('should throw error when fetch fails due to network error', async () => {
+      // Mock fetch to throw a network error
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+
+      await expect(
+        uploadJsonToPinata('valid_jwt', {
+          name: 'Test',
+        }),
+      ).rejects.toThrow('Failed to upload JSON to Pinata: Network error')
+    })
+
+    it('should throw error when fetch fails with non-Error object', async () => {
+      // Mock fetch to throw a non-Error object
+      global.fetch = vi.fn().mockRejectedValue('String error')
+
+      await expect(
+        uploadJsonToPinata('valid_jwt', {
+          name: 'Test',
+        }),
+      ).rejects.toThrow('Failed to upload JSON to Pinata: Unknown error')
+    })
+
+    it('should handle malformed JSON response', async () => {
+      // Mock fetch to return invalid JSON
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON')
+        },
+      })
+
+      await expect(
+        uploadJsonToPinata('valid_jwt', {
+          name: 'Test',
+        }),
+      ).rejects.toThrow('Invalid JSON')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Migrates from backend-mediated IPFS pinning (via GraphQL API) to client-side Pinata uploads for improved performance and reliability. This removes the dependency on the GraphQL backend for IPFS operations, allowing SDK users to interact directly with Pinata.

### Breaking Changes
- `createAtomFromThing` now requires `pinataApiJWT` in the config parameter
- `batchCreateAtomsFromThings` now requires `pinataApiJWT` in the config parameter
- Both functions now use `CreateAtomConfigWithIpfs` type instead of `WriteConfig`

### Deprecations
- **GraphQL:** `pinThing` mutation is deprecated (use `uploadJsonToPinata` from SDK instead)
- **SDK:** `pinThing` function is deprecated (use `uploadJsonToPinata` instead)

### Changes
- Updated SDK functions to use direct Pinata uploads via `uploadJsonToPinata`
- Added comprehensive deprecation notices to GraphQL README and mutation files
- Updated all SDK documentation and examples with new Pinata JWT requirement
- Modified nextjs-template example to demonstrate new configuration
- Added CHANGELOG entries for both SDK and GraphQL packages

### Migration Guide
**Before:**
```typescript
const atom = await createAtomFromThing(
  { walletClient, publicClient, address },
  { name: 'Example', url: 'https://example.com' }
)
```

**After:**
```typescript
const atom = await createAtomFromThing(
  {
    walletClient,
    publicClient,
    address,
    pinataApiJWT: process.env.PINATA_API_JWT, // New required parameter
  },
  { name: 'Example', url: 'https://example.com' }
)
```

## Test plan
- [ ] Verify `createAtomFromThing` works with Pinata JWT
- [ ] Verify `batchCreateAtomsFromThings` works with Pinata JWT
- [ ] Confirm proper error handling when Pinata JWT is missing
- [ ] Test nextjs-template example with updated configuration
- [ ] Verify all documentation links and examples are accurate
- [ ] Ensure backward compatibility warnings are visible in deprecated functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)