### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/huge-cycles-pick.md
+++ b/.changeset/huge-cycles-pick.md
@@ -1,7 +1,0 @@
----
-'intuition-cli': patch
-'@0xintuition/graphql': patch
-'@0xintuition/sdk': patch
----
-
-Remove public IPFS pinning

--- a/.changeset/itchy-roses-stare.md
+++ b/.changeset/itchy-roses-stare.md
@@ -1,7 +1,0 @@
----
-'intuition-cli': patch
-'@0xintuition/graphql': patch
-'@0xintuition/sdk': patch
----
-
-Remove public IPFS pinning

--- a/.changeset/publish-entrypoint-guards.md
+++ b/.changeset/publish-entrypoint-guards.md
@@ -1,8 +1,0 @@
----
-'@0xintuition/protocol': patch
-'@0xintuition/graphql': patch
-'@0xintuition/sdk': patch
-'intuition-cli': patch
----
-
-Build and verify package entrypoints before publish so packages include runnable `dist` artifacts.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # intuition-cli
 
+## 3.0.1
+
+### Patch Changes
+
+- aebd3d1: Remove public IPFS pinning
+- 393dab8: Build and verify package entrypoints before publish so packages include runnable `dist` artifacts.
+- Updated dependencies [aebd3d1]
+- Updated dependencies [393dab8]
+  - @0xintuition/sdk@3.0.1
+  - @0xintuition/protocol@2.0.3
+
 ## 3.0.0
 
 ### Major Changes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intuition-cli",
   "description": "A CLI for the Intuition protocol.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Intuition Systems",
   "license": "MIT",
   "types": "dist/index.d.ts",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @0xintuition/graphql
 
+## 3.0.1
+
+### Patch Changes
+
+- aebd3d1: Remove public IPFS pinning
+- 393dab8: Build and verify package entrypoints before publish so packages include runnable `dist` artifacts.
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xintuition/graphql",
   "description": "Intuition GraphQL",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2.1.3 (2025-10-30)
 
+## 2.0.3
+
+### Patch Changes
+
+- 393dab8: Build and verify package entrypoints before publish so packages include runnable `dist` artifacts.
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xintuition/protocol",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Intuition Protocol",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @0xintuition/sdk
 
+## 3.0.1
+
+### Patch Changes
+
+- aebd3d1: Remove public IPFS pinning
+- 393dab8: Build and verify package entrypoints before publish so packages include runnable `dist` artifacts.
+- Updated dependencies [aebd3d1]
+- Updated dependencies [393dab8]
+  - @0xintuition/graphql@3.0.1
+  - @0xintuition/protocol@2.0.3
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xintuition/sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Intuition SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@0xintuition/graphql": "workspace:^",
-    "@0xintuition/protocol": "^2.0.2"
+    "@0xintuition/protocol": "^2.0.3"
   },
   "peerDependencies": {
     "viem": "^2.0.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@0xintuition/graphql": "workspace:^",
-    "@0xintuition/protocol": "^2.0.3"
+    "@0xintuition/protocol": "workspace:^"
   },
   "peerDependencies": {
     "viem": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,8 +470,8 @@ importers:
         specifier: workspace:^
         version: link:../graphql
       '@0xintuition/protocol':
-        specifier: ^2.0.2
-        version: 2.0.2(viem@2.31.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)(zod@3.25.67))
+        specifier: workspace:^
+        version: link:../protocol
     devDependencies:
       '@viem/anvil':
         specifier: ^0.0.10
@@ -510,11 +510,6 @@ packages:
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0
-
-  '@0xintuition/protocol@2.0.2':
-    resolution: {integrity: sha512-BjdBkskuTj5K7KyCd6/33gDkZLh1rEMSGMNfA6iD5jM5TU7OC32ySybBKZ2tQzicnvWGYTSUSh01muBAmILgPw==}
-    peerDependencies:
-      viem: 2.31.4
 
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
@@ -12662,10 +12657,6 @@ snapshots:
       '@gql.tada/internal': 1.0.8(graphql@16.9.0)(typescript@5.4.5)
       graphql: 16.9.0
       typescript: 5.4.5
-
-  '@0xintuition/protocol@2.0.2(viem@2.31.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)(zod@3.25.67))':
-    dependencies:
-      viem: 2.31.4(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.4)(zod@3.25.67)
 
   '@adobe/css-tools@4.4.0': {}
 


### PR DESCRIPTION
## Summary

- Version packages from the pending Changesets after the package artifact publish fix.
- Bump `@0xintuition/graphql`, `@0xintuition/sdk`, and `intuition-cli` to `3.0.1`.
- Bump `@0xintuition/protocol` to `2.0.3` and update the SDK dependency range.

## Validation

- `bun run build:publish`
- `pnpm --filter @0xintuition/graphql test`
- `env PINATA_API_JWT="$(cat /tmp/intuition-pinata-api-jwt)" pnpm --filter @0xintuition/sdk test`
- `git diff --check`
- pre-commit hook: `pnpm lint && pnpm typecheck && pretty-quick --verbose --staged` (existing CLI lint warnings only)