### PR TITLE
fix: forward the correct payable value in deposit and batch creation wrappers

### DIFF
--- a/.changeset/fix-sdk-payable-deposit.md
+++ b/.changeset/fix-sdk-payable-deposit.md
@@ -1,0 +1,5 @@
+---
+'@0xintuition/sdk': minor
+---
+
+Add an optional payable value to the SDK deposit input while preserving bare argument calls.

--- a/.changeset/fix-sdk-payable-deposit.md
+++ b/.changeset/fix-sdk-payable-deposit.md
@@ -2,4 +2,4 @@
 '@0xintuition/sdk': minor
 ---
 
-Forward the correct payable value when depositing into one or more vaults and when creating triple statements in a batch.
+Forward the correct payable value when depositing into one or more vaults and when creating triple statements in a batch. `batchCreateTripleStatements` now warns once when its deprecated, ignored `depositAmount` parameter is passed with a nonzero value.

--- a/.changeset/fix-sdk-payable-deposit.md
+++ b/.changeset/fix-sdk-payable-deposit.md
@@ -2,4 +2,4 @@
 '@0xintuition/sdk': minor
 ---
 
-Add an optional payable value to the SDK deposit input while preserving bare argument calls.
+Forward the correct payable value when depositing into one or more vaults and when creating triple statements in a batch.

--- a/packages/sdk/src/core/batch-create-triple-statements.ts
+++ b/packages/sdk/src/core/batch-create-triple-statements.ts
@@ -5,20 +5,51 @@ import {
   type WriteConfig,
 } from '@0xintuition/protocol'
 
+type BatchCreateTripleStatementsResult = {
+  transactionHash: Awaited<ReturnType<typeof multiVaultCreateTriples>>
+  state: Awaited<ReturnType<typeof eventParseTripleCreated>>[number]['args'][]
+}
+
+let hasWarnedAboutDepositAmount = false
+
 /**
  * Creates triples in batch and returns parsed TripleCreated events.
  * @param config Contract address and viem clients.
- * @param data CreateTriples arguments for the MultiVault contract.
- * @param depositAmount Deprecated and ignored. Each asset in data is the total value for its triple.
+ * @param data CreateTriples arguments. The call value is the sum of the assets array.
  * @returns Transaction hash and decoded event args.
  */
