### PR TITLE
fix: move GraphQL codegen tooling out of runtime dependencies

### DIFF
--- a/.changeset/quiet-documents-build.md
+++ b/.changeset/quiet-documents-build.md
@@ -1,0 +1,5 @@
+---
+'@0xintuition/graphql': patch
+---
+
+Move GraphQL document code generation tooling out of runtime dependencies so SDK consumers no longer install its vulnerable transitive dependency tree.

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -21,6 +21,7 @@
     "dev": "concurrently \"pnpm codegen:watch\" \"tsup --watch\"",
     "codegen": "NODE_ENV=production graphql-codegen --config codegen.ts",
     "codegen:watch": "NODE_ENV=development dotenv graphql-codegen --config codegen.ts",
+    "audit:packed-consumer": "node scripts/packed-consumer-audit.mjs",
     "pack:verify": "node ../../scripts/verify-package-entrypoints.mjs",
     "prepack": "pnpm run build && pnpm run pack:verify",
     "test": "vitest run",
@@ -37,7 +38,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@graphql-codegen/typescript-document-nodes": "^4.0.11",
     "@tanstack/react-query": "^5.32.0",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.0"
@@ -50,6 +50,7 @@
     "@graphql-codegen/plugin-helpers": "^5.0.4",
     "@graphql-codegen/schema-ast": "^4.1.0",
     "@graphql-codegen/typescript": "^4.1.0",
+    "@graphql-codegen/typescript-document-nodes": "^4.0.11",
     "@graphql-codegen/typescript-operations": "^4.3.0",
     "@graphql-codegen/typescript-react-apollo": "^4.3.2",
     "@graphql-codegen/typescript-react-query": "^6.1.0",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -21,7 +21,6 @@
     "dev": "concurrently \"pnpm codegen:watch\" \"tsup --watch\"",
     "codegen": "NODE_ENV=production graphql-codegen --config codegen.ts",
     "codegen:watch": "NODE_ENV=development dotenv graphql-codegen --config codegen.ts",
-    "audit:packed-consumer": "node scripts/packed-consumer-audit.mjs",
     "pack:verify": "node ../../scripts/verify-package-entrypoints.mjs",
     "prepack": "pnpm run build && pnpm run pack:verify",
     "test": "vitest run",

--- a/packages/graphql/scripts/packed-consumer-audit.mjs
+++ b/packages/graphql/scripts/packed-consumer-audit.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(scriptDirectory, '../../..')
+const graphqlDirectory = join(repositoryRoot, 'packages/graphql')
+const sdkDirectory = join(repositoryRoot, 'packages/sdk')
+const temporaryRoot = mkdtempSync(
+  join(tmpdir(), 'intuition-packed-consumer-audit-'),
+)
+const packDirectory = join(temporaryRoot, 'packs')
+const consumerDirectory = join(temporaryRoot, 'consumer')
+const npmCacheDirectory = join(temporaryRoot, 'npm-cache')
+
+mkdirSync(packDirectory)
+mkdirSync(consumerDirectory)
+
+try {
+  run('pnpm', [
+    '--dir',
+    graphqlDirectory,
+    'pack',
+    '--pack-destination',
+    packDirectory,
+  ])
+  run('pnpm', [
+    '--dir',
+    sdkDirectory,
+    'pack',
+    '--pack-destination',
+    packDirectory,
+  ])
+
+  const graphqlTarball = findTarball('0xintuition-graphql-')
+  const sdkTarball = findTarball('0xintuition-sdk-')
+  const packedGraphqlPackage = JSON.parse(
+    output('tar', ['-xOf', graphqlTarball, 'package/package.json']),
+  )
+
+  if (
+    packedGraphqlPackage.dependencies?.[
+      '@graphql-codegen/typescript-document-nodes'
+    ]
+  ) {
+    throw new Error(
+      'Packed GraphQL package exposes typescript-document-nodes as a runtime dependency',
+    )
+  }
+
+  writeFileSync(
+    join(consumerDirectory, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'intuition-packed-consumer-audit',
+        version: '1.0.0',
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@0xintuition/graphql': fileDependency(graphqlTarball),
+          '@0xintuition/sdk': fileDependency(sdkTarball),
+          viem: '^2.0.0',
+        },
+        overrides: {
+          '@0xintuition/sdk': {
+            '@0xintuition/graphql': '$@0xintuition/graphql',
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  )
+
+  run('npm', ['install'], { cwd: consumerDirectory })
+  run(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      "import * as graphql from '@0xintuition/graphql'; import * as sdk from '@0xintuition/sdk'; if (typeof graphql.PinThingDocument !== 'string' || !graphql.PinThingDocument.includes('mutation pinThing')) throw new Error('generated PinThingDocument export changed'); if (typeof sdk.configureSdk !== 'function') throw new Error('SDK configureSdk export missing'); console.log('Packed exports smoke passed')",
+    ],
+    { cwd: consumerDirectory },
+  )
+  run('npm', ['audit', '--omit=dev'], { cwd: consumerDirectory })
+
+  console.log(
+    `Packed GraphQL runtime dependencies: ${Object.keys(
+      packedGraphqlPackage.dependencies ?? {},
+    ).join(', ')}`,
+  )
+  console.log('Packed consumer audit passed')
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true })
+}
+
+function findTarball(prefix) {
+  const filename = readdirSync(packDirectory).find(
+    (entry) => entry.startsWith(prefix) && entry.endsWith('.tgz'),
+  )
+
+  if (!filename) {
+    throw new Error(`Missing packed tarball with prefix ${prefix}`)
+  }
+
+  return join(packDirectory, filename)
+}
+
+function fileDependency(tarball) {
+  return `file:${relative(consumerDirectory, tarball).split(sep).join('/')}`
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repositoryRoot,
+    env: {
+      ...process.env,
+      npm_config_cache: npmCacheDirectory,
+    },
+    stdio: 'inherit',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with status ${result.status}`)
+  }
+}
+
+function output(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} exited with status ${result.status}: ${result.stderr}`,
+    )
+  }
+
+  return result.stdout
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,9 +372,6 @@ importers:
 
   packages/graphql:
     dependencies:
-      '@graphql-codegen/typescript-document-nodes':
-        specifier: ^4.0.11
-        version: 4.0.11(encoding@0.1.13)(graphql@16.9.0)
       '@tanstack/react-query':
         specifier: ^5.32.0
         version: 5.45.0(react@18.3.1)
@@ -406,6 +403,9 @@ importers:
       '@graphql-codegen/typescript':
         specifier: ^4.1.0
         version: 4.1.0(encoding@0.1.13)(graphql@16.9.0)
+      '@graphql-codegen/typescript-document-nodes':
+        specifier: ^4.0.11
+        version: 4.0.11(encoding@0.1.13)(graphql@16.9.0)
       '@graphql-codegen/typescript-operations':
         specifier: ^4.3.0
         version: 4.3.0(encoding@0.1.13)(graphql@16.9.0)


### PR DESCRIPTION
## Summary

Consumers of `@0xintuition/graphql` currently install the full `@graphql-codegen` toolchain at runtime, though it is only used to generate code at build time. This moves codegen to `devDependencies`, cutting a large tree of build-only transitive packages (and their vulnerability surface) out of every consumer install.

## Verification

- **Packed-consumer audit** (`packages/graphql/scripts/packed-consumer-audit.mjs`, repo-only — excluded from the published manifest): packs the tarball, installs it into a clean scratch consumer with dev dependencies absent, and verifies all public imports resolve.
- Lockfile change is confined to the importer section; `pnpm install --frozen-lockfile` passes — the same check CI runs.
- Changeset included (patch).