### PR TITLE
fix(sdk): Allow calculateAtomId to accept string | Hex for better DX

### DIFF
--- a/packages/protocol/tests/helpers/calculate.ts
+++ b/packages/protocol/tests/helpers/calculate.ts
@@ -1,10 +1,13 @@
 import type { Hex } from 'viem'
-import { encodePacked, keccak256, toHex } from 'viem'
+import { encodePacked, keccak256, stringToHex, toHex } from 'viem'
 
-export function calculateAtomId(atomData: Hex) {
+export function calculateAtomId(atomData: string | Hex) {
   const salt = keccak256(toHex('ATOM_SALT'))
+  // Convert to hex if it's a string, ensuring safe input to keccak256
+  const hexData =
+    typeof atomData === 'string' ? stringToHex(atomData) : atomData
   return keccak256(
-    encodePacked(['bytes32', 'bytes'], [salt, keccak256(atomData)]),
+    encodePacked(['bytes32', 'bytes'], [salt, keccak256(hexData)]),
   )
 }
 

--- a/packages/protocol/tests/helpers/calculate.ts
+++ b/packages/protocol/tests/helpers/calculate.ts
@@ -1,11 +1,10 @@
 import type { Hex } from 'viem'
-import { encodePacked, keccak256, stringToHex, toHex } from 'viem'
+import { encodePacked, isHex, keccak256, stringToHex, toHex } from 'viem'
 
 export function calculateAtomId(atomData: string | Hex) {
   const salt = keccak256(toHex('ATOM_SALT'))
-  // Convert to hex if it's a string, ensuring safe input to keccak256
-  const hexData =
-    typeof atomData === 'string' ? stringToHex(atomData) : atomData
+  // Convert to hex if it's not already hex-encoded, ensuring safe input to keccak256
+  const hexData = isHex(atomData) ? atomData : stringToHex(atomData)
   return keccak256(
     encodePacked(['bytes32', 'bytes'], [salt, keccak256(hexData)]),
   )

--- a/packages/sdk/src/utils/calculate-atom-id.ts
+++ b/packages/sdk/src/utils/calculate-atom-id.ts
@@ -1,5 +1,5 @@
 import type { Hex } from 'viem'
-import { encodePacked, keccak256, stringToHex, toHex } from 'viem'
+import { encodePacked, isHex, keccak256, stringToHex, toHex } from 'viem'
 
 /**
  * Computes an atom ID by hashing the atom data with the ATOM_SALT.
@@ -8,9 +8,8 @@ import { encodePacked, keccak256, stringToHex, toHex } from 'viem'
  */
 export function calculateAtomId(atomData: string | Hex) {
   const salt = keccak256(toHex('ATOM_SALT'))
-  // Convert to hex if it's a string, ensuring safe input to keccak256
-  const hexData =
-    typeof atomData === 'string' ? stringToHex(atomData) : atomData
+  // Convert to hex if it's not already hex-encoded, ensuring safe input to keccak256
+  const hexData = isHex(atomData) ? atomData : stringToHex(atomData)
   return keccak256(
     encodePacked(['bytes32', 'bytes'], [salt, keccak256(hexData)]),
   )

--- a/packages/sdk/src/utils/calculate-atom-id.ts
+++ b/packages/sdk/src/utils/calculate-atom-id.ts
@@ -1,14 +1,17 @@
 import type { Hex } from 'viem'
-import { encodePacked, keccak256, toHex } from 'viem'
+import { encodePacked, keccak256, stringToHex, toHex } from 'viem'
 
 /**
  * Computes an atom ID by hashing the atom data with the ATOM_SALT.
- * @param atomData Raw atom data as hex.
+ * @param atomData Raw atom data as string or hex.
  * @returns Keccak256 hash representing the atom ID.
  */
-export function calculateAtomId(atomData: Hex) {
+export function calculateAtomId(atomData: string | Hex) {
   const salt = keccak256(toHex('ATOM_SALT'))
+  // Convert to hex if it's a string, ensuring safe input to keccak256
+  const hexData =
+    typeof atomData === 'string' ? stringToHex(atomData) : atomData
   return keccak256(
-    encodePacked(['bytes32', 'bytes'], [salt, keccak256(atomData)]),
+    encodePacked(['bytes32', 'bytes'], [salt, keccak256(hexData)]),
   )
 }


### PR DESCRIPTION
## Problem

The `calculateAtomId` function currently has a restrictive type signature that only accepts `Hex`, but this creates a poor developer experience where documentation and expected usage patterns don't match the actual types.

### Evidence of the Issue

1. **Documentation mismatch**: [Official docs](https://www.docs.intuition.systems/docs/intuition-sdk/atoms-guide#calculateatomid) show examples using strings directly:
   ```typescript
   const termId = calculateAtomId("completed");
   ```

2. **Developer pain point**: Real user experiencing this DX issue in Discord:
   > "it is not the returned value that is the issue, it the value passed into the calculateAtomId. on the docs the code is `const termId = calculateAtomId("completed");` but when i do the same thing in code, i get a lint error that an 0xstring(address) is what should be passed instead of a regular string"
   
   [Discord thread](https://discord.com/channels/909531430881746974/1416097676772249753/1494751047909118155)

3. **Comprehensive testing**: [Demo repository](https://github.com/jeremie-olivier/intuition-calculateAtomId-demo) proving that both string and hex inputs work identically at runtime but TypeScript types are restrictive.

## Solution

Update the type signature from:
```typescript
function calculateAtomId(atomData: Hex): string
```

To:
```typescript  
function calculateAtomId(atomData: string | Hex): string
```

### Implementation Details

- **Type safe**: Uses explicit conversion with `stringToHex()` rather than type assertions
- **Performance optimized**: Only converts strings when needed via `typeof` check  
- **Backward compatible**: Existing hex usage continues to work unchanged
- **Clear intent**: Comments explain the conversion logic

```typescript
export function calculateAtomId(atomData: string | Hex) {
  const salt = keccak256(toHex('ATOM_SALT'))
  // Convert to hex if it's a string, ensuring safe input to keccak256
  const hexData = typeof atomData === 'string' ? stringToHex(atomData) : atomData
  return keccak256(
    encodePacked(['bytes32', 'bytes'], [salt, keccak256(hexData)]),
  )
}
```

## Benefits

- ✅ **Types match documentation** - No more confusion between docs and reality
- ✅ **Better DX** - Developers can use strings directly as shown in docs  
- ✅ **Backward compatible** - Existing code with hex inputs continues to work
- ✅ **Type safe** - No dangerous type assertions, explicit conversion only
- ✅ **Performance** - Only converts when needed

## Changes

- `packages/sdk/src/utils/calculate-atom-id.ts`: Updated type signature and implementation
- `packages/protocol/tests/helpers/calculate.ts`: Updated for consistency

## Testing

- ✅ All existing tests pass
- ✅ Build succeeds  
- ✅ Linting passes
- ✅ Type checking passes
- ✅ [External demo](https://github.com/jeremie-olivier/intuition-calculateAtomId-demo) validates both input formats work identically

This change aligns the SDK with its documentation and significantly improves developer experience while maintaining full backward compatibility and type safety.