+export function batchCreateTripleStatements(
+  config: WriteConfig,
+  data: CreateTriplesInputs['args'],
+): Promise<BatchCreateTripleStatementsResult>
+
+/**
+ * @deprecated `depositAmount` is ignored because each entry in the `data` assets array already carries that triple's full value. Call with only `config` and `data`.
+ */
+export function batchCreateTripleStatements(
+  config: WriteConfig,
+  data: CreateTriplesInputs['args'],
+  depositAmount: bigint,
+): Promise<BatchCreateTripleStatementsResult>
+
 export async function batchCreateTripleStatements(
   config: WriteConfig,
   data: CreateTriplesInputs['args'],
   depositAmount?: bigint,
-) {
+): Promise<BatchCreateTripleStatementsResult> {
   const { publicClient } = config
-  void depositAmount
+
+  if (
+    depositAmount !== undefined &&
+    depositAmount !== 0n &&
+    !hasWarnedAboutDepositAmount
+  ) {
+    hasWarnedAboutDepositAmount = true
+    console.warn(
+      'batchCreateTripleStatements: depositAmount is deprecated and ignored; ' +
+        "each entry in the data assets array already carries that triple's full value.",
+    )
+  }
 
   const txHash = await multiVaultCreateTriples(config, {
     args: data,

--- a/packages/sdk/src/core/batch-create-triple-statements.ts
+++ b/packages/sdk/src/core/batch-create-triple-statements.ts
@@ -1,7 +1,6 @@
 import {
   eventParseTripleCreated,
   multiVaultCreateTriples,
-  multiVaultGetTripleCost,
   type CreateTriplesInputs,
   type WriteConfig,
 } from '@0xintuition/protocol'
@@ -10,7 +9,7 @@ import {
  * Creates triples in batch and returns parsed TripleCreated events.
  * @param config Contract address and viem clients.
  * @param data CreateTriples arguments for the MultiVault contract.
- * @param depositAmount Optional additional deposit amount.
+ * @param depositAmount Deprecated and ignored. Each asset in data is the total value for its triple.
  * @returns Transaction hash and decoded event args.
  */
 export async function batchCreateTripleStatements(
@@ -18,15 +17,12 @@ export async function batchCreateTripleStatements(
   data: CreateTriplesInputs['args'],
   depositAmount?: bigint,
 ) {
-  const { address, publicClient } = config
-  const tripleBaseCost = await multiVaultGetTripleCost({
-    publicClient,
-    address,
-  })
+  const { publicClient } = config
+  void depositAmount
 
   const txHash = await multiVaultCreateTriples(config, {
     args: data,
-    value: tripleBaseCost + BigInt(depositAmount || 0),
+    value: data[3].reduce((sum, assets) => sum + assets, 0n),
   })
 
   if (!txHash) {

--- a/packages/sdk/src/core/batch-deposit.ts
+++ b/packages/sdk/src/core/batch-deposit.ts
@@ -8,7 +8,7 @@ import {
 /**
  * Deposits assets for multiple terms and returns parsed Deposited events.
  * @param config Contract address and viem clients.
- * @param data DepositBatch arguments for the MultiVault contract.
+ * @param data DepositBatch arguments. The call value is the sum of the assets array.
  * @returns Transaction hash and decoded event args.
  */
 export async function batchDeposit(

--- a/packages/sdk/src/core/batch-deposit.ts
+++ b/packages/sdk/src/core/batch-deposit.ts
@@ -19,7 +19,7 @@ export async function batchDeposit(
 
   const txHash = await multiVaultDepositBatch(config, {
     args: data,
-    value: data[4].reduce(
+    value: data[3].reduce(
       (sum: number | bigint, item: number | bigint) =>
         BigInt(sum) + BigInt(item),
       0n,

--- a/packages/sdk/src/core/deposit.ts
+++ b/packages/sdk/src/core/deposit.ts
@@ -5,21 +5,40 @@ import {
   type WriteConfig,
 } from '@0xintuition/protocol'
 
+type DepositResult = {
+  transactionHash: Awaited<ReturnType<typeof multiVaultDeposit>>
+  state: any[]
+}
+
 /**
  * Deposits assets for a term and returns parsed Deposited events.
  * @param config Contract address and viem clients.
- * @param data Deposit arguments for the MultiVault contract.
+ * @param data Deposit arguments and optional call value for the MultiVault contract.
  * @returns Transaction hash and decoded event args.
  */
-export async function deposit(
+export function deposit(
+  config: WriteConfig,
+  data: DepositInputs,
+): Promise<DepositResult>
+
+/**
+ * @deprecated Pass `{ args, value? }` instead. Bare args send no call value.
+ */
+export function deposit(
   config: WriteConfig,
   data: DepositInputs['args'],
-) {
-  const { publicClient } = config
+): Promise<DepositResult>
 
-  const txHash = await multiVaultDeposit(config, {
-    args: data,
-  })
+export async function deposit(
+  config: WriteConfig,
+  data: DepositInputs | DepositInputs['args'],
+): Promise<DepositResult> {
+  const { publicClient } = config
+  const inputs = Array.isArray(data)
+    ? { args: data as DepositInputs['args'] }
+    : (data as DepositInputs)
+
+  const txHash = await multiVaultDeposit(config, inputs)
 
   if (!txHash) {
     throw new Error('Failed to deposit')

--- a/packages/sdk/tests/batch-create-triple-statements.test.ts
+++ b/packages/sdk/tests/batch-create-triple-statements.test.ts
@@ -5,8 +5,8 @@ import {
   type CreateTriplesInputs,
   type WriteConfig,
 } from '@0xintuition/protocol'
-import { parseEther } from 'viem'
 
+import { parseEther } from 'viem'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { batchCreateTripleStatements } from '../src/core/batch-create-triple-statements'
@@ -51,6 +51,7 @@ const args = [
 
 describe('batchCreateTripleStatements', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
@@ -72,5 +73,48 @@ describe('batchCreateTripleStatements', () => {
       args,
       value: parseEther('250'),
     })
+  })
+
+  it('warns once for nonzero legacy deposit amounts and stays silent otherwise', async () => {
+    // A fresh module makes the once-guard deterministic regardless of prior tests.
+    vi.resetModules()
+    const { multiVaultCreateTriples: freshMultiVaultCreateTriples } =
+      await import('@0xintuition/protocol')
+    const { batchCreateTripleStatements: freshBatchCreateTripleStatements } =
+      await import('../src/core/batch-create-triple-statements')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const warningCallCounts: number[] = []
+
+    await freshBatchCreateTripleStatements(writeConfig, args)
+    warningCallCounts.push(warnSpy.mock.calls.length)
+
+    await freshBatchCreateTripleStatements(writeConfig, args, 0n)
+    warningCallCounts.push(warnSpy.mock.calls.length)
+
+    await freshBatchCreateTripleStatements(writeConfig, args, parseEther('999'))
+    warningCallCounts.push(warnSpy.mock.calls.length)
+
+    await freshBatchCreateTripleStatements(
+      writeConfig,
+      args,
+      parseEther('1000'),
+    )
+    warningCallCounts.push(warnSpy.mock.calls.length)
+
+    expect(freshMultiVaultCreateTriples).toHaveBeenCalledTimes(4)
+    for (let call = 1; call <= 4; call += 1) {
+      expect(freshMultiVaultCreateTriples).toHaveBeenNthCalledWith(
+        call,
+        writeConfig,
+        {
+          args,
+          value: parseEther('250'),
+        },
+      )
+    }
+    expect(warningCallCounts).toEqual([0, 0, 1, 1])
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/deprecated.*ignored/i),
+    )
   })
 })

--- a/packages/sdk/tests/batch-create-triple-statements.test.ts
+++ b/packages/sdk/tests/batch-create-triple-statements.test.ts
@@ -1,0 +1,76 @@
+import {
+  eventParseTripleCreated,
+  multiVaultCreateTriples,
+  multiVaultGetTripleCost,
+  type CreateTriplesInputs,
+  type WriteConfig,
+} from '@0xintuition/protocol'
+import { parseEther } from 'viem'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { batchCreateTripleStatements } from '../src/core/batch-create-triple-statements'
+
+vi.mock('@0xintuition/protocol', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@0xintuition/protocol')>()
+
+  return {
+    ...actual,
+    eventParseTripleCreated: vi.fn(async () => []),
+    multiVaultCreateTriples: vi.fn(
+      async () =>
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+    ),
+    multiVaultGetTripleCost: vi.fn(async () => parseEther('0.01')),
+  }
+})
+
+const writeConfig = {
+  address: '0x0000000000000000000000000000000000000001',
+  publicClient: {},
+  walletClient: {},
+} as WriteConfig
+
+const value1 = parseEther('100')
+const value2 = parseEther('150')
+const args = [
+  [
+    '0x0000000000000000000000000000000000000000000000000000000000000002',
+    '0x0000000000000000000000000000000000000000000000000000000000000003',
+  ],
+  [
+    '0x0000000000000000000000000000000000000000000000000000000000000004',
+    '0x0000000000000000000000000000000000000000000000000000000000000005',
+  ],
+  [
+    '0x0000000000000000000000000000000000000000000000000000000000000006',
+    '0x0000000000000000000000000000000000000000000000000000000000000007',
+  ],
+  [value1, value2],
+] as const satisfies CreateTriplesInputs['args']
+
+describe('batchCreateTripleStatements', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards the summed assets value 250000000000000000000n', async () => {
+    await batchCreateTripleStatements(writeConfig, args)
+
+    expect(multiVaultCreateTriples).toHaveBeenCalledWith(writeConfig, {
+      args,
+      value: parseEther('250'),
+    })
+    expect(multiVaultGetTripleCost).not.toHaveBeenCalled()
+    expect(eventParseTripleCreated).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps accepting the legacy deposit amount without double-counting it', async () => {
+    await batchCreateTripleStatements(writeConfig, args, parseEther('999'))
+
+    expect(multiVaultCreateTriples).toHaveBeenCalledWith(writeConfig, {
+      args,
+      value: parseEther('250'),
+    })
+  })
+})

--- a/packages/sdk/tests/batch-deposit.test.ts
+++ b/packages/sdk/tests/batch-deposit.test.ts
@@ -1,0 +1,56 @@
+import {
+  eventParseDeposited,
+  multiVaultDepositBatch,
+  type DepositBatchInputs,
+  type WriteConfig,
+} from '@0xintuition/protocol'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { batchDeposit } from '../src/core/batch-deposit'
+
+vi.mock('@0xintuition/protocol', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@0xintuition/protocol')>()
+
+  return {
+    ...actual,
+    eventParseDeposited: vi.fn(async () => []),
+    multiVaultDepositBatch: vi.fn(
+      async () =>
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+    ),
+  }
+})
+
+const writeConfig = {
+  address: '0x0000000000000000000000000000000000000001',
+  publicClient: {},
+  walletClient: {},
+} as WriteConfig
+
+const args = [
+  '0x0000000000000000000000000000000000000002',
+  [
+    '0x0000000000000000000000000000000000000000000000000000000000000003',
+    '0x0000000000000000000000000000000000000000000000000000000000000004',
+  ],
+  [1n, 2n],
+  [11n, 29n],
+  [0n, 0n],
+] as const satisfies DepositBatchInputs['args']
+
+describe('batchDeposit', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards the assets-derived value 40n', async () => {
+    await batchDeposit(writeConfig, args)
+
+    expect(multiVaultDepositBatch).toHaveBeenCalledWith(writeConfig, {
+      args,
+      value: 40n,
+    })
+    expect(eventParseDeposited).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/sdk/tests/deposit.test.ts
+++ b/packages/sdk/tests/deposit.test.ts
@@ -1,0 +1,75 @@
+import {
+  eventParseDeposited,
+  multiVaultDeposit,
+  type DepositInputs,
+  type WriteConfig,
+} from '@0xintuition/protocol'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { deposit } from '../src/core/deposit'
+
+vi.mock('@0xintuition/protocol', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@0xintuition/protocol')>()
+
+  return {
+    ...actual,
+    eventParseDeposited: vi.fn(async () => []),
+    multiVaultDeposit: vi.fn(
+      async () =>
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+    ),
+  }
+})
+
+const writeConfig = {
+  address: '0x0000000000000000000000000000000000000001',
+  publicClient: {},
+  walletClient: {},
+} as WriteConfig
+
+const args = [
+  '0x0000000000000000000000000000000000000002',
+  '0x0000000000000000000000000000000000000000000000000000000000000003',
+  1n,
+  0n,
+] as const satisfies DepositInputs['args']
+
+describe('deposit', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards the payable value to the protocol deposit request', async () => {
+    const value = 42n
+
+    await deposit(writeConfig, { args, value })
+
+    expect(multiVaultDeposit).toHaveBeenCalledWith(writeConfig, {
+      args,
+      value,
+    })
+    expect(eventParseDeposited).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards an explicit zero value', async () => {
+    await deposit(writeConfig, { args, value: 0n })
+
+    expect(multiVaultDeposit).toHaveBeenCalledWith(writeConfig, {
+      args,
+      value: 0n,
+    })
+  })
+
+  it('sends no value when the payable input omits it', async () => {
+    await deposit(writeConfig, { args })
+
+    expect(multiVaultDeposit).toHaveBeenCalledWith(writeConfig, { args })
+  })
+
+  it('keeps bare deposit args backward compatible without sending value', async () => {
+    await deposit(writeConfig, args)
+
+    expect(multiVaultDeposit).toHaveBeenCalledWith(writeConfig, { args })
+  })
+})


### PR DESCRIPTION
## Summary

Three SDK write wrappers sent incorrect transaction value:

- `deposit()` never forwarded a payable value at all.
- `batchDeposit()` derived value from the `minShares` tuple slot instead of `assets`, sending `0n`.
- `batchCreateTripleStatements()` sent a single base-cost + deposit pair instead of the per-triple sum.

All three now forward the assets-derived value, with failing-first tests proving the old behavior at the protocol seam and the corrected value after.

## Compatibility

- Signatures stay backward-compatible via overloads: `deposit()` gains a `{ args, value? }` form, with the bare-args form deprecated.
- The legacy `depositAmount` parameter of `batchCreateTripleStatements` is ignored by design — each entry in the assets array already carries its triple's full value. It is now observably deprecated: a one-time console warning fires when a nonzero value is passed, and an `@deprecated` overload surfaces strike-through in editors. Slated for removal in the next major.
- Passing an explicit `undefined` as the third argument no longer type-checks (no call site or documented example does this).

## Verification

- Failing-first tests at the protocol seam for each wrapper prove the exact value forwarded before and after.
- Value math verified against the MultiVault ABI tuple order and the protocol package's own tests.
- `tsc --noEmit` clean; SDK suite passes (except the pre-existing credential-gated external test).
- Changeset included (minor